### PR TITLE
0.03 Heavy Support Update

### DIFF
--- a/Imperial_Guard_9th_Ed.cat
+++ b/Imperial_Guard_9th_Ed.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="53e9d88f-7463-8c27-fe67-e1a0d1ed0287" name="Imperium - Imperial Guard 9th Ed" revision="312" battleScribeVersion="2.03" authorName="" authorContact="" authorUrl="" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="53e9d88f-7463-8c27-fe67-e1a0d1ed0287" name="Imperium - Imperial Guard 9th Ed" revision="313" battleScribeVersion="2.03" authorName="" authorContact="" authorUrl="" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="99a162d9-4854-cc3b-c35e-b0c3a3cc77d6" name="Commissar Yarrick" hidden="false" collective="false" import="true" targetId="5dac-1ff6-7352-3745" type="selectionEntry">
       <modifiers>
@@ -19,27 +19,8 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="5f44-129d-c825-aa50" name="Command Squad" hidden="false" collective="false" import="true" targetId="3b7d-927b-8856-e8b7" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="c41d-16a1-f950-68e1" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="8f83-c34c-36a4-23bb" name="Veterans" hidden="false" collective="false" import="true" targetId="eee1-85bc-99e2-4144" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="9e9a-c333-cd8f-6a08" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8d90-63c4-a710-0ee0" name="Ogryns" hidden="false" collective="false" import="true" targetId="e722-8d0c-7ed1-d08b" type="selectionEntry">
@@ -57,14 +38,7 @@
         <categoryLink id="10d8-f940-2821-d295-638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4f73-fca7-1f3e-40ac" name="Rough Riders [Legends]" hidden="false" collective="false" import="true" targetId="cb55-1684-cb92-8146" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <entryLink id="4f73-fca7-1f3e-40ac" name="Attilan Rough Riders" hidden="false" collective="false" import="true" targetId="cb55-1684-cb92-8146" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="4f73-fca7-1f3e-40ac-c274d0b0-5866-44bc-9810-91c136ae7438" hidden="false" targetId="c274d0b0-5866-44bc-9810-91c136ae7438" primary="true"/>
       </categoryLinks>
@@ -75,73 +49,26 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="3ef9-2a24-4dc5-7d5f" name="Company Commander" hidden="false" collective="false" import="true" targetId="716d-5866-fe42-6511" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="977f-d01e-2cbd-e3e8" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ced1-f367-1044-62b0" name="Platoon Commander" hidden="false" collective="false" import="true" targetId="6499-885c-a205-d0e1" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="379d-3625-48ac-ca86" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ad22-0104-d3a9-f32f" name="Infantry Squad" hidden="false" collective="false" import="true" targetId="7905-3074-b98d-ce54" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="1b78-e1ac-becd-2715" name="New CategoryLink" hidden="false" targetId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5c47-3ade-3e9b-b273" name="Special Weapons Squad" hidden="false" collective="false" import="true" targetId="9d2d-88a5-7ca6-e582" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <categoryLinks>
-        <categoryLink id="1a9a-2297-c479-d7c8" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="0077-ac29-5ab9-7cce" name="Heavy Weapons Squad" hidden="false" collective="false" import="true" targetId="b796-7e12-3616-52e6" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="1c5e-7600-06e7-c4ce" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="578e-e480-ae27-5806" name="Conscripts" hidden="false" collective="false" import="true" targetId="2d05-89c5-1926-3127" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="9391-b601-6e9e-89dc" name="New CategoryLink" hidden="false" targetId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" primary="true"/>
       </categoryLinks>
@@ -167,63 +94,26 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="d881-ffa2-f3fb-bbf1" name="Hellhammer" hidden="false" collective="false" import="true" targetId="f6ce-eff4-32ac-51dc" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="e129-9eac-2616-3cd2" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="dae7-e08b-cdc3-c087" name="Banesword" hidden="false" collective="false" import="true" targetId="73ff-56ca-4d17-e248" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="e74f-52bb-d6a1-552c" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="cd1c-a79b-0a16-eabf" name="Leman Russ Battle Tanks" hidden="false" collective="false" import="true" targetId="af7a-3b6b-099c-c23b" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="05c9-a229-f8e3-ace8" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
-        <categoryLink id="ef06-890a-fdf0-bb95" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
-        <categoryLink id="6e3e-1704-8fff-e6fd" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e71e-bfe9-bf1e-a576" name="Doomhammer" hidden="false" collective="false" import="true" targetId="36c4-e49f-cb7a-a22e" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="a39b-49f5-dd0b-c3c0" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="2a93-91c5-6840-11c1" name="Armoured Sentinels" hidden="false" collective="false" import="true" targetId="85c7-45a7-e283-2dba" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="29d4-7da8-4bfb-968f" name="New CategoryLink" hidden="false" targetId="c274d0b0-5866-44bc-9810-91c136ae7438" primary="true"/>
         <categoryLink id="36a5-dae5-7521-c66e" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
@@ -231,25 +121,11 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="ed86-9c3f-9a9b-2823" name="Deathstrike" hidden="false" collective="false" import="true" targetId="2255-9de3-c6f8-838b" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="8d40-a675-dd8a-275a" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4200-8596-04db-fdc7" name="Banehammer" hidden="false" collective="false" import="true" targetId="ccf7-ace2-9b05-80da" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="ebce-4c87-2533-d758" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
       </categoryLinks>
@@ -260,13 +136,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="29fd-b780-fec3-7f64" name="Taurox" hidden="false" collective="false" import="true" targetId="f8ad-8cb3-9d8d-0ce5" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="7204-7f5e-49bd-82fc" name="New CategoryLink" hidden="false" targetId="1b66-3f5f-6705-079a" primary="true"/>
       </categoryLinks>
@@ -277,13 +146,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="930d-7ed4-60a3-aab1" name="Scout Sentinels" hidden="false" collective="false" import="true" targetId="5d31-5e21-5ec2-7f79" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="5ec7-b6ba-d831-2f76" name="New CategoryLink" hidden="false" targetId="c274d0b0-5866-44bc-9810-91c136ae7438" primary="true"/>
         <categoryLink id="d72c-bfa4-1f14-20b4" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
@@ -296,29 +158,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="08a6-d005-611b-51e7" name="Stormlord" hidden="false" collective="false" import="true" targetId="8e95-af10-b229-cd6d" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="a1eb-590b-1a15-8c49" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="74d6-b323-db83-fa57" name="Wyverns" hidden="false" collective="false" import="true" targetId="8cc0-1f53-200b-9c7f" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <entryLink id="74d6-b323-db83-fa57" name="Wyvern" hidden="false" collective="false" import="true" targetId="aa0e-0155-aed7-0679" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="0a0e-d424-f194-5fee" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
-        <categoryLink id="4b0d-7b08-732c-e057" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
-        <categoryLink id="89e7-1d18-14f5-f5dc" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="9340-15d8-ec35-bfe2" name="Taurox Prime" hidden="false" collective="false" import="true" targetId="b85c-eb11-d135-54e0" type="selectionEntry">
@@ -327,25 +173,11 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="4732-a98a-a421-288c" name="Manticore" hidden="false" collective="false" import="true" targetId="3e24-04de-c5d1-ac51" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="b40a-1e34-75fc-77f9" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="5544-ff0a-d434-4cf5" name="Chimera" hidden="false" collective="false" import="true" targetId="8b0c-1be4-4ae4-23a3" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="e39e-7c65-0a2f-534f" name="New CategoryLink" hidden="false" targetId="1b66-3f5f-6705-079a" primary="true"/>
         <categoryLink id="9e59-1623-a1b1-7173" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
@@ -353,37 +185,16 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="4717-9a3f-2fce-fa7e" name="Dominus Armoured Siege Bombard [Legends]" hidden="false" collective="false" import="true" targetId="becb-2b03-419e-59fc" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="c734-3b18-054b-3f19" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="c564-ca52-4427-2b61" name="Armageddon-pattern Basilisk" hidden="false" collective="false" import="true" targetId="6428-6030-a035-ba1e" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="8ff1-6581-3793-bce0" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="dec6-8982-1027-f1b5" name="Earthshaker Battery" hidden="false" collective="false" import="true" targetId="c5ab-986a-84ea-2562" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <entryLink id="dec6-8982-1027-f1b5" name="Earthshaker Battery [Legends]" hidden="false" collective="false" import="true" targetId="c5ab-986a-84ea-2562" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="81bf-c344-6e35-2a51" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
@@ -394,25 +205,11 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="d8a9-c02c-ce10-4b6a" name="Arkurian Stormhammer [Legends]" hidden="false" collective="false" import="true" targetId="3e1b-b5b8-6e98-5c2d" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="fcb2-21cf-4b8b-5145" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="3934-4843-f457-cb47" name="Crassus Armoured Assault Vehicle" hidden="false" collective="false" import="true" targetId="1cb2-d5d7-da19-9dc9" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <entryLink id="3934-4843-f457-cb47" name="Crassus" hidden="false" collective="false" import="true" targetId="1cb2-d5d7-da19-9dc9" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="025b-8a76-df71-a9f2" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
       </categoryLinks>
@@ -427,14 +224,7 @@
         <categoryLink id="9932-f8bc-2021-d4b4" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="62e5-0854-fcfd-cafd" name="Hydra Battery" hidden="false" collective="false" import="true" targetId="9e27-39c8-4731-dc6a" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <entryLink id="62e5-0854-fcfd-cafd" name="Hydra Battery [Legends]" hidden="false" collective="false" import="true" targetId="9e27-39c8-4731-dc6a" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="2a75-0f24-e93c-89fd" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
@@ -445,87 +235,38 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="3006-b323-6b61-5fb0" name="Manticore Battery [Legends]" hidden="false" collective="false" import="true" targetId="5977-4fef-b3c9-5e29" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="fcde-bf7b-1d1f-0ee2" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="4b2a-5cbd-87f3-0129" name="Sentinel Powerlifters [Legends]" hidden="false" collective="false" import="true" targetId="e6d3-8dbd-de04-9187" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="74b1-146b-8d75-cbe3" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="fc3f-a2b9-18a9-848b" name="Salamander Command Vehicle" hidden="false" collective="false" import="true" targetId="a152-0b14-b280-e96a" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <entryLink id="fc3f-a2b9-18a9-848b" name="Salamander Command Vehicle [Legends]" hidden="false" collective="false" import="true" targetId="a152-0b14-b280-e96a" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="ebca-6d5f-68c9-6b47" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e185-e1e5-5158-9e75" name="Valdor Tank Hunter" hidden="false" collective="false" import="true" targetId="4666-f0c7-caf2-2eb3" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="550d-b82e-4c17-b9bd" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
         <categoryLink id="729d-2452-ea2c-609f" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
         <categoryLink id="9add-f0bd-422b-660b" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="162c-0579-cf97-521a" name="Sabre Weapons Battery" hidden="false" collective="false" import="true" targetId="986b-3521-bb98-46f8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <entryLink id="162c-0579-cf97-521a" name="Sabre Weapons Battery [Legends]" hidden="false" collective="false" import="true" targetId="986b-3521-bb98-46f8" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="a7c0-c93c-e99c-af71" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="7bd9-e385-1b6d-1c71" name="Praetor" hidden="false" collective="false" import="true" targetId="6180-83df-5874-095a" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="0252-1369-f743-e0ad" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="d392-c637-8b56-98f7" name="Minotaur" hidden="false" collective="false" import="true" targetId="6953-dac8-ed09-e7ce" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="a518-3d63-ce0c-692a" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
         <categoryLink id="ca2e-35c0-79b4-5288" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
@@ -581,13 +322,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="625e-bcfc-d49d-7cfb" name="Carnodon" hidden="false" collective="false" import="true" targetId="58af-c7a1-b4a6-3e90" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="fc6a-6924-0d9d-7616" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
@@ -638,13 +372,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="7203-bda5-04c7-06b5" name="Master of Ordnance" hidden="false" collective="false" import="true" targetId="3d6b-fb42-442f-cd3f" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="9e8b-cd23-7cd0-0d14" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
       </categoryLinks>
@@ -655,39 +382,18 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="2997-24e8-5719-6033" name="Stormblade" hidden="false" collective="false" import="true" targetId="dd1b-faed-2f1c-c9ba" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="207d-0aaa-0db6-4159" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8ce9-fbfb-41d4-0b62" name="Armageddon-pattern Medusa" hidden="false" collective="false" import="true" targetId="a729-31f4-7610-8e00" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="6c72-6f39-f1a5-cb7a" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
         <categoryLink id="8ce7-1315-7015-a8cf" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
         <categoryLink id="3651-3a92-d166-c524" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="53b8-f74b-1f60-b4d1" name="Atlas Recovery Tank" hidden="false" collective="false" import="true" targetId="e172-910d-aae4-d668" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <entryLink id="53b8-f74b-1f60-b4d1" name="Atlas Recovery Tank [Legends]" hidden="false" collective="false" import="true" targetId="e172-910d-aae4-d668" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e28f-fd8a-1ec6-0fae" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
       </categoryLinks>
@@ -698,53 +404,23 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="3f70-99a2-09dc-3316" name="Baneblade" hidden="false" collective="false" import="true" targetId="3ac6-8d6e-850e-6aee" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="9665-e5da-b6c7-b69a" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
         <categoryLink id="afb3-6073-3918-0359" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
         <categoryLink id="29e1-cbef-a654-8c5c" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="ffc3-0c20-3684-45f1" name="Basilisks" hidden="false" collective="false" import="true" targetId="8c17-9bce-4cb6-3fe5" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <entryLink id="ffc3-0c20-3684-45f1" name="Basilisk" hidden="false" collective="false" import="true" targetId="8c17-9bce-4cb6-3fe5" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="416e-dc58-c097-2dc2" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
-        <categoryLink id="1201-f2cc-af56-e991" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
-        <categoryLink id="0455-0cbb-ed53-5d36" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="9e51-5077-fdc0-7939" name="Centaur Light Carrier" hidden="false" collective="false" import="true" targetId="bf72-f767-adb8-0447" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <entryLink id="9e51-5077-fdc0-7939" name="Centaur Light Carrier [Legends]" hidden="false" collective="false" import="true" targetId="bf72-f767-adb8-0447" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="06ba-7a40-5176-3501" name="New CategoryLink" hidden="false" targetId="1b66-3f5f-6705-079a" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="bd61-4342-404e-f96a" name="Colossus Bombard" hidden="false" collective="false" import="true" targetId="05af-872f-e4ab-aba9" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="36ec-2813-fa12-e3fc" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
         <categoryLink id="290a-5900-b615-5af4" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
@@ -752,51 +428,23 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="6f7f-e6d3-9da5-0c00" name="Cyclops Demolition Vehicle" hidden="false" collective="false" import="true" targetId="bf5a-3932-75bf-df92" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="6b18-6afd-9d58-1a43" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="3aee-2364-7209-d071" name="Earthshaker Carriage Battery" hidden="false" collective="false" import="true" targetId="635b-6d42-0315-e7f5" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="5ee2-c7e0-4080-aace" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
         <categoryLink id="a792-717f-e975-cae9" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
         <categoryLink id="5886-7261-b269-c694" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1484-bed2-475c-8215" name="Gorgon Heavy Transporter" hidden="false" collective="false" import="true" targetId="066c-5ca9-3a9a-1c60" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <entryLink id="1484-bed2-475c-8215" name="Gorgon Heavy Transport [Legends]" hidden="false" collective="false" import="true" targetId="066c-5ca9-3a9a-1c60" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5790-e3b8-8d57-8aae" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="bb49-7670-aa08-2295" name="Griffon Mortar Carrier" hidden="false" collective="false" import="true" targetId="fcb4-8468-4b88-cdbd" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <entryLink id="bb49-7670-aa08-2295" name="Griffon Mortar Carrier [Legends]" hidden="false" collective="false" import="true" targetId="fcb4-8468-4b88-cdbd" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="55e4-1dc5-4b4e-3f7c" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
         <categoryLink id="838b-ed48-6f6b-c6c5" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
@@ -804,25 +452,11 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="55f8-c8f7-299b-399c" name="Hades Breaching Drill" hidden="false" collective="false" import="true" targetId="5e41-bbe4-121d-7ac3" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="edcc-eaf2-6ac9-bc0a" name="New CategoryLink" hidden="false" targetId="1b66-3f5f-6705-079a" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="1b9b-e38b-7392-1e51" name="Heavy Mortar Battery" hidden="false" collective="false" import="true" targetId="5990-c95f-2668-64a8" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="dbf1-67fa-eec9-1afb" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
         <categoryLink id="40dd-64e8-efb8-a667" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
@@ -830,13 +464,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="3a29-0727-56ae-4333" name="Heavy Quad Launcher Battery" hidden="false" collective="false" import="true" targetId="8884-5a39-1c40-190a" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="e12a-9382-7579-754a" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
         <categoryLink id="8701-0c15-a2e2-1ddc" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
@@ -844,31 +471,15 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="52d4-0d80-0dd4-73b9" name="Hellhounds" hidden="false" collective="false" import="true" targetId="2985-edd1-a2d6-618d" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="ab98-c275-13e6-6c66" name="New CategoryLink" hidden="false" targetId="c274d0b0-5866-44bc-9810-91c136ae7438" primary="true"/>
         <categoryLink id="2f88-d8a4-ebe7-4eaa" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
         <categoryLink id="d2be-0a1f-e628-716c" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="45f3-e4a7-6119-946d" name="Hydras" hidden="false" collective="false" import="true" targetId="1ad4-bc03-d515-d1d9" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <entryLink id="45f3-e4a7-6119-946d" name="Hydra" hidden="false" collective="false" import="true" targetId="411a-f57a-9f2b-b9df" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="033d-a136-5a02-2b45" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
-        <categoryLink id="a47a-025b-8b78-bc57" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
-        <categoryLink id="d409-d8ed-9bb2-3a1e" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="b8ea-a591-9039-6173" name="Imperial Commander&apos;s Armoury" hidden="false" collective="false" import="true" targetId="d7be-7049-0cc9-dcf3" type="selectionEntry">
@@ -884,27 +495,13 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="8cb0-121e-770d-b5b4" name="Macharius" hidden="false" collective="false" import="true" targetId="eaaf-e58c-f7ba-6f81" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="963b-d381-adde-1769" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
         <categoryLink id="7910-3a7d-88e4-49cc" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
         <categoryLink id="e6b2-5be9-c3a9-d38d" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="31f1-b9db-415e-9dd7" name="Macharius Omega" hidden="false" collective="false" import="true" targetId="6681-ab8d-6e19-6e02" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <entryLink id="31f1-b9db-415e-9dd7" name="Macharius Omega [Legends]" hidden="false" collective="false" import="true" targetId="6681-ab8d-6e19-6e02" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="735b-26f1-a597-01a6" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
         <categoryLink id="c79d-e865-5a89-45c7" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
@@ -912,13 +509,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="2f94-355e-3cbb-4ad1" name="Macharius Vanquisher" hidden="false" collective="false" import="true" targetId="084a-38b8-08d0-f2d6" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="c1d1-1777-10b2-bfd1" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
         <categoryLink id="df27-80de-ef39-ecf5" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
@@ -926,13 +516,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="edf2-c17e-07bd-7b92" name="Macharius Vulcan" hidden="false" collective="false" import="true" targetId="f54c-7343-16cd-4be5" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="49d8-b855-8bd9-21ac" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
         <categoryLink id="0379-35b5-9eba-06ed" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
@@ -940,25 +523,11 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="7408-fd4b-9bee-d297" name="Malcador Infernus" hidden="false" collective="false" import="true" targetId="a4e4-00cf-afd1-be77" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="1689-17c1-49bc-9e14" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="432c-de91-89fc-b8d9" name="Medusa Carriage Battery" hidden="false" collective="false" import="true" targetId="206c-e447-9219-49ac" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="dd51-d117-b787-1b5b" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
         <categoryLink id="4c6a-a791-3082-8675" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
@@ -970,29 +539,15 @@
         <categoryLink id="c006-ac0d-e9d0-df79" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="92ec-0453-95e7-62b0" name="Operative Requisition Sanctioned" hidden="false" collective="false" import="true" targetId="0b7d-bfe1-b63e-ecb6" type="selectionEntry"/>
-    <entryLink id="60ff-decf-f438-cf5d" name="Rapier Laser Destroyer" hidden="false" collective="false" import="true" targetId="259e-17d2-3f79-528b" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <entryLink id="92ec-0453-95e7-62b0" name="Stratagem: Shadow Assignment" hidden="false" collective="false" import="true" targetId="0b7d-bfe1-b63e-ecb6" type="selectionEntry"/>
+    <entryLink id="60ff-decf-f438-cf5d" name="Rapier Laser Destroyer Battery" hidden="false" collective="false" import="true" targetId="259e-17d2-3f79-528b" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="7842-aa2a-30eb-2c58" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
         <categoryLink id="2196-66e6-3eaa-3cfa" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
         <categoryLink id="2c90-4be3-8eda-ceb7" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="a199-6389-37b7-a98b" name="Salamander Scout Tank" hidden="false" collective="false" import="true" targetId="887f-86e7-69d4-fc5c" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <entryLink id="a199-6389-37b7-a98b" name="Salamander Scout Tanks [Legends]" hidden="false" collective="false" import="true" targetId="887f-86e7-69d4-fc5c" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="5d65-09c4-5ddc-4330" name="New CategoryLink" hidden="false" targetId="c274d0b0-5866-44bc-9810-91c136ae7438" primary="true"/>
         <categoryLink id="72a6-afd4-f676-2c12" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
@@ -1000,97 +555,41 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="9944-9595-3e86-2667" name="Shadowsword" hidden="false" collective="false" import="true" targetId="8194-93bb-950a-d88b" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="5d3c-6076-eb7a-9456" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="38e6-2898-1004-7752" name="Stormsword" hidden="false" collective="false" import="true" targetId="3a4e-81fe-1325-ac27" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="a908-decb-a573-9571" name="New CategoryLink" hidden="false" targetId="c888f08a-6cea-4a01-8126-d374a9231554" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="d6e4-3f7a-ecb6-512c" name="Stygies Destroyer Tank Hunter" hidden="false" collective="false" import="true" targetId="cf12-f293-0d51-75df" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <entryLink id="d6e4-3f7a-ecb6-512c" name="Stygies Destroyer Tank Hunter [Legends]" hidden="false" collective="false" import="true" targetId="cf12-f293-0d51-75df" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="6fa3-5dcf-3fb7-900e" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5263-f558-d4a1-b271" name="Stygies Thunderer Siege Tank" hidden="false" collective="false" import="true" targetId="17b0-32eb-49b5-41c4" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <entryLink id="5263-f558-d4a1-b271" name="Thunderers" hidden="false" collective="false" import="true" targetId="17b0-32eb-49b5-41c4" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="deaf-c55a-36f4-fa2a" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="e364-790e-d473-e4f3" name="Tank Commander" hidden="false" collective="false" import="true" targetId="da34-52b0-53cc-1128" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="d2c2-74bc-a96e-8b2a" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="a8a4-c87d-4bf2-1a0b" name="Tarantula Battery" hidden="false" collective="false" import="true" targetId="8334-4726-0084-b6fc" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="fb1c-67c2-c6a2-ee1d" name="Fortification" hidden="false" targetId="d713cda3-5d0f-40d8-b621-69233263ec2a" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1ef3-a574-fd40-fa9c" name="Tauros Assault Vehicle" hidden="false" collective="false" import="true" targetId="26bd-4dc8-d2d2-6769" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <entryLink id="1ef3-a574-fd40-fa9c" name="Tauros Assault Vehicles [Legends]" hidden="false" collective="false" import="true" targetId="26bd-4dc8-d2d2-6769" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="71f5-a6a1-e2e7-a5e8" name="New CategoryLink" hidden="false" targetId="c274d0b0-5866-44bc-9810-91c136ae7438" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="4055-8132-e343-e217" name="Tauros Venator" hidden="false" collective="false" import="true" targetId="0474-4cc1-8d7e-0f69" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <entryLink id="4055-8132-e343-e217" name="Tauros Venators [Legends]" hidden="false" collective="false" import="true" targetId="0474-4cc1-8d7e-0f69" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="de68-3048-6ce2-d048" name="New CategoryLink" hidden="false" targetId="c274d0b0-5866-44bc-9810-91c136ae7438" primary="true"/>
       </categoryLinks>
@@ -1101,13 +600,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="89d3-104d-4d20-5850" name="Trojan Support Vehicle" hidden="false" collective="false" import="true" targetId="366c-cdc1-20e0-4209" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="b819-9b82-dfc9-889c" name="New CategoryLink" hidden="false" targetId="1b66-3f5f-6705-079a" primary="true"/>
       </categoryLinks>
@@ -1128,26 +620,12 @@
         <categoryLink id="e763-a0a9-e93e-d1a4" name="New CategoryLink" hidden="false" targetId="e888-1504-aa61-95ff" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="8a90-a615-f26e-5508" name="Malcador Heavy Tank" hidden="false" collective="false" import="true" targetId="86a7-45f9-d8e3-42b2" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
+    <entryLink id="8a90-a615-f26e-5508" name="Malcador" hidden="false" collective="false" import="true" targetId="86a7-45f9-d8e3-42b2" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="b2aa-db1a-2319-fdf7" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="69ec-86aa-7f3c-9228" name="Malcador Defender" hidden="false" collective="false" import="true" targetId="e1d7-0ed5-988f-7439" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="68f2-9e87-cddf-0fc8" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
         <categoryLink id="a593-52a6-5bd4-3f9e" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
@@ -1155,13 +633,6 @@
       </categoryLinks>
     </entryLink>
     <entryLink id="44db-50c3-3415-8580" name="Malcador Annihilator" hidden="false" collective="false" import="true" targetId="89ac-4e4c-2377-45f0" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="9558-9ac7-0e70-323f" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
         <categoryLink id="c467-e5cb-e009-8ac6" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
@@ -1201,6 +672,16 @@
     <entryLink id="ba6f-7219-826c-7a15" name="Kasrkin" hidden="false" collective="false" import="true" targetId="0609-08fb-cd8a-8b1e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e1fa-6329-3a3a-822a" name="Elites" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="9895-bea4-4268-b336" name="Rogal Dorn Battle Tank" hidden="false" collective="false" import="true" targetId="95b5-ba43-04f7-91fa" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="7240-130a-c133-481b" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="425f-762b-9856-7a33" name="Field Ordnance Battery" hidden="false" collective="false" import="true" targetId="7e79-96d0-b25b-e3ed" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="dcc2-5547-43c1-c02f" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>

--- a/Imperium_-_Imperial_Guard_9th_Ed_Library.cat
+++ b/Imperium_-_Imperial_Guard_9th_Ed_Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a2d9-e3b7-13cc-6f15" name="Imperium - Imperial Guard - 9th Ed - Library" revision="101" battleScribeVersion="2.03" authorName="denny, TheHalfinStream" authorContact="" authorUrl="" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a2d9-e3b7-13cc-6f15" name="Imperium - Imperial Guard - 9th Ed - Library" revision="102" battleScribeVersion="2.03" authorName="denny, TheHalfinStream" authorContact="" authorUrl="" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="53e9d88f--pubN88319" name="Codex: Astra Militarum"/>
     <publication id="53e9d88f--pubN183884" name="GW Datasheet"/>
@@ -220,8 +220,14 @@
     <categoryEntry id="3bb8-2f9a-48de-c16f" name="Gaunt&apos;s Ghosts" hidden="false"/>
     <categoryEntry id="e877-5452-e7f3-cd31" name="Whiteshields" hidden="false"/>
     <categoryEntry id="81e5-0f46-a4ab-4211" name="Cadian Warlord" hidden="false"/>
-    <categoryEntry id="fdd3-90b2-0078-6c5b" name="Battle Tank" hidden="false"/>
     <categoryEntry id="3f49-5a36-0a51-3f82" name="Faction: Imperial Guard" hidden="false"/>
+    <categoryEntry id="ae9d-34d2-e8f7-62df" name="Battle Tank" hidden="false"/>
+    <categoryEntry id="54e0-767a-ea48-e51c" name="Regimental" hidden="false"/>
+    <categoryEntry id="6838-e734-295c-7de5" name="Rogal Dorn Battle Tank" hidden="false"/>
+    <categoryEntry id="eba3-3a9f-b907-d83a" name="Squadron" hidden="false"/>
+    <categoryEntry id="bcf4-1bd8-9794-feaa" name="Smoke" hidden="false"/>
+    <categoryEntry id="717a-8f8b-caee-189d" name="Platoon" hidden="false"/>
+    <categoryEntry id="60d7-cb82-ac4f-fb9b" name="Field Ordnance Battery" hidden="false"/>
   </categoryEntries>
   <rules>
     <rule id="431d-d055-dd6e-d714" name="Defenders of Humanity" hidden="false">
@@ -506,7 +512,7 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
         <profile id="0231-9a03-0f43-82e5" name="Stat Damage (HS) 1" hidden="false" typeId="e6d5-85c5-7b01-a3c4" typeName="Stat Damage - M/BS/A">
           <characteristics>
             <characteristic name="Remaining W" typeId="233c-fa78-4641-68d9">6-11+</characteristic>
-            <characteristic name="Movement" typeId="fc73-9b3f-5e4b-86b9">12&quot;</characteristic>
+            <characteristic name="Movement" typeId="fc73-9b3f-5e4b-86b9">10&quot;</characteristic>
             <characteristic name="BS" typeId="8010-b879-355a-c137">4+</characteristic>
             <characteristic name="Attacks" typeId="2e64-2e5c-f4d1-52d3">3</characteristic>
           </characteristics>
@@ -522,7 +528,7 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
         <profile id="6429-35d0-d54a-fd21" name="Stat Damage (HS) 3" hidden="false" typeId="e6d5-85c5-7b01-a3c4" typeName="Stat Damage - M/BS/A">
           <characteristics>
             <characteristic name="Remaining W" typeId="233c-fa78-4641-68d9">1-2</characteristic>
-            <characteristic name="Movement" typeId="fc73-9b3f-5e4b-86b9">4&quot;</characteristic>
+            <characteristic name="Movement" typeId="fc73-9b3f-5e4b-86b9">6&quot;</characteristic>
             <characteristic name="BS" typeId="8010-b879-355a-c137">6+</characteristic>
             <characteristic name="Attacks" typeId="2e64-2e5c-f4d1-52d3">1</characteristic>
           </characteristics>
@@ -551,7 +557,7 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
         <profile id="e165-e184-5efd-7afb" name="Leman Russ 2" hidden="false" typeId="e6d5-85c5-7b01-a3c4" typeName="Stat Damage - M/BS/A">
           <characteristics>
             <characteristic name="Remaining W" typeId="233c-fa78-4641-68d9">4-6</characteristic>
-            <characteristic name="Movement" typeId="fc73-9b3f-5e4b-86b9">7&quot;</characteristic>
+            <characteristic name="Movement" typeId="fc73-9b3f-5e4b-86b9">8&quot;</characteristic>
             <characteristic name="BS" typeId="8010-b879-355a-c137">5+</characteristic>
             <characteristic name="Attacks" typeId="2e64-2e5c-f4d1-52d3">D6</characteristic>
           </characteristics>
@@ -559,7 +565,7 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
         <profile id="ab1b-6be1-dd5d-92e7" name="Leman Russ 3" hidden="false" typeId="e6d5-85c5-7b01-a3c4" typeName="Stat Damage - M/BS/A">
           <characteristics>
             <characteristic name="Remaining W" typeId="233c-fa78-4641-68d9">1-3</characteristic>
-            <characteristic name="Movement" typeId="fc73-9b3f-5e4b-86b9">4&quot;</characteristic>
+            <characteristic name="Movement" typeId="fc73-9b3f-5e4b-86b9">6&quot;</characteristic>
             <characteristic name="BS" typeId="8010-b879-355a-c137">6+</characteristic>
             <characteristic name="Attacks" typeId="2e64-2e5c-f4d1-52d3">D3</characteristic>
           </characteristics>
@@ -731,10 +737,10 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
           <characteristics>
             <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">72&quot;</characteristic>
             <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 1</characteristic>
-            <characteristic name="S" typeId="59b1-319e-ec13-d466">8</characteristic>
-            <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
-            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D6</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Roll two dice when inflicting damage with this weapon and discard the lowest result.</characteristic>
+            <characteristic name="S" typeId="59b1-319e-ec13-d466">14</characteristic>
+            <characteristic name="AP" typeId="75aa-a838-b675-6484">-5</characteristic>
+            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3+6</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Turret Weapon. Each time an attack is made with this weapon, if that attack successfully wounds the target, invulnerable saving throws cannot be made against that attack and the target suffers D3 mortal wounds in addition to any normal damage.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -748,13 +754,22 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bae5-d6f0-82d3-5193" type="max"/>
       </constraints>
-      <infoLinks>
-        <infoLink id="bc21-7c54-2ad9-00fa" name="Punisher Gatling Cannon" hidden="false" targetId="9fac-07c9-3595-784e" type="profile"/>
-      </infoLinks>
+      <profiles>
+        <profile id="9b91-db8d-c96a-7e2d" name="Punisher Gatling Cannon" publicationId="e831-8627-fbc7-5b35" page="105" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 20</characteristic>
+            <characteristic name="S" typeId="59b1-319e-ec13-d466">6</characteristic>
+            <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
+            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Turret Weapon</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
       <costs>
-        <cost name="pts" typeId="points" value="20.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="7bb3-24e8-431d-6bca" name="Turret-mounted Exterminator Autocannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -765,18 +780,18 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
         <profile id="c57e-43b9-2cf4-2fbb" name="Exterminator Autocannon" publicationId="53e9d88f--pubN88319" page="0" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">48&quot;</characteristic>
-            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 4</characteristic>
-            <characteristic name="S" typeId="59b1-319e-ec13-d466">7</characteristic>
-            <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
+            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 6</characteristic>
+            <characteristic name="S" typeId="59b1-319e-ec13-d466">8</characteristic>
+            <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
             <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"/>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Turret Weapon</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <costs>
-        <cost name="pts" typeId="points" value="15.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3a4b-c307-894e-3e63" name="Turret-mounted Executioner Plasma Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -787,21 +802,21 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
         <profile id="5147-f63c-9245-98ee" name="Executioner Plasma Cannon - Standard" publicationId="53e9d88f--pubN88319" page="0" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">36&quot;</characteristic>
-            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D6</characteristic>
+            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D6+3</characteristic>
             <characteristic name="S" typeId="59b1-319e-ec13-d466">7</characteristic>
-            <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
-            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast.</characteristic>
+            <characteristic name="AP" typeId="75aa-a838-b675-6484">-4</characteristic>
+            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast, Turret Weapon</characteristic>
           </characteristics>
         </profile>
         <profile id="aefa-0a3a-e78e-82f8" name="Executioner Plasma Cannon - Supercharge" publicationId="53e9d88f--pubN88319" page="0" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">36&quot;</characteristic>
-            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D6</characteristic>
+            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D6+3</characteristic>
             <characteristic name="S" typeId="59b1-319e-ec13-d466">8</characteristic>
-            <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
-            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. Each time an unmodified hit roll of 1 is made for an attack with this weapon profile, the bearer suffers 1 mortal wound after all of this weapon&apos;s shots have been resolved.</characteristic>
+            <characteristic name="AP" typeId="75aa-a838-b675-6484">-4</characteristic>
+            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">3</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. Turret Weapon. Each time an unmodified hit roll of 1 is made for an attack with this weapon profile, the bearer suffers 1 mortal wound after shooting with this weapon.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -819,11 +834,11 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
         <profile id="79f0-d958-9f8a-265c" name="Eradicator Nova Cannon" publicationId="53e9d88f--pubN88319" page="0" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">36&quot;</characteristic>
-            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D6</characteristic>
+            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D3+6</characteristic>
             <characteristic name="S" typeId="59b1-319e-ec13-d466">6</characteristic>
             <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
-            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. Units attacked by this weapon do not gain any bonus to their saving throws for being in cover.</characteristic>
+            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. Turret Weapon. Each time an attack is made with this weapon, the target does not receive the benefits of Light Cover against that attack.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -833,12 +848,12 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7def-3d84-3d31-afba" name="Turret-mounted Demolisher Siege Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="7def-3d84-3d31-afba" name="Turret-mounted Demolisher Battle Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="863d-cab0-136d-fc46" type="max"/>
       </constraints>
       <profiles>
-        <profile id="246c-c5dd-dd5a-64a2" name="Demolisher battle cannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+        <profile id="246c-c5dd-dd5a-64a2" name="Demolisher Battle Cannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
             <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D6</characteristic>
@@ -850,9 +865,9 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
         </profile>
       </profiles>
       <costs>
-        <cost name="pts" typeId="points" value="5.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="da34-52b0-53cc-1128" name="Tank Commander" publicationId="53e9d88f--pubN88319" page="0" hidden="false" collective="false" import="true" type="model">
@@ -1132,119 +1147,6 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1ad4-bc03-d515-d1d9" name="Hydras" publicationId="53e9d88f--pubN88319" page="49" hidden="false" collective="false" import="true" type="unit">
-      <categoryLinks>
-        <categoryLink id="1045-c72c-caa7-c861" name="Hydra" hidden="false" targetId="1d43-1f70-0642-964f" primary="false"/>
-        <categoryLink id="e6c7-b006-8028-45af" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
-        <categoryLink id="99ab-cb4f-f457-6488" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="dcb2-4118-98d5-0181" name="Hydra" page="0" hidden="false" collective="false" import="true" type="model">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5aab-129c-b711-b0da" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0daf-8220-6fba-79fc" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="553c-e855-3d1d-d0ec" name="Hydra" publicationId="53e9d88f--pubN88319" page="49" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
-              <characteristics>
-                <characteristic name="M" typeId="0bdf-a96e-9e38-7779">*</characteristic>
-                <characteristic name="WS" typeId="e7f0-1278-0250-df0c">6+</characteristic>
-                <characteristic name="BS" typeId="381b-eb28-74c3-df5f">*</characteristic>
-                <characteristic name="S" typeId="2218-aa3c-265f-2939">6</characteristic>
-                <characteristic name="T" typeId="9c9f-9774-a358-3a39">6</characteristic>
-                <characteristic name="W" typeId="f330-5e6e-4110-0978">11</characteristic>
-                <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">*</characteristic>
-                <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
-                <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="5003-fe19-899f-7819" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
-            <infoLink id="8481-7715-dd13-d165" name="Smoke Launchers" hidden="false" targetId="c883-3078-1367-cc2c" type="profile"/>
-            <infoLink id="9a1e-61ed-065c-1e33" name="Explodes" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
-            <infoLink id="4520-b5ed-a877-00f3" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
-          </infoLinks>
-          <selectionEntries>
-            <selectionEntry id="6339-b313-1828-0971" name="Hydra Quad Autocannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e8de-cf79-b3d7-9595" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1d14-e1b5-94a6-aff5" type="max"/>
-              </constraints>
-              <profiles>
-                <profile id="b6db-9a2d-6e4f-5a93" name="Hydra Quad Autocannon" publicationId="e831-8627-fbc7-5b35" page="107" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">72&quot;</characteristic>
-                    <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 8</characteristic>
-                    <characteristic name="S" typeId="59b1-319e-ec13-d466">7</characteristic>
-                    <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
-                    <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
-                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Turret Weapon [pg 75], Eah time an attack is made with this weapon against an AIRCRAFT unit, make 2 hit rolls instead of 1 and add 1 to both hit rolls</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="2680-11b0-6a56-e83f" name="Pintle Mount" hidden="false" collective="false" import="true">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8295-3e52-6956-b406" type="max"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="7ea9-e6a7-fcc1-dba8" name="Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
-                  <infoLinks>
-                    <infoLink id="2e90-18dc-1949-c9b1" name="Heavy stubber" hidden="false" targetId="0031-0314-5b36-a220" type="profile"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name="pts" typeId="points" value="5.0"/>
-                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-                <selectionEntry id="d93e-b107-5992-1d03" name="Storm Bolter" hidden="false" collective="false" import="true" type="upgrade">
-                  <infoLinks>
-                    <infoLink id="aab0-2597-9664-6ffc" name="New InfoLink" hidden="false" targetId="505e-a5aa-edab-6d5b" type="profile"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                    <cost name="pts" typeId="points" value="3.0"/>
-                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <entryLinks>
-            <entryLink id="9817-121f-a59c-f602" name="Hull Weapon" hidden="false" collective="false" import="true" targetId="846f-095f-3967-92af" type="selectionEntryGroup"/>
-            <entryLink id="cabe-da9d-f618-e7c1" name="Stat Damage (HS)" hidden="false" collective="false" import="true" targetId="da25-46a9-4472-2e07" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5988-495f-8beb-2a2e" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a2b9-c438-d737-c34a" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="260b-3a1c-2a35-d460" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
-            <entryLink id="c450-a80b-4abf-3b19" name="Unit has battle honors?" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-            <entryLink id="7750-dc2f-09af-b27e" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
-            <entryLink id="a010-4dc9-feab-89aa" name="Tank Aces" hidden="false" collective="false" import="true" targetId="998b-b53a-603f-6c5b" type="selectionEntryGroup"/>
-          </entryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="110.0"/>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="2985-edd1-a2d6-618d" name="Hellhounds" publicationId="53e9d88f--pubN88319" page="54" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="f638-c63c-2ebe-810e" name="Hellhound" hidden="false" targetId="740d-96f7-3ca7-c336" primary="false"/>
@@ -1468,87 +1370,75 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8c17-9bce-4cb6-3fe5" name="Basilisks" publicationId="53e9d88f--pubN88319" page="50" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="8c17-9bce-4cb6-3fe5" name="Basilisk" publicationId="e831-8627-fbc7-5b35" page="106" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="969a-0a0c-8a8c-b1ae" name="Basilisk" publicationId="53e9d88f--pubN88319" page="50" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="0bdf-a96e-9e38-7779">*</characteristic>
+            <characteristic name="WS" typeId="e7f0-1278-0250-df0c">6+</characteristic>
+            <characteristic name="BS" typeId="381b-eb28-74c3-df5f">*</characteristic>
+            <characteristic name="S" typeId="2218-aa3c-265f-2939">6</characteristic>
+            <characteristic name="T" typeId="9c9f-9774-a358-3a39">7</characteristic>
+            <characteristic name="W" typeId="f330-5e6e-4110-0978">11</characteristic>
+            <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">*</characteristic>
+            <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
+            <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="dde7-55ab-c18d-998c" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
+        <infoLink id="14bd-85ce-5b5c-78fc" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
+        <infoLink id="63c2-d799-c820-ff94" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="81d2-ed3e-1c0a-a263" name="Basilisk" hidden="false" targetId="7d7c-9011-2791-72d9" primary="false"/>
         <categoryLink id="653d-44e3-0f8a-4879" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
         <categoryLink id="8cfd-0c24-381d-d651" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="1ac7-a7ca-e65e-9eb3" name="Artillery" hidden="false" targetId="ae37-74e2-8391-d0f8" primary="false"/>
+        <categoryLink id="ee6f-5147-e811-b661" name="Smoke" hidden="false" targetId="bcf4-1bd8-9794-feaa" primary="false"/>
+        <categoryLink id="66a4-f756-92be-1e90" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+        <categoryLink id="31ef-817e-f40e-eec8" name="Squadron" hidden="false" targetId="eba3-3a9f-b907-d83a" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="2401-f8f4-1823-3283" name="Basilisk" page="0" hidden="false" collective="false" import="true" type="model">
+        <selectionEntry id="bc83-6515-2a06-17e9" name="Earthshaker Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="124c-d92f-e2a1-8cc7" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6d8f-beac-516a-507e" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="803a-bbe5-0d75-6f04" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5f34-7b16-a481-1cf1" type="max"/>
           </constraints>
           <profiles>
-            <profile id="93e0-d430-72ea-94d4" name="Basilisk" publicationId="53e9d88f--pubN88319" page="50" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+            <profile id="7f5a-1651-5532-8531" name="Earthshaker Cannon" publicationId="e831-8627-fbc7-5b35" page="106" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
               <characteristics>
-                <characteristic name="M" typeId="0bdf-a96e-9e38-7779">*</characteristic>
-                <characteristic name="WS" typeId="e7f0-1278-0250-df0c">6+</characteristic>
-                <characteristic name="BS" typeId="381b-eb28-74c3-df5f">*</characteristic>
-                <characteristic name="S" typeId="2218-aa3c-265f-2939">6</characteristic>
-                <characteristic name="T" typeId="9c9f-9774-a358-3a39">6</characteristic>
-                <characteristic name="W" typeId="f330-5e6e-4110-0978">11</characteristic>
-                <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">*</characteristic>
-                <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
-                <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">240&quot;</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D6+3</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">10</characteristic>
+                <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. This weapon can target units that are not visible to the bearer.</characteristic>
               </characteristics>
             </profile>
           </profiles>
-          <infoLinks>
-            <infoLink id="c88e-671f-9816-b82f" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
-            <infoLink id="7b5c-b3e3-ee60-6878" name="Smoke Launchers" hidden="false" targetId="c883-3078-1367-cc2c" type="profile"/>
-            <infoLink id="52bb-c901-29de-bf9a" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
-            <infoLink id="d789-ef61-53a7-c80f" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
-          </infoLinks>
-          <selectionEntries>
-            <selectionEntry id="27c7-8938-b404-3e9c" name="Earthshaker Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d10a-a5db-04b2-e8f1" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9002-db21-bd69-a28b" type="max"/>
-              </constraints>
-              <profiles>
-                <profile id="3e9e-d1bd-ba2c-2f70" name="Earthshaker Cannon" publicationId="53e9d88f--pubN88319" page="0" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">240&quot;</characteristic>
-                    <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D6</characteristic>
-                    <characteristic name="S" typeId="59b1-319e-ec13-d466">9</characteristic>
-                    <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
-                    <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
-                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. Roll two dice for the number of attacks when firing this weapon and discard the lowest result.  This weapon can target units that are not visible to the bearer.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="b5f4-7e7c-da1d-9f1a" name="Hull Weapon" hidden="false" collective="false" import="true" targetId="846f-095f-3967-92af" type="selectionEntryGroup"/>
-            <entryLink id="09f3-97d2-5ed7-ebe8" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
-            <entryLink id="c5ff-21f1-efe9-ad8e" name="Stat Damage (HS)" hidden="false" collective="false" import="true" targetId="da25-46a9-4472-2e07" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c396-3d37-de5a-601a" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cc5-2211-a52b-23c2" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="df24-aaf7-445f-e12b" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
-            <entryLink id="cbe7-331d-9d80-df6e" name="Tank Aces" hidden="false" collective="false" import="true" targetId="998b-b53a-603f-6c5b" type="selectionEntryGroup"/>
-          </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="125.0"/>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
+      <entryLinks>
+        <entryLink id="63de-7f47-f9eb-5503" name="Stat Damage (HS)" hidden="false" collective="false" import="true" targetId="da25-46a9-4472-2e07" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="164b-cb92-0136-a9c5" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="653a-50d9-8d10-32c5" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="0977-0307-a1a5-8a8c" name="Basilisk Hull Weapon" hidden="false" collective="false" import="true" targetId="809c-35f5-e84b-7065" type="selectionEntryGroup"/>
+        <entryLink id="1075-13f1-cceb-e1b7" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
+      </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="pts" typeId="points" value="140.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="3ac6-8d6e-850e-6aee" name="Baneblade" publicationId="53e9d88f--pubN88319" page="0" hidden="false" collective="false" import="true" type="model">
@@ -3853,6 +3743,31 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
           <infoLinks>
             <infoLink id="6f5b-1705-9fe3-46cb" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
           </infoLinks>
+          <selectionEntries>
+            <selectionEntry id="d4e1-6b85-ec43-1035" name="Earthshaker Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f90a-5132-1319-d8dd" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="58f9-2683-7612-5a05" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="73f6-593d-eb70-8d2b" name="Earthshaker Cannon" publicationId="53e9d88f--pubN88319" page="0" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">240&quot;</characteristic>
+                    <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D6</characteristic>
+                    <characteristic name="S" typeId="59b1-319e-ec13-d466">9</characteristic>
+                    <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
+                    <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
+                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. Roll two dice for the number of attacks when firing this weapon and discard the lowest result. This weapon can target units that are not visible to the bearer.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
           <entryLinks>
             <entryLink id="b48c-a7bb-b2ac-23e0" name="Guardsmen Crew" hidden="false" collective="false" import="true" targetId="70eb-d2d7-5172-ec78" type="selectionEntry">
               <constraints>
@@ -3862,7 +3777,6 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
             </entryLink>
             <entryLink id="35e4-8197-ae0d-be92" name="Unit has battle honors?" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
             <entryLink id="350c-878c-753a-f67c" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
-            <entryLink id="5831-347a-51cf-e47b" name="Earthshaker Cannon" hidden="false" collective="false" import="true" targetId="27c7-8938-b404-3e9c" type="selectionEntry"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="120.0"/>
@@ -6519,18 +6433,6 @@ This WARLORD knows those Orders in addition to any others it knows.</characteris
       </costs>
     </selectionEntry>
     <selectionEntry id="1f07-a468-bda8-fd3f" name="Warlord" hidden="false" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="add" field="category" value="fd1f-41ee-98cb-559e">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ab32-8146-6b3d-3ca7" type="greaterThan"/>
-          </conditions>
-        </modifier>
-        <modifier type="add" field="category" value="81e5-0f46-a4ab-4211">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ef96-6f0e-04be-8b2c" type="greaterThan"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="000a-cf6d-4c86-a749" type="max"/>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="010b-c4e3-7372-fcb7" type="max"/>
@@ -6564,19 +6466,6 @@ This WARLORD knows those Orders in addition to any others it knows.</characteris
       </costs>
     </selectionEntry>
     <selectionEntry id="bed3-70b2-ff0b-8788" name="Relic (9th Iotan Gorgonnes): Blessed Bolt Pistol" hidden="false" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3931-794a-b0a8-4299" type="equalTo"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3984-854b-4603-be64" type="notInstanceOf"/>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd1f-41ee-98cb-559e" type="equalTo"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="b0c0-61b6-4141-54ef" type="max"/>
       </constraints>
@@ -6609,7 +6498,6 @@ This WARLORD knows those Orders in addition to any others it knows.</characteris
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e7d3-614e-cf26-f161" type="equalTo"/>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3984-854b-4603-be64" type="notInstanceOf"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd1f-41ee-98cb-559e" type="equalTo"/>
               </conditions>
@@ -6639,7 +6527,6 @@ This WARLORD knows those Orders in addition to any others it knows.</characteris
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="05d3-4163-cfb9-5288" type="equalTo"/>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3984-854b-4603-be64" type="notInstanceOf"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd1f-41ee-98cb-559e" type="equalTo"/>
               </conditions>
@@ -6689,7 +6576,6 @@ This WARLORD knows those Orders in addition to any others it knows.</characteris
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c180-9110-58a1-51dc" type="equalTo"/>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3984-854b-4603-be64" type="notInstanceOf"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd1f-41ee-98cb-559e" type="equalTo"/>
               </conditions>
@@ -6719,7 +6605,6 @@ This WARLORD knows those Orders in addition to any others it knows.</characteris
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2ed5-9369-adca-05fd" type="equalTo"/>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3984-854b-4603-be64" type="notInstanceOf"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd1f-41ee-98cb-559e" type="equalTo"/>
               </conditions>
@@ -6759,7 +6644,6 @@ This WARLORD knows those Orders in addition to any others it knows.</characteris
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4fdd-f6f2-4f85-fcd9" type="equalTo"/>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3984-854b-4603-be64" type="notInstanceOf"/>
                 <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd1f-41ee-98cb-559e" type="equalTo"/>
               </conditions>
@@ -7383,7 +7267,6 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
             <conditionGroup type="or">
               <conditions>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3984-854b-4603-be64" type="notInstanceOf"/>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -7410,13 +7293,6 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
       </costs>
     </selectionEntry>
     <selectionEntry id="98ef-33e0-c9ec-a8ac" name="Advanced Countermeasures" hidden="false" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditions>
-            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-          </conditions>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15b4-dcb4-00d4-5cad" type="max"/>
       </constraints>
@@ -9428,13 +9304,6 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
           </characteristics>
         </profile>
         <profile id="5ae8-008e-69a2-7960" name="Elimination Protocol Sanctioned!" hidden="false" typeId="5c3a-03e3-c48d-726c" typeName="Regimental Orders">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ab32-8146-6b3d-3ca7" type="equalTo"/>
-              </conditions>
-            </modifier>
-          </modifiers>
           <characteristics>
             <characteristic name="Effect" typeId="e15a-5346-1d34-3504">You can re-roll failed wound rolls for models from the ordered unit when attacking any enemy VEHICLES or MONSTERS this phase.</characteristic>
           </characteristics>
@@ -9885,61 +9754,76 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
           </characteristics>
         </profile>
-        <profile id="e668-9c0f-c22f-c54e" name="The Hour is Nigh" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+        <profile id="55c1-e46b-040c-66d0" name=" Deathstrike Missile" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">The Deathstrike missile cannot be fired normally in the Shooting phase or during Overwatch.  In a friendly Shooting phase, if you wish to fire the Deathstrike missile, roll a D6 and add the battle round number.  If the result is 8 or more, you can fire the Deathstrike missile during this Shooting phase.  For example, in the third battle round, a roll of 5+ would be needed to fire the Deathstrike missile.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">During the Muster Armies step, after you have seen your opponent&apos;s army roster, select one of the following warheads for this model to be equipped with and make a note of this selection on your army roster: 
+- Godspear warhead
+- Plasma barrage warhead 
+- Vortex warhead</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="18b7-fa1d-4650-6399" name="Align Target" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model can perform the following action: 
+Align Target (Action): In your Command phase, any number of DEATHSTRIKE models from your army that have not launched their missile can start to perform this action. 
+
+The action is completed at the end of your turn. 
+
+If completed, you must do one of the following: 
+(1) place a Deathstrike Target marker anywhere on the battlefield for the model that completed this action.
+(2) if a Deathstrike Target marker is already on the battlefield forthe model that completed this action, move that marker to anywhere on the battlefield.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="5fa7-bdee-443b-85cc" name="Launch Missile" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">In your Shooting phase, when this model is selected to shoot, if it is not within Engagement Range of any enemy units, its Deathstrike Target marker is on the battlefield, and it has not launched its missile, you can choose for its missile to be launched.
+If you do so, resolve the relevant effect below for the warhead this model is equipped with:
+
+• Godspear Warhead: Roll one D6 for each unit within 3&quot; of the centre of this model&apos;s Deathstrike Target marker: 
+On a 2-3, that unit suffers 8 mortal wounds; on a 4-5, that unit suffers 12 mortal wounds; on a 6, that unit suffers 16 mortal wounds. 
+Then remove this model&apos;s Deathstrike Target marker from the battlefield. 
+
+• Plasma Barrage Warhead: Roll one D6 for each unit within D3+6&quot; of the centre of this model&apos;s Deathstrike Target marker, subtracting 1 from the result if that unit is an INFANTRY CHARACTER unit: 
+On a 2-3, that unit suffers D3+1 mortal wounds
+On a 4-5, that unit suffers 2D3 mortal wounds 
+On a 6, that unit suffers D3+3 mortal wounds. 
+Then remove this model&apos;s Deathstrike Target marker from the battlefield.
+
+• Vortex Warhead: At the end of each of your Shooting phases, if this model&apos;s Deathstrike Target marker is on the battlefield, roll one D6 for each unit within D3+3&quot; of the centre of that marker: 
+On a 2-3, that unit suffers D3 mortal wounds
+On a 4-5, that unit suffers D3+1 mortal wounds
+On a 6, that unit suffers 2D3 mortal wounds. 
+Then roll one D6: 
+On a 1-3, remove this model&apos;s Deathstrike Target marker from the battlefield
+On a 4+ do not remove that marker from the battlefield, but that marker cannot be moved using the Align Target action for the rest of the battle.</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <infoLinks>
         <infoLink id="9486-485f-fc70-0eda" name="Explodes (6+/6&quot;/D6)" hidden="false" targetId="7525-aa8c-bea2-9691" type="profile"/>
-        <infoLink id="9339-82df-27b0-068e" name="Smoke Launchers" hidden="false" targetId="c883-3078-1367-cc2c" type="profile"/>
         <infoLink id="dddb-83cc-2a24-6567" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
+        <infoLink id="dd60-7c69-f10d-5492" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="daf7-11c7-4764-6d0b" name="Deathstrike" hidden="false" targetId="53b9-ff6c-bca7-8e1c" primary="false"/>
-        <categoryLink id="eddc-e4a1-cfec-7604" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
         <categoryLink id="ccc2-1e4a-9a0f-58ed" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
         <categoryLink id="0a15-39bf-4d1f-b171" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
         <categoryLink id="2dcd-fbd2-f9ec-99bf" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="8f53-5783-ce6d-ec99" name="Artillery" hidden="false" targetId="ae37-74e2-8391-d0f8" primary="false"/>
+        <categoryLink id="8276-44c0-46ee-e4df" name="Smoke" hidden="false" targetId="bcf4-1bd8-9794-feaa" primary="false"/>
+        <categoryLink id="3e99-2826-81de-b38c" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+        <categoryLink id="ddcf-727f-40e8-ea97" name="Squadron" hidden="false" targetId="eba3-3a9f-b907-d83a" primary="false"/>
       </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="7866-9494-2011-d35b" name="Deathstrike Missile" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5682-cc41-d196-1427" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0d77-59d9-e890-6a03" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="d093-3840-8fe7-81da" name="Deathstrike Missile" publicationId="53e9d88f--pubN88319" page="0" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">200&quot;</characteristic>
-                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 3D6</characteristic>
-                <characteristic name="S" typeId="59b1-319e-ec13-d466">*</characteristic>
-                <characteristic name="AP" typeId="75aa-a838-b675-6484">*</characteristic>
-                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">*</characteristic>
-                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. This weapon can only be fired once per battle. This weapon can target units that are not visible to the bearer.  Each time you hit the target with this weapon it suffers a mortal wound. After resolving all damage on the unit, roll a D6 for every other unit within 6&quot; of the target unit - on a 4+ that unit also suffers D3 mortal wounds.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
       <entryLinks>
         <entryLink id="aaa3-082d-7429-1d0d" name="Stat Damage (HS)" hidden="false" collective="false" import="true" targetId="da25-46a9-4472-2e07" type="selectionEntry"/>
         <entryLink id="6891-6aa3-c888-5fd1" name="Hull Weapon" hidden="false" collective="false" import="true" targetId="846f-095f-3967-92af" type="selectionEntryGroup"/>
-        <entryLink id="a0d6-4072-5e21-0ce5" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
         <entryLink id="f0ff-12f3-b18f-09ca" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
-        <entryLink id="efc0-8c6d-2152-f932" name="Unit has battle honors?" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="efc0-8c6d-2152-f932" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
         <entryLink id="33f4-f274-554a-dc2e" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
-        <entryLink id="d578-53da-ecc3-0867" name="Tank Aces" hidden="false" collective="false" import="true" targetId="998b-b53a-603f-6c5b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="120.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
+        <cost name="pts" typeId="points" value="160.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="9.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -10225,10 +10109,34 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
             <infoLink id="96af-012a-4529-5cbc" name="Artillery Battery" hidden="false" targetId="b5b7-88a4-88d9-dc53" type="profile"/>
             <infoLink id="2b0a-33a9-3eab-9c31" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
           </infoLinks>
+          <selectionEntries>
+            <selectionEntry id="1f01-5efd-5676-37b9" name="Earthshaker Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bdb8-db0f-0162-522e" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1a5a-52f8-eca3-b7a2" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="a70f-cc97-422a-2ef3" name="Earthshaker Cannon" publicationId="53e9d88f--pubN88319" page="0" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">240&quot;</characteristic>
+                    <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D6</characteristic>
+                    <characteristic name="S" typeId="59b1-319e-ec13-d466">9</characteristic>
+                    <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
+                    <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
+                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. Roll two dice for the number of attacks when firing this weapon and discard the lowest result. This weapon can target units that are not visible to the bearer.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="0.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
           <entryLinks>
             <entryLink id="8b69-e276-197c-8ee5" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
             <entryLink id="7739-d04c-ea59-fb06" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
-            <entryLink id="50f2-d4d9-73fa-fe02" name="Earthshaker Cannon" hidden="false" collective="false" import="true" targetId="27c7-8938-b404-3e9c" type="selectionEntry"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="125.0"/>
@@ -10512,19 +10420,21 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b796-7e12-3616-52e6" name="Heavy Weapons Squad" publicationId="53e9d88f--pubN88319" page="0" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="b796-7e12-3616-52e6" name="Heavy Weapons Squad" publicationId="e831-8627-fbc7-5b35" page="104" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
-        <infoLink id="839d-8321-d166-9586" name="Frag grenade" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
+        <infoLink id="839d-8321-d166-9586" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
+        <infoLink id="3ee4-362e-20c0-ab10" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="e33a-55c5-e9f2-6f1a" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
         <categoryLink id="0954-6dc6-315a-1f67" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
         <categoryLink id="2a0b-8b2b-1e89-39d8" name="Heavy Weapons Squad" hidden="false" targetId="534e-85e2-ac99-92a7" primary="false"/>
         <categoryLink id="dcef-1d1c-bf18-54d3" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
         <categoryLink id="eaab-a63f-6faf-def1" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="6910-70b8-1d7e-f1bf" name="Core" hidden="false" targetId="08f1-d244-eb44-7e01" primary="false"/>
+        <categoryLink id="524b-e17a-d08a-e61c" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
       </categoryLinks>
       <selectionEntries>
-        <selectionEntry id="15ba-9733-be99-c375" name="Heavy Weapon Team" page="0" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="15ba-9733-be99-c375" name="Heavy Weapon Team" publicationId="e831-8627-fbc7-5b35" page="104" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3b1d-7c29-5012-c2aa" type="max"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50f6-6f21-cc72-fd9d" type="min"/>
@@ -10553,12 +10463,12 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="c3b3-d4f2-1af5-f37f" name="Unit has battle honors?" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="21fd-14a9-fc62-fd93" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="c3b3-d4f2-1af5-f37f" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="21fd-14a9-fc62-fd93" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="3.0"/>
-        <cost name="pts" typeId="points" value="50.0"/>
+        <cost name="pts" typeId="points" value="55.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -10773,7 +10683,7 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
           <entryLinks>
             <entryLink id="f8c2-62dd-2b60-3a2a" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
             <entryLink id="cdda-8524-dcfe-6036" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
-            <entryLink id="e2e4-e8ff-5d89-9861" name="Hydra Quad Autocannon" hidden="false" collective="false" import="true" targetId="6339-b313-1828-0971" type="selectionEntry"/>
+            <entryLink id="e2e4-e8ff-5d89-9861" name="Hydra" hidden="false" collective="false" import="true" targetId="411a-f57a-9f2b-b9df" type="selectionEntry"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="80.0"/>
@@ -11023,13 +10933,16 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="af7a-3b6b-099c-c23b" name="Leman Russ Battle Tanks" publicationId="53e9d88f--pubN88319" page="46" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="af7a-3b6b-099c-c23b" name="Leman Russ Battle Tanks" publicationId="e831-8627-fbc7-5b35" page="105" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="6303-3caa-d0f5-46fe" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
         <categoryLink id="bc43-a148-1176-e457" name="Leman Russ Battle Tank" hidden="false" targetId="dccb-7194-05d6-9725" primary="false"/>
         <categoryLink id="5b15-40dc-e36c-4728" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
         <categoryLink id="d68d-7471-7b96-a612" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
-        <categoryLink id="449f-8515-0ef5-51cd" name="Battle Tank" hidden="false" targetId="fdd3-90b2-0078-6c5b" primary="false"/>
+        <categoryLink id="4cdb-5ca9-6cb6-6975" name="Battle Tank" hidden="false" targetId="ae9d-34d2-e8f7-62df" primary="false"/>
+        <categoryLink id="1297-dd9c-6b02-3d29" name="Smoke" hidden="false" targetId="bcf4-1bd8-9794-feaa" primary="false"/>
+        <categoryLink id="b7e1-f100-0dd8-b38f" name="Squadron" hidden="false" targetId="eba3-3a9f-b907-d83a" primary="false"/>
+        <categoryLink id="e89c-91b3-a7fa-621f" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+        <categoryLink id="88b4-3cf3-afb1-4cc8" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="cab8-09fb-4f01-e432" name="Leman Russ" hidden="false" collective="false" import="true">
@@ -11038,7 +10951,7 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f954-1d7f-49ef-1b9f" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="1942-754b-39c5-cd09" name="Leman Russ Battle Tank" publicationId="53e9d88f--pubN88319" page="46" hidden="false" collective="false" import="true" type="model">
+            <selectionEntry id="1942-754b-39c5-cd09" name="Leman Russ Battle Tank" publicationId="e831-8627-fbc7-5b35" page="105" hidden="false" collective="false" import="true" type="model">
               <modifiers>
                 <modifier type="append" field="name" value="[Legends]">
                   <conditionGroups>
@@ -11046,8 +10959,8 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                       <conditions>
                         <condition field="selections" scope="1942-754b-39c5-cd09" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac67-32a6-44a4-8dff" type="greaterThan"/>
                         <condition field="selections" scope="1942-754b-39c5-cd09" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7b19-bc3c-4a64-2f3f" type="greaterThan"/>
-                        <condition field="selections" scope="1942-754b-39c5-cd09" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0161-5957-f75f-0d37" type="greaterThan"/>
                         <condition field="selections" scope="1942-754b-39c5-cd09" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9211-39f2-d24b-0fcf" type="greaterThan"/>
+                        <condition field="selections" scope="1942-754b-39c5-cd09" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0569-31b8-8524-2a78" type="greaterThan"/>
                         <condition field="selections" scope="1942-754b-39c5-cd09" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0569-31b8-8524-2a78" type="greaterThan"/>
                       </conditions>
                     </conditionGroup>
@@ -11056,12 +10969,10 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
               </modifiers>
               <infoLinks>
                 <infoLink id="9c1a-50da-9849-e7c2" name="Leman Russ" hidden="false" targetId="59561fd3-8437-5e2e-1080-fe4d29ae4a60" type="profile"/>
-                <infoLink id="04df-7b9e-3a09-f040" name="Grinding Advance" hidden="false" targetId="d894-c3d2-278d-3678" type="profile"/>
                 <infoLink id="b51c-4e8c-a5d6-1aa0" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
-                <infoLink id="819c-dcc8-27e0-f46d" name="Smoke Launchers" hidden="false" targetId="c883-3078-1367-cc2c" type="profile"/>
                 <infoLink id="d595-6557-60e3-77b9" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
-                <infoLink id="71b2-ec8d-b850-fc94" name="Emergency Plasma Vents" hidden="false" targetId="fdc3-2a0f-e726-f47c" type="profile"/>
-                <infoLink id="e287-75b0-3783-a7da" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
+                <infoLink id="f12f-794f-0378-f6cf" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
+                <infoLink id="d339-bb79-80b0-0b65" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="9084-bff1-9911-3b16" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
@@ -11181,7 +11092,6 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
               <entryLinks>
                 <entryLink id="d49b-8437-b9c6-5053" name="Russ Hull Weapon" hidden="false" collective="false" import="true" targetId="5bed-1f36-dd00-bd20" type="selectionEntryGroup"/>
                 <entryLink id="5c9b-6070-f427-6b3c" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
-                <entryLink id="bcf7-4c77-493d-83f6" name="Sponson Weapons" hidden="false" collective="false" import="true" targetId="2358-1348-7c6b-bb88" type="selectionEntryGroup"/>
                 <entryLink id="a286-a161-cabe-dbd9" name="Stat Damage (Leman Russ)" hidden="false" collective="false" import="true" targetId="aff3-db41-0dc2-49ce" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2b4-7223-4a11-2b81" type="min"/>
@@ -11189,23 +11099,22 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                   </constraints>
                 </entryLink>
                 <entryLink id="9234-32ed-62d3-c89b" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
-                <entryLink id="1526-b899-be3f-3b14" name="Tank Aces" hidden="false" collective="false" import="true" targetId="998b-b53a-603f-6c5b" type="selectionEntryGroup"/>
+                <entryLink id="1526-b899-be3f-3b14" name="Tank Aces (Battle Tank)" hidden="false" collective="false" import="true" targetId="d8ad-1ab9-059c-9325" type="selectionEntryGroup"/>
+                <entryLink id="f0b8-2bc3-b6ab-81bd" name="Sponson Weapons" hidden="false" collective="false" import="true" targetId="3ba3-a817-04f2-0282" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
-                <cost name="pts" typeId="points" value="130.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="10.0"/>
+                <cost name="pts" typeId="points" value="150.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="9.0"/>
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
             <selectionEntry id="fe7f-2ffa-6b35-cb9f" name="Leman Russ Eradicator" publicationId="53e9d88f--pubN88319" page="47" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
                 <infoLink id="a22d-1e58-6d29-6e46" name="Leman Russ" hidden="false" targetId="59561fd3-8437-5e2e-1080-fe4d29ae4a60" type="profile"/>
-                <infoLink id="c324-6ffb-050c-06b7" name="Grinding Advance" hidden="false" targetId="d894-c3d2-278d-3678" type="profile"/>
                 <infoLink id="ccf0-a7a6-f2d3-071f" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
-                <infoLink id="b4e4-b13c-6664-1992" name="Smoke Launchers" hidden="false" targetId="c883-3078-1367-cc2c" type="profile"/>
                 <infoLink id="0884-cc6d-2bd2-1c1d" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
-                <infoLink id="5d67-bfac-5fb3-b870" name="Improved Emergency Plasma Vents" hidden="false" targetId="fdc3-2a0f-e726-f47c" type="profile"/>
-                <infoLink id="3248-0964-7cc6-8e46" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
+                <infoLink id="42f1-c630-5158-7c3c" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
+                <infoLink id="72c1-90ee-9ad1-f876" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="7c73-1ab7-cafe-52de" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
@@ -11218,7 +11127,7 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                 </entryLink>
                 <entryLink id="3786-5498-5d26-fdd6" name="Russ Hull Weapon" hidden="false" collective="false" import="true" targetId="5bed-1f36-dd00-bd20" type="selectionEntryGroup"/>
                 <entryLink id="5cd6-35b5-a757-c1a2" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
-                <entryLink id="7690-21be-dc42-b637" name="Sponson Weapons" hidden="false" collective="false" import="true" targetId="2358-1348-7c6b-bb88" type="selectionEntryGroup"/>
+                <entryLink id="7690-21be-dc42-b637" name="Sponson Weapons" hidden="false" collective="false" import="true" targetId="3ba3-a817-04f2-0282" type="selectionEntryGroup"/>
                 <entryLink id="202d-e7fa-de1d-74bc" name="Stat Damage (Leman Russ)" hidden="false" collective="false" import="true" targetId="aff3-db41-0dc2-49ce" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb7a-48c6-d342-8799" type="min"/>
@@ -11226,7 +11135,7 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                   </constraints>
                 </entryLink>
                 <entryLink id="b795-1dff-530d-961b" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
-                <entryLink id="bf09-6043-9e6a-934a" name="Tank Aces" hidden="false" collective="false" import="true" targetId="998b-b53a-603f-6c5b" type="selectionEntryGroup"/>
+                <entryLink id="bf09-6043-9e6a-934a" name="Tank Aces (Battle Tank)" hidden="false" collective="false" import="true" targetId="d8ad-1ab9-059c-9325" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="130.0"/>
@@ -11236,13 +11145,11 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
             </selectionEntry>
             <selectionEntry id="10e8-3f53-f686-d0a9" name="Leman Russ Exterminator" publicationId="53e9d88f--pubN88319" page="46" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
-                <infoLink id="eff0-5319-6b70-00ac" hidden="false" targetId="59561fd3-8437-5e2e-1080-fe4d29ae4a60" type="profile"/>
-                <infoLink id="1f58-724f-88b0-e2c1" name="Grinding Advance" hidden="false" targetId="d894-c3d2-278d-3678" type="profile"/>
+                <infoLink id="eff0-5319-6b70-00ac" name="Leman Russ" hidden="false" targetId="59561fd3-8437-5e2e-1080-fe4d29ae4a60" type="profile"/>
                 <infoLink id="c3ae-d145-4b23-c911" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
-                <infoLink id="87eb-1402-2882-4bd1" name="Smoke Launchers" hidden="false" targetId="c883-3078-1367-cc2c" type="profile"/>
                 <infoLink id="faba-e220-35c9-07ed" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
-                <infoLink id="da9d-6211-27c7-6418" name="Improved Emergency Plasma Vents" hidden="false" targetId="fdc3-2a0f-e726-f47c" type="profile"/>
-                <infoLink id="c72c-690f-cc14-30b8" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
+                <infoLink id="332e-63f3-1706-7c18" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
+                <infoLink id="232b-0cb2-b6a3-82a4" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="b543-4f7c-7117-44ee" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
@@ -11255,7 +11162,7 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                 </entryLink>
                 <entryLink id="c6ca-816d-ecf2-3026" name="Russ Hull Weapon" hidden="false" collective="false" import="true" targetId="5bed-1f36-dd00-bd20" type="selectionEntryGroup"/>
                 <entryLink id="b526-3ca8-e048-68eb" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
-                <entryLink id="1318-87d1-7da1-a024" name="Sponson Weapons" hidden="false" collective="false" import="true" targetId="2358-1348-7c6b-bb88" type="selectionEntryGroup"/>
+                <entryLink id="1318-87d1-7da1-a024" name="Sponson Weapons" hidden="false" collective="false" import="true" targetId="3ba3-a817-04f2-0282" type="selectionEntryGroup"/>
                 <entryLink id="8577-2b04-e57a-ceb5" name="Stat Damage (Leman Russ)" hidden="false" collective="false" import="true" targetId="aff3-db41-0dc2-49ce" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50b8-4248-2acb-206b" type="min"/>
@@ -11263,7 +11170,7 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                   </constraints>
                 </entryLink>
                 <entryLink id="706a-ead8-38c1-cbec" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
-                <entryLink id="ff9b-e0e1-7931-ed74" name="Tank Aces" hidden="false" collective="false" import="true" targetId="998b-b53a-603f-6c5b" type="selectionEntryGroup"/>
+                <entryLink id="ff9b-e0e1-7931-ed74" name="Tank Aces (Battle Tank)" hidden="false" collective="false" import="true" targetId="d8ad-1ab9-059c-9325" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="130.0"/>
@@ -11274,12 +11181,10 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
             <selectionEntry id="e7a1-ec8c-78a0-94a8" name="Leman Russ Vanquisher" publicationId="53e9d88f--pubN88319" page="47" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
                 <infoLink id="2550-ef33-ce56-f484" name="Leman Russ" hidden="false" targetId="59561fd3-8437-5e2e-1080-fe4d29ae4a60" type="profile"/>
-                <infoLink id="8bc9-c3a5-5e4a-a5e2" name="Grinding Advance" hidden="false" targetId="d894-c3d2-278d-3678" type="profile"/>
-                <infoLink id="b2c0-6262-1d97-dd05" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
-                <infoLink id="5540-7ecc-c4f1-c82b" name="Smoke Launchers" hidden="false" targetId="c883-3078-1367-cc2c" type="profile"/>
                 <infoLink id="0824-166c-fe9e-845b" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
-                <infoLink id="beb7-23df-19c8-1c72" name="Improved Emergency Plasma Vents" hidden="false" targetId="fdc3-2a0f-e726-f47c" type="profile"/>
-                <infoLink id="a40d-6996-cb4c-285f" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
+                <infoLink id="780c-c171-0175-bd13" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
+                <infoLink id="d08f-302c-bbfe-9e87" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+                <infoLink id="1247-2439-7ef4-4cc3" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="12fb-c09f-7b39-0be4" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
@@ -11292,7 +11197,7 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                 </entryLink>
                 <entryLink id="61aa-6d50-0ef9-c281" name="Russ Hull Weapon" hidden="false" collective="false" import="true" targetId="5bed-1f36-dd00-bd20" type="selectionEntryGroup"/>
                 <entryLink id="d964-61e9-5ccd-0276" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
-                <entryLink id="bc7f-acc3-f859-0c9e" name="Sponson Weapons" hidden="false" collective="false" import="true" targetId="2358-1348-7c6b-bb88" type="selectionEntryGroup"/>
+                <entryLink id="bc7f-acc3-f859-0c9e" name="Sponson Weapons" hidden="false" collective="false" import="true" targetId="3ba3-a817-04f2-0282" type="selectionEntryGroup"/>
                 <entryLink id="1006-7346-4b08-9017" name="Stat Damage (Leman Russ)" hidden="false" collective="false" import="true" targetId="aff3-db41-0dc2-49ce" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8760-8e34-6311-b4ad" type="min"/>
@@ -11300,7 +11205,7 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                   </constraints>
                 </entryLink>
                 <entryLink id="c2d2-f506-bf9b-0387" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
-                <entryLink id="dcd4-3cc8-e77c-c2b6" name="Tank Aces" hidden="false" collective="false" import="true" targetId="998b-b53a-603f-6c5b" type="selectionEntryGroup"/>
+                <entryLink id="dcd4-3cc8-e77c-c2b6" name="Tank Aces (Battle Tank)" hidden="false" collective="false" import="true" targetId="d8ad-1ab9-059c-9325" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="130.0"/>
@@ -11310,13 +11215,11 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
             </selectionEntry>
             <selectionEntry id="70d3-335c-e94b-9a8d" name="Leman Russ Executioner" publicationId="53e9d88f--pubN88319" page="47" hidden="false" collective="false" import="true" type="model">
               <infoLinks>
-                <infoLink id="cf4a-2766-d886-7eb9" hidden="false" targetId="59561fd3-8437-5e2e-1080-fe4d29ae4a60" type="profile"/>
+                <infoLink id="cf4a-2766-d886-7eb9" name="Leman Russ" hidden="false" targetId="59561fd3-8437-5e2e-1080-fe4d29ae4a60" type="profile"/>
                 <infoLink id="3d6f-e9e7-3506-015d" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
-                <infoLink id="9e24-17f6-0d0f-3653" name="Grinding Advance" hidden="false" targetId="d894-c3d2-278d-3678" type="profile"/>
                 <infoLink id="2ad2-0d2b-cbb8-a8d9" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
-                <infoLink id="ace3-5db2-22cd-145b" name="Smoke Launchers" hidden="false" targetId="c883-3078-1367-cc2c" type="profile"/>
-                <infoLink id="ddd3-b5fd-ca4f-ede5" name="Improved Emergency Plasma Vents" hidden="false" targetId="fdc3-2a0f-e726-f47c" type="profile"/>
-                <infoLink id="ae50-c864-5efb-7688" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
+                <infoLink id="5b65-66a0-84e5-f1e2" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
+                <infoLink id="8d3e-59d6-c722-9208" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="4d06-97f3-b5e6-267c" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
@@ -11329,7 +11232,7 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                 </entryLink>
                 <entryLink id="c47f-6523-de69-2786" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
                 <entryLink id="b69a-7624-5939-1afb" name="Russ Hull Weapon" hidden="false" collective="false" import="true" targetId="5bed-1f36-dd00-bd20" type="selectionEntryGroup"/>
-                <entryLink id="dc04-7bba-6259-4f06" name="Sponson Weapons" hidden="false" collective="false" import="true" targetId="2358-1348-7c6b-bb88" type="selectionEntryGroup"/>
+                <entryLink id="dc04-7bba-6259-4f06" name="Sponson Weapons" hidden="false" collective="false" import="true" targetId="3ba3-a817-04f2-0282" type="selectionEntryGroup"/>
                 <entryLink id="519f-d0ce-03ed-9374" name="Stat Damage (Leman Russ)" hidden="false" collective="false" import="true" targetId="aff3-db41-0dc2-49ce" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f90a-cb60-c660-65b5" type="min"/>
@@ -11337,7 +11240,7 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                   </constraints>
                 </entryLink>
                 <entryLink id="4d6c-fb66-8be8-d6f9" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
-                <entryLink id="34d6-26e2-3096-0347" name="Tank Aces" hidden="false" collective="false" import="true" targetId="998b-b53a-603f-6c5b" type="selectionEntryGroup"/>
+                <entryLink id="34d6-26e2-3096-0347" name="Tank Aces (Battle Tank)" hidden="false" collective="false" import="true" targetId="d8ad-1ab9-059c-9325" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="130.0"/>
@@ -11349,11 +11252,9 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
               <infoLinks>
                 <infoLink id="b1b5-484d-2d36-ab94" name="Leman Russ" hidden="false" targetId="59561fd3-8437-5e2e-1080-fe4d29ae4a60" type="profile"/>
                 <infoLink id="727d-e34f-c3dd-4281" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
-                <infoLink id="bc89-96b4-2342-2cdd" name="Grinding Advance" hidden="false" targetId="d894-c3d2-278d-3678" type="profile"/>
                 <infoLink id="4af0-cef5-1509-77af" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
-                <infoLink id="3135-024c-fc42-a6be" name="Smoke Launchers" hidden="false" targetId="c883-3078-1367-cc2c" type="profile"/>
-                <infoLink id="a6ac-0137-9dfa-e80b" name="Improved Emergency Plasma Vents" hidden="false" targetId="fdc3-2a0f-e726-f47c" type="profile"/>
-                <infoLink id="1e3d-b7c9-4c6b-f204" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
+                <infoLink id="68a8-622a-54c5-abad" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
+                <infoLink id="1e91-fa98-8130-a14a" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="088a-d4d4-e27e-ed59" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
@@ -11366,7 +11267,7 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                 </entryLink>
                 <entryLink id="6555-27a9-234e-643b" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
                 <entryLink id="7137-c0d7-eee0-e7b6" name="Russ Hull Weapon" hidden="false" collective="false" import="true" targetId="5bed-1f36-dd00-bd20" type="selectionEntryGroup"/>
-                <entryLink id="bdb6-2d10-8744-b8d7" name="Sponson Weapons" hidden="false" collective="false" import="true" targetId="2358-1348-7c6b-bb88" type="selectionEntryGroup"/>
+                <entryLink id="bdb6-2d10-8744-b8d7" name="Sponson Weapons" hidden="false" collective="false" import="true" targetId="3ba3-a817-04f2-0282" type="selectionEntryGroup"/>
                 <entryLink id="ebea-ac66-2130-99c0" name="Stat Damage (Leman Russ)" hidden="false" collective="false" import="true" targetId="aff3-db41-0dc2-49ce" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66d3-22be-9ce2-aec5" type="min"/>
@@ -11374,7 +11275,7 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                   </constraints>
                 </entryLink>
                 <entryLink id="a281-a303-ddd6-4e74" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
-                <entryLink id="884e-5118-8a4e-3672" name="Tank Aces" hidden="false" collective="false" import="true" targetId="998b-b53a-603f-6c5b" type="selectionEntryGroup"/>
+                <entryLink id="884e-5118-8a4e-3672" name="Tank Aces (Battle Tank)" hidden="false" collective="false" import="true" targetId="d8ad-1ab9-059c-9325" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="130.0"/>
@@ -11386,11 +11287,9 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
               <infoLinks>
                 <infoLink id="f311-898c-9180-e208" name="Leman Russ" hidden="false" targetId="59561fd3-8437-5e2e-1080-fe4d29ae4a60" type="profile"/>
                 <infoLink id="518a-46b0-3edb-4725" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
-                <infoLink id="9908-638e-6a13-a03f" name="Grinding Advance" hidden="false" targetId="d894-c3d2-278d-3678" type="profile"/>
                 <infoLink id="7fa4-9c60-07b7-15cb" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
-                <infoLink id="b1c7-2a2f-c0b7-cf2b" name="Smoke Launchers" hidden="false" targetId="c883-3078-1367-cc2c" type="profile"/>
-                <infoLink id="f3ff-889a-1c41-b20e" name="Improved Emergency Plasma Vents" hidden="false" targetId="fdc3-2a0f-e726-f47c" type="profile"/>
-                <infoLink id="164b-dfbb-fe10-5a67" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
+                <infoLink id="f5e8-0c2c-ae7f-b103" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
+                <infoLink id="aee4-9be1-6a28-65f9" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="5c48-35f3-e5c9-78db" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
@@ -11403,7 +11302,7 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                 </entryLink>
                 <entryLink id="c7d4-a89a-8077-672b" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
                 <entryLink id="97ca-3c8c-25ec-5840" name="Russ Hull Weapon" hidden="false" collective="false" import="true" targetId="5bed-1f36-dd00-bd20" type="selectionEntryGroup"/>
-                <entryLink id="9158-9a56-019c-294f" name="Sponson Weapons" hidden="false" collective="false" import="true" targetId="2358-1348-7c6b-bb88" type="selectionEntryGroup"/>
+                <entryLink id="9158-9a56-019c-294f" name="Sponson Weapons" hidden="false" collective="false" import="true" targetId="3ba3-a817-04f2-0282" type="selectionEntryGroup"/>
                 <entryLink id="a719-1897-1914-a5e1" name="Stat Damage (Leman Russ)" hidden="false" collective="false" import="true" targetId="aff3-db41-0dc2-49ce" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d21a-83bd-a527-2bd9" type="min"/>
@@ -11411,7 +11310,7 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                   </constraints>
                 </entryLink>
                 <entryLink id="7b9c-b690-7fc4-71e3" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
-                <entryLink id="c6e8-0a3f-5463-96f8" name="Tank Aces" hidden="false" collective="false" import="true" targetId="998b-b53a-603f-6c5b" type="selectionEntryGroup"/>
+                <entryLink id="c6e8-0a3f-5463-96f8" name="Tank Aces (Battle Tank)" hidden="false" collective="false" import="true" targetId="d8ad-1ab9-059c-9325" type="selectionEntryGroup"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="130.0"/>
@@ -11572,15 +11471,18 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="0d2a-7b34-8514-00d8" name="Smoke Launchers" hidden="false" targetId="c883-3078-1367-cc2c" type="profile"/>
         <infoLink id="b23f-3bff-7087-4ca0" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
+        <infoLink id="0a5f-5909-28ab-00ac" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="e430-4e55-9759-9a49" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
         <categoryLink id="b46b-695a-ce6f-877a" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
         <categoryLink id="169d-a601-69f6-0814" name="Manticore" hidden="false" targetId="794d-6be2-da97-2e95" primary="false"/>
         <categoryLink id="f7eb-845b-5089-00bd" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
         <categoryLink id="4fac-8fd2-35ca-a4e7" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="a642-d9db-e6a7-150f" name="Artillery" hidden="false" targetId="ae37-74e2-8391-d0f8" primary="false"/>
+        <categoryLink id="1929-8a9f-d428-e658" name="Smoke" hidden="false" targetId="bcf4-1bd8-9794-feaa" primary="false"/>
+        <categoryLink id="8064-2bf9-14ce-eae8" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+        <categoryLink id="5dd7-774e-4dad-9bc7" name="Squadron" hidden="false" targetId="eba3-3a9f-b907-d83a" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="39cb-3f5c-f735-602e" name="Storm Eagle Rockets" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -11592,11 +11494,11 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
             <profile id="ff1e-d4ee-4507-8988" name="Storm Eagle Rockets" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">120&quot;</characteristic>
-                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 2D6</characteristic>
-                <characteristic name="S" typeId="59b1-319e-ec13-d466">10</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D6+3</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">9</characteristic>
                 <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
-                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
-                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. This weapon can target units that are not visible to the bearer.  A model can only fire a single storm eagle rocket per turn.  Each storm eagle rocket can only be fired once per battle.</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">3</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. This weapon can target units that are not visible to the bearer.  The bearer can only shoot with this weapon 4 times per battle.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -11647,15 +11549,13 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3958-fe21-bcdf-b5b0" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="9ef5-6c06-693c-5560" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
         <entryLink id="d84f-a45c-36b1-a44b" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
-        <entryLink id="8d76-562a-17ec-8f8b" name="Unit has battle honors?" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="61fd-d9b5-f43a-14cf" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
-        <entryLink id="9c5d-04e3-d6af-a327" name="Tank Aces" hidden="false" collective="false" import="true" targetId="998b-b53a-603f-6c5b" type="selectionEntryGroup"/>
+        <entryLink id="8d76-562a-17ec-8f8b" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="61fd-d9b5-f43a-14cf" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="155.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="9.0"/>
+        <cost name="pts" typeId="points" value="140.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="7.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -14114,106 +14014,6 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="9d2d-88a5-7ca6-e582" name="Special Weapons Squad" publicationId="53e9d88f--pubN88319" page="0" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="append" field="name" value="[Legends]">
-          <conditions>
-            <condition field="selections" scope="self" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="48f2-4072-269a-b60e" type="atLeast"/>
-          </conditions>
-        </modifier>
-      </modifiers>
-      <infoLinks>
-        <infoLink id="acde-a2eb-1ef3-950e" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
-      </infoLinks>
-      <categoryLinks>
-        <categoryLink id="6003-16d2-5f5f-3a75" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
-        <categoryLink id="efce-c269-a02b-abae" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
-        <categoryLink id="f3e4-eb48-bc88-f2c0" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
-        <categoryLink id="921f-b2cb-874c-a54b" name="Special Weapons Squad" hidden="false" targetId="4d2f-f735-2949-2b0a" primary="false"/>
-        <categoryLink id="cc10-7814-9782-e5ad" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="6c20-9e6b-276e-4331" name="Guardsman" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9ca4-4f65-f24a-eeea" type="max"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0b02-0742-51eb-98dc" type="min"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="40d7-11cc-3989-b884" name="Guardsman" hidden="false" targetId="3635-257d-26f1-26e8" type="profile"/>
-          </infoLinks>
-          <entryLinks>
-            <entryLink id="b913-767e-5485-055e" name="Lasgun" hidden="false" collective="false" import="true" targetId="7236-b28a-2b6e-ded7" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4cad-6e1b-6382-2d7c" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c550-0957-791a-5df4" type="min"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="c4a0-a029-6730-5a73" name="Guardsman W/ Special Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b418-178a-3fc9-77ed" type="max"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d915-bdff-2167-056c" type="min"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="3515-23de-4afb-5d4e" name="Guardsman" hidden="false" targetId="3635-257d-26f1-26e8" type="profile"/>
-          </infoLinks>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="b146-b3e4-d76f-0b7a" name="Special Weapon" hidden="false" collective="false" import="true">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="80f7-087d-7817-a9f9" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="562b-bbc1-0920-7fe7" type="min"/>
-              </constraints>
-              <selectionEntries>
-                <selectionEntry id="48f2-4072-269a-b60e" name="Demolition Charge and Lasgun" hidden="false" collective="false" import="true" type="upgrade">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6376-caa8-bd50-7442" type="max"/>
-                  </constraints>
-                  <profiles>
-                    <profile id="fc1b-5ca8-737d-41ac" name="Demolition Charge" publicationId="53e9d88f--pubN88319" page="0" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-                      <characteristics>
-                        <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">6</characteristic>
-                        <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Grenade D6</characteristic>
-                        <characteristic name="S" typeId="59b1-319e-ec13-d466">8</characteristic>
-                        <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
-                        <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
-                        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. One use only.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
-                  <infoLinks>
-                    <infoLink id="22c8-30a3-3ba1-13f9" name="Lasgun" hidden="false" targetId="d174-eb55-aaa6-d032" type="profile"/>
-                  </infoLinks>
-                  <costs>
-                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                    <cost name="pts" typeId="points" value="0.0"/>
-                  </costs>
-                </selectionEntry>
-              </selectionEntries>
-              <entryLinks>
-                <entryLink id="c902-4840-3b20-0d42" name="Astra Militarum Special Weapons" hidden="false" collective="false" import="true" targetId="a465-d3f9-68f9-2e55" type="selectionEntryGroup"/>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="2.0"/>
-        <cost name="pts" typeId="points" value="45.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="8e95-af10-b229-cd6d" name="Stormlord" page="0" hidden="false" collective="false" import="true" type="model">
       <profiles>
         <profile id="7ccf-c1b1-9a42-7ec9" name="Transport: Stormlord" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
@@ -14733,93 +14533,6 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="1.0"/>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="8cc0-1f53-200b-9c7f" name="Wyverns" publicationId="53e9d88f--pubN88319" page="51" hidden="false" collective="false" import="true" type="unit">
-      <infoLinks>
-        <infoLink id="64bd-11bb-35be-4072" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
-        <infoLink id="436f-7284-f105-d3bf" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
-        <infoLink id="6cbf-48f9-8939-849d" name="Smoke Launchers" hidden="false" targetId="c883-3078-1367-cc2c" type="profile"/>
-      </infoLinks>
-      <categoryLinks>
-        <categoryLink id="9b72-0671-439e-21b3" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
-        <categoryLink id="4c6b-c7a9-fd37-29d0" name="Wyvern" hidden="false" targetId="e12a-0a79-a7e7-3640" primary="false"/>
-        <categoryLink id="7de2-883c-78eb-9565" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="504f-3851-1ad0-8b9c" name="Wyvern" page="0" hidden="false" collective="false" import="true" type="model">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6547-faad-2a7f-3159" type="min"/>
-            <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9ce9-fe51-7036-c88e" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="9706-b830-1b7b-6116" name="Wyvern" publicationId="53e9d88f--pubN88319" page="51" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
-              <characteristics>
-                <characteristic name="M" typeId="0bdf-a96e-9e38-7779">*</characteristic>
-                <characteristic name="WS" typeId="e7f0-1278-0250-df0c">6+</characteristic>
-                <characteristic name="BS" typeId="381b-eb28-74c3-df5f">*</characteristic>
-                <characteristic name="S" typeId="2218-aa3c-265f-2939">6</characteristic>
-                <characteristic name="T" typeId="9c9f-9774-a358-3a39">6</characteristic>
-                <characteristic name="W" typeId="f330-5e6e-4110-0978">11</characteristic>
-                <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">*</characteristic>
-                <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
-                <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <infoLinks>
-            <infoLink id="5651-89ed-f654-093e" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
-          </infoLinks>
-          <selectionEntries>
-            <selectionEntry id="7e05-704e-7b5e-8677" name="Wyvern Quad Stormshard Mortar" page="0" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fad4-4dcf-bfe7-a7a7" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="332e-65ee-52a7-06db" type="max"/>
-              </constraints>
-              <profiles>
-                <profile id="5e05-4c44-bd87-1e08" name="Wyvern Quad Stormshard Mortar" publicationId="53e9d88f--pubN88319" page="51" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-                  <characteristics>
-                    <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">48&quot;</characteristic>
-                    <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 4D6</characteristic>
-                    <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
-                    <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
-                    <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
-                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. This weapon can target units not visible to the bearer.  You can re-roll failed wound rolls for this weapon.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <costs>
-                <cost name="pts" typeId="points" value="0.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="8c8f-23e7-bed3-24a0" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
-            <entryLink id="c03b-8fa0-2136-cce8" name="Hull Weapon" hidden="false" collective="false" import="true" targetId="846f-095f-3967-92af" type="selectionEntryGroup"/>
-            <entryLink id="d9c3-e128-b267-ca0e" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
-            <entryLink id="d0bf-64ea-43e7-d6eb" name="Tank Aces" hidden="false" collective="false" import="true" targetId="998b-b53a-603f-6c5b" type="selectionEntryGroup"/>
-          </entryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="135.0"/>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="8.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <entryLinks>
-        <entryLink id="911d-ced7-c270-d7e5" name="Stat Damage (HS)" hidden="false" collective="false" import="true" targetId="da25-46a9-4472-2e07" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1ac-5e59-eb1b-1353" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7be-e0f5-04dc-12eb" type="min"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -17151,6 +16864,524 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="95b5-ba43-04f7-91fa" name="Rogal Dorn Battle Tank" hidden="false" collective="false" import="true" type="model">
+      <profiles>
+        <profile id="e828-bc4d-2b30-0a9d" name="Rogal Dorn Battle Tank [1] (9+ wounds remaining)" publicationId="e831-8627-fbc7-5b35" page="103" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="0bdf-a96e-9e38-7779">10&quot;</characteristic>
+            <characteristic name="WS" typeId="e7f0-1278-0250-df0c">6+</characteristic>
+            <characteristic name="BS" typeId="381b-eb28-74c3-df5f">4+</characteristic>
+            <characteristic name="S" typeId="2218-aa3c-265f-2939">8</characteristic>
+            <characteristic name="T" typeId="9c9f-9774-a358-3a39">9</characteristic>
+            <characteristic name="W" typeId="f330-5e6e-4110-0978">N/A</characteristic>
+            <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">6</characteristic>
+            <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">8</characteristic>
+            <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">2+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="19d0-659a-bc0e-e1fd" name="Rogal Dorn Battle Tank [2] (5-8 wounds remaining)" publicationId="e831-8627-fbc7-5b35" page="103" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="0bdf-a96e-9e38-7779">8&quot;</characteristic>
+            <characteristic name="WS" typeId="e7f0-1278-0250-df0c">6+</characteristic>
+            <characteristic name="BS" typeId="381b-eb28-74c3-df5f">5+</characteristic>
+            <characteristic name="S" typeId="2218-aa3c-265f-2939">8</characteristic>
+            <characteristic name="T" typeId="9c9f-9774-a358-3a39">9</characteristic>
+            <characteristic name="W" typeId="f330-5e6e-4110-0978">N/A</characteristic>
+            <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">D6</characteristic>
+            <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">8</characteristic>
+            <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">2+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="48e6-b38f-5eb2-c0cc" name="Rogal Dorn Battle Tank [3] (1-4 wounds remaining)" publicationId="e831-8627-fbc7-5b35" page="103" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+            <characteristic name="WS" typeId="e7f0-1278-0250-df0c">6+</characteristic>
+            <characteristic name="BS" typeId="381b-eb28-74c3-df5f">6+</characteristic>
+            <characteristic name="S" typeId="2218-aa3c-265f-2939">8</characteristic>
+            <characteristic name="T" typeId="9c9f-9774-a358-3a39">9</characteristic>
+            <characteristic name="W" typeId="f330-5e6e-4110-0978">N/A</characteristic>
+            <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">D3</characteristic>
+            <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">8</characteristic>
+            <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">2+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="9951-8504-4c92-09f4" name="Explodes (6+/6&quot;/D6)" hidden="false" targetId="7525-aa8c-bea2-9691" type="profile"/>
+        <infoLink id="b05c-b12f-7578-9579" name="Heavy stubber" hidden="false" targetId="0031-0314-5b36-a220" type="profile"/>
+        <infoLink id="61dd-e723-bd4c-d490" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="8363-d9d5-78fd-6eb6" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
+        <categoryLink id="780a-7013-363a-5a47" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
+        <categoryLink id="bdd1-8244-93b3-0970" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="f5dd-14e8-059f-7de9" name="Battle Tank" hidden="false" targetId="ae9d-34d2-e8f7-62df" primary="false"/>
+        <categoryLink id="ed6c-e82a-a3ee-f691" name="Smoke" hidden="false" targetId="bcf4-1bd8-9794-feaa" primary="false"/>
+        <categoryLink id="5577-f65c-8c55-6427" name="Rogal Dorn Battle Tank" hidden="false" targetId="6838-e734-295c-7de5" primary="false"/>
+        <categoryLink id="89d0-9a1d-a330-f1f9" name="Squadron" hidden="false" targetId="eba3-3a9f-b907-d83a" primary="false"/>
+        <categoryLink id="c046-da60-e884-addd" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="33e8-0758-b136-1229" name="Turret Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="f08f-de79-a950-5bcb">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e42-cbb2-0c86-f342" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c79-8e48-41d7-c612" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="f08f-de79-a950-5bcb" name="Twin Battle Cannon" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="points" value="0.0"/>
+              </modifiers>
+              <profiles>
+                <profile id="374d-6694-d127-2878" name="Twin Battle Cannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">72&quot;</characteristic>
+                    <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 2D6</characteristic>
+                    <characteristic name="S" typeId="59b1-319e-ec13-d466">8</characteristic>
+                    <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
+                    <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">3</characteristic>
+                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. Turret Weapon (pg 75).</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name="pts" typeId="points" value="30.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="67dd-406b-1dcb-cf45" name="Oppressor Cannon and Co-Axial Autocannon" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="points" value="0.0"/>
+              </modifiers>
+              <profiles>
+                <profile id="6293-c409-28f3-303f" name="Oppressor Cannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">90&quot;</characteristic>
+                    <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D6+3</characteristic>
+                    <characteristic name="S" typeId="59b1-319e-ec13-d466">10</characteristic>
+                    <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
+                    <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">4</characteristic>
+                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. Turret Weapon (pg 75)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="7a5c-c997-ed47-d3ee" name="Co-axial Autocannon" hidden="false" targetId="90d5-721a-d654-2783" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name="pts" typeId="points" value="30.0"/>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="65ac-ce3c-a580-a0b1" name="Hull-Mounted Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="ca47-a699-3ad6-80c4">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c946-07a1-a3e2-99ad" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="776a-7372-4ee1-887b" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="ca47-a699-3ad6-80c4" name="Castigator Gatling Cannon" publicationId="e831-8627-fbc7-5b35" page="103" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="62e7-b2cc-98ce-4118" name="Castigator Gatling Cannon" publicationId="7573-8d1b-acdf-2de8" page="58" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+                    <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 12</characteristic>
+                    <characteristic name="S" typeId="59b1-319e-ec13-d466">5</characteristic>
+                    <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
+                    <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="dece-e02e-8699-e4aa" name="Pulveriser Cannon" publicationId="7573-8d1b-acdf-2de8" page="103" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="cd35-127e-5309-eeef" name="Pulveriser Cannon" publicationId="7573-8d1b-acdf-2de8" page="58" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+                    <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D6</characteristic>
+                    <characteristic name="S" typeId="59b1-319e-ec13-d466">8</characteristic>
+                    <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
+                    <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">3</characteristic>
+                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="a59c-db2b-d684-dd38" name="Additional Hull-Mounted Weapons" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9068-2bd3-3780-5879" type="max"/>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4c17-28c8-1f9e-7c8e" type="min"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="9de4-3c4a-af79-3fb9" name="2 Additional Heavy Stubbers" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="df8b-2fde-c9ea-f85c" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="0db5-7c3c-1c53-461b" name="Heavy stubber" hidden="false" collective="false" import="true" targetId="cfa3-5fcd-af10-5520" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c7a-ec32-7add-9409" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9721-b759-d7a1-80f4" type="min"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b058-48ee-0682-ca45" name="2 Meltaguns" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7282-c66b-d1d5-2b51" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="9bcb-ec19-02f3-0880" name="Meltagun" hidden="false" collective="false" import="true" targetId="efc8-c51d-5b02-a3a2" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c88-637d-7199-39f7" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a74-022e-bd84-6436" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="216a-e5af-946c-2012" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="24cf-270a-e02b-bfe9" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="f020-98eb-67cd-c92e" name="Rogal Dorn Sponson Weapons" hidden="false" collective="false" import="true" targetId="2358-1348-7c6b-bb88" type="selectionEntryGroup"/>
+        <entryLink id="7008-1b81-5929-6b70" name="Rogal Dorn Equipment List" hidden="false" collective="false" import="true" targetId="e5ea-94cb-40bf-722b" type="selectionEntryGroup"/>
+        <entryLink id="ff72-8116-51d8-4a23" name="Tank Aces (Battle Tank)" hidden="false" collective="false" import="true" targetId="d8ad-1ab9-059c-9325" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="250.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="14.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7e79-96d0-b25b-e3ed" name="Field Ordnance Battery" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="a2b0-ca78-a533-76c2" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="2410-00d7-7f1f-fc4c" name="Artillery" hidden="false" targetId="ae37-74e2-8391-d0f8" primary="false"/>
+        <categoryLink id="dceb-ea05-f9a8-b114" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="e92d-1c77-aded-cba1" name="Platoon" hidden="false" targetId="717a-8f8b-caee-189d" primary="false"/>
+        <categoryLink id="e16d-0864-3a4a-1ef2" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+        <categoryLink id="901c-425b-d458-ba01" name="Field Ordnance Battery" hidden="false" targetId="60d7-cb82-ac4f-fb9b" primary="false"/>
+      </categoryLinks>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="eb67-5b01-f7a6-0df6" name="Ordnance Team" hidden="false" collective="false" import="true" defaultSelectionEntryId="f23d-651f-1b4c-0872">
+          <constraints>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0345-2a91-b0f1-3b16" type="min"/>
+            <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f036-6336-922b-2ede" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="b712-9bc8-16bb-f40b" name="Bombast Field Gun" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="ce06-0934-d3da-d74f" name="Ordnance Team" publicationId="e831-8627-fbc7-5b35" page="104" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+                  <characteristics>
+                    <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                    <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
+                    <characteristic name="BS" typeId="381b-eb28-74c3-df5f">4+</characteristic>
+                    <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                    <characteristic name="T" typeId="9c9f-9774-a358-3a39">4</characteristic>
+                    <characteristic name="W" typeId="f330-5e6e-4110-0978">6</characteristic>
+                    <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">3</characteristic>
+                    <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">6</characteristic>
+                    <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">4+</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="f052-bcd6-7668-8604" name="Bombast Field Gun" publicationId="e831-8627-fbc7-5b35" page="104" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">48&quot;</characteristic>
+                    <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D6</characteristic>
+                    <characteristic name="S" typeId="59b1-319e-ec13-d466">7</characteristic>
+                    <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
+                    <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
+                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. This weapon can target units that are not visible to the bearer.</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <entryLinks>
+                <entryLink id="f19b-ab38-0cc9-d861" name="Lasgun" hidden="false" collective="false" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a0d-61f6-e1ca-8839" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4c4-31a0-5535-f5f9" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6a22-7fb0-ca35-62f0" name="Heavy Lascannon" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="3b13-47aa-6727-1358" name="Heavy Lascannon" publicationId="e831-8627-fbc7-5b35" page="104" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">48&quot;</characteristic>
+                    <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 2</characteristic>
+                    <characteristic name="S" typeId="59b1-319e-ec13-d466">10</characteristic>
+                    <characteristic name="AP" typeId="75aa-a838-b675-6484">-4</characteristic>
+                    <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3+3</characteristic>
+                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="3046-bcd1-0bfb-92e3" name="Ordnance Team" publicationId="e831-8627-fbc7-5b35" page="104" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+                  <characteristics>
+                    <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                    <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
+                    <characteristic name="BS" typeId="381b-eb28-74c3-df5f">4+</characteristic>
+                    <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                    <characteristic name="T" typeId="9c9f-9774-a358-3a39">4</characteristic>
+                    <characteristic name="W" typeId="f330-5e6e-4110-0978">6</characteristic>
+                    <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">3</characteristic>
+                    <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">6</characteristic>
+                    <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">4+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <entryLinks>
+                <entryLink id="c3c2-4632-9244-57c0" name="Lasgun" hidden="false" collective="false" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b262-1d26-e654-201b" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f462-4d67-b89b-6a72" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f23d-651f-1b4c-0872" name="Malleus Rocket Launcher" hidden="false" collective="false" import="true" type="upgrade">
+              <profiles>
+                <profile id="f287-de41-5cbb-1a16" name="Malleus Rocket Launcher" publicationId="e831-8627-fbc7-5b35" page="104" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">48&quot;</characteristic>
+                    <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D6+6</characteristic>
+                    <characteristic name="S" typeId="59b1-319e-ec13-d466">6</characteristic>
+                    <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
+                    <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast.</characteristic>
+                  </characteristics>
+                </profile>
+                <profile id="00f0-d2ff-aa2c-b791" name="Ordnance Team" publicationId="e831-8627-fbc7-5b35" page="104" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+                  <characteristics>
+                    <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                    <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
+                    <characteristic name="BS" typeId="381b-eb28-74c3-df5f">4+</characteristic>
+                    <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                    <characteristic name="T" typeId="9c9f-9774-a358-3a39">4</characteristic>
+                    <characteristic name="W" typeId="f330-5e6e-4110-0978">6</characteristic>
+                    <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">3</characteristic>
+                    <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">6</characteristic>
+                    <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">4+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <entryLinks>
+                <entryLink id="0ea7-41b2-7b60-ab67" name="Lasgun" hidden="false" collective="false" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3429-8d2a-9a5d-29fa" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d2b-1fb0-a551-fe13" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+          <entryLinks>
+            <entryLink id="6c1f-4c12-63d5-af76" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+            <entryLink id="8b44-2ffe-5e55-4220" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
+        <cost name="pts" typeId="points" value="130.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="411a-f57a-9f2b-b9df" name="Hydra" page="0" hidden="false" collective="false" import="true" type="model">
+      <profiles>
+        <profile id="27fa-1133-a681-859c" name="Hydra" publicationId="53e9d88f--pubN88319" page="49" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="0bdf-a96e-9e38-7779">*</characteristic>
+            <characteristic name="WS" typeId="e7f0-1278-0250-df0c">6+</characteristic>
+            <characteristic name="BS" typeId="381b-eb28-74c3-df5f">*</characteristic>
+            <characteristic name="S" typeId="2218-aa3c-265f-2939">6</characteristic>
+            <characteristic name="T" typeId="9c9f-9774-a358-3a39">7</characteristic>
+            <characteristic name="W" typeId="f330-5e6e-4110-0978">11</characteristic>
+            <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">*</characteristic>
+            <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
+            <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="f2d5-3b56-da4b-3008" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
+        <infoLink id="6977-79dd-7ced-b4ce" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
+        <infoLink id="0cd3-5fe3-c424-0949" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="9dcd-5f81-46ac-f1da" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
+        <categoryLink id="8797-f434-7f6a-7a7d" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="64ab-fa96-4beb-f3bf" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
+        <categoryLink id="2543-aebc-07a7-af0e" name="Smoke" hidden="false" targetId="bcf4-1bd8-9794-feaa" primary="false"/>
+        <categoryLink id="c925-c01f-1200-faba" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+        <categoryLink id="577a-d103-0beb-1397" name="Squadron" hidden="false" targetId="eba3-3a9f-b907-d83a" primary="false"/>
+        <categoryLink id="0827-5464-168c-02c4" name="Hydra" hidden="false" targetId="1d43-1f70-0642-964f" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="827a-bad1-8186-6027" name="Hydra Quad Autocannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6ba4-0c14-09e5-82ad" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3921-17a7-55f4-094e" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="58bd-6559-301c-4c9f" name="Hydra Quad Autocannon" publicationId="e831-8627-fbc7-5b35" page="107" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">72&quot;</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 8</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">7</characteristic>
+                <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Turret Weapon, Each time an attack is made with this weapon against an AIRCRAFT unit, make 2 hit rolls instead of 1 and add 1 to both hit rolls.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="936f-d23e-532a-efae" name="Hull Weapon" hidden="false" collective="false" import="true" targetId="846f-095f-3967-92af" type="selectionEntryGroup"/>
+        <entryLink id="e773-e908-a8a4-92c2" name="Stat Damage (HS)" hidden="false" collective="false" import="true" targetId="da25-46a9-4472-2e07" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="339d-550c-5464-5c70" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98a9-0285-4358-9ab0" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="4ccb-ebdb-7e74-100a" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
+        <entryLink id="d160-e37d-9a00-43ac" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="f0a1-8d98-eea1-f4b6" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="110.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="aa0e-0155-aed7-0679" name="Wyvern" page="0" hidden="false" collective="false" import="true" type="model">
+      <profiles>
+        <profile id="59e3-66c1-a79c-7118" name="Wyvern" publicationId="53e9d88f--pubN88319" page="51" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="0bdf-a96e-9e38-7779">*</characteristic>
+            <characteristic name="WS" typeId="e7f0-1278-0250-df0c">6+</characteristic>
+            <characteristic name="BS" typeId="381b-eb28-74c3-df5f">*</characteristic>
+            <characteristic name="S" typeId="2218-aa3c-265f-2939">6</characteristic>
+            <characteristic name="T" typeId="9c9f-9774-a358-3a39">6</characteristic>
+            <characteristic name="W" typeId="f330-5e6e-4110-0978">11</characteristic>
+            <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">*</characteristic>
+            <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
+            <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="24ef-c115-0701-4727" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
+        <infoLink id="fc80-8d72-7fd2-8d0c" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
+        <infoLink id="c026-d9ae-b06d-9973" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="837c-d9b6-12a5-71c0" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
+        <categoryLink id="9658-8d92-da6f-3e65" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="a30f-2eca-d801-b81f" name="Smoke" hidden="false" targetId="bcf4-1bd8-9794-feaa" primary="false"/>
+        <categoryLink id="0f6f-9ec7-1331-455a" name="Artillery" hidden="false" targetId="ae37-74e2-8391-d0f8" primary="false"/>
+        <categoryLink id="bf62-3f54-55a3-0772" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+        <categoryLink id="b44a-8f24-b787-b849" name="Squadron" hidden="false" targetId="eba3-3a9f-b907-d83a" primary="false"/>
+        <categoryLink id="72ab-e6e5-08cf-1323" name="Wyvern" hidden="false" targetId="e12a-0a79-a7e7-3640" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="54dd-0b52-5fb7-339e" name="Wyvern Quad Stormshard Mortar" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="13b7-fe23-75b4-a63f" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9be4-7f42-4d98-8d1a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d5ae-9ce2-0d44-29f6" name="Wyvern Quad Stormshard Mortar" publicationId="53e9d88f--pubN88319" page="51" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">48&quot;</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 4D6</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">5</characteristic>
+                <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. This weapon can target units not visible to the bearer.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="4f00-d04e-cad8-4ccf" name="Hull Weapon" hidden="false" collective="false" import="true" targetId="846f-095f-3967-92af" type="selectionEntryGroup"/>
+        <entryLink id="44c2-1e1d-7908-db65" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
+        <entryLink id="c70e-3251-c092-fef2" name="Stat Damage (HS)" hidden="false" collective="false" import="true" targetId="da25-46a9-4472-2e07" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e89f-4da8-b1fa-504d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1abf-763d-a017-6636" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="120.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="9ef3-0f17-2aeb-436e" name="Astra Militarum Ranged Weapons" hidden="false" collective="false" import="true">
@@ -17260,14 +17491,14 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="29c3-5475-96d1-6a44" name="Astra Militarum Heavy Weapons" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="29c3-5475-96d1-6a44" name="Astra Militarum Heavy Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="40ae-6101-8b54-4a7a">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1208-9ef3-e37a-a81e" type="max"/>
       </constraints>
       <selectionEntries>
         <selectionEntry id="d09c-c188-009a-e711" name="Mortar" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
-            <modifier type="set" field="points" value="10.0">
+            <modifier type="set" field="points" value="0.0">
               <conditions>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3b7d-927b-8856-e8b7" type="instanceOf"/>
               </conditions>
@@ -17298,7 +17529,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
       <entryLinks>
         <entryLink id="4a1a-85bf-8226-22b8" name="Lascannon" hidden="false" collective="false" import="true" targetId="a908-4664-11cd-f8b2" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="15.0">
+            <modifier type="set" field="points" value="0.0">
               <conditions>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3b7d-927b-8856-e8b7" type="instanceOf"/>
               </conditions>
@@ -17310,7 +17541,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         </entryLink>
         <entryLink id="bec4-f1b7-24f7-4c26" name="Missile launcher" hidden="false" collective="false" import="true" targetId="1469-1964-7a91-94d4" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="15.0">
+            <modifier type="set" field="points" value="0.0">
               <conditions>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3b7d-927b-8856-e8b7" type="instanceOf"/>
               </conditions>
@@ -17322,7 +17553,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         </entryLink>
         <entryLink id="40ae-6101-8b54-4a7a" name="Heavy bolter" hidden="false" collective="false" import="true" targetId="05ab-e7cc-e856-c36f" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="10.0">
+            <modifier type="set" field="points" value="0.0">
               <conditions>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3b7d-927b-8856-e8b7" type="instanceOf"/>
               </conditions>
@@ -17334,7 +17565,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         </entryLink>
         <entryLink id="510d-6c49-cae7-cc8c" name="Autocannon" hidden="false" collective="false" import="true" targetId="5210-8cb2-b5a2-a04f" type="selectionEntry">
           <modifiers>
-            <modifier type="set" field="points" value="10.0">
+            <modifier type="set" field="points" value="0.0">
               <conditions>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3b7d-927b-8856-e8b7" type="instanceOf"/>
               </conditions>
@@ -17565,7 +17796,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
           </infoLinks>
           <costs>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" typeId="points" value="3.0"/>
+            <cost name="pts" typeId="points" value="5.0"/>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
@@ -17666,39 +17897,11 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         </selectionEntry>
       </selectionEntries>
     </selectionEntryGroup>
-    <selectionEntryGroup id="2358-1348-7c6b-bb88" name="Sponson Weapons" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="2358-1348-7c6b-bb88" name="Rogal Dorn Sponson Weapons" hidden="false" collective="false" import="true">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4837-ab83-9028-1417" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="0161-5957-f75f-0d37" name="2 Lascannons [Legends]" page="0" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4b7b-8f42-fa44-0ea8" type="max"/>
-          </constraints>
-          <costs>
-            <cost name="pts" typeId="points" value="10.0"/>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="53ec-340f-70ca-9338" name="2 Heavy Flamers" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e569-7aa9-670b-7980" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="a6af-19b4-f171-1e53" name="Heavy flamer" hidden="false" collective="false" import="true" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7f23-c9cb-f6ba-fb3a" type="min"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e527-8023-cdd3-febe" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="30.0"/>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-          </costs>
-        </selectionEntry>
         <selectionEntry id="f976-71b6-2a93-778f" name="2 Multi-meltas" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6fd8-7abd-06fc-c702" type="max"/>
@@ -17709,30 +17912,15 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="71bb-73c1-d19a-60b8" type="min"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="adfc-6087-a261-839a" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="15.0"/>
+              </costs>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="50.0"/>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="f418-79f6-bf5b-dd37" name="2 Plasma Cannons" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="04be-2da6-a9cc-2aa7" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="c9cb-51a1-aa13-cbf8" name="Plasma cannon" hidden="false" collective="false" import="true" targetId="eb15-db61-5d4f-b65e" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="753e-8e5b-1064-acb8" type="min"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1348-dc15-09af-64ff" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name="pts" typeId="points" value="40.0"/>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="4617-87fc-e1a0-0919" name="2 Heavy Bolters" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -17745,12 +17933,15 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88dc-e92e-b429-5551" type="min"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad0d-db11-a6c1-05f9" type="max"/>
               </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
             </entryLink>
           </entryLinks>
           <costs>
-            <cost name="pts" typeId="points" value="30.0"/>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -18370,7 +18561,6 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4fdd-f6f2-4f85-fcd9" type="equalTo"/>
                         <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3984-854b-4603-be64" type="notInstanceOf"/>
                       </conditions>
                     </conditionGroup>
@@ -18384,7 +18574,6 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3931-794a-b0a8-4299" type="equalTo"/>
                         <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3984-854b-4603-be64" type="notInstanceOf"/>
                       </conditions>
                     </conditionGroup>
@@ -18398,7 +18587,6 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2ed5-9369-adca-05fd" type="equalTo"/>
                         <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3984-854b-4603-be64" type="notInstanceOf"/>
                       </conditions>
                     </conditionGroup>
@@ -18412,7 +18600,6 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e7d3-614e-cf26-f161" type="equalTo"/>
                         <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3984-854b-4603-be64" type="notInstanceOf"/>
                       </conditions>
                     </conditionGroup>
@@ -18426,7 +18613,6 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c180-9110-58a1-51dc" type="equalTo"/>
                         <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3984-854b-4603-be64" type="notInstanceOf"/>
                       </conditions>
                     </conditionGroup>
@@ -18440,7 +18626,6 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="05d3-4163-cfb9-5288" type="equalTo"/>
                         <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3984-854b-4603-be64" type="notInstanceOf"/>
                       </conditions>
                     </conditionGroup>
@@ -18524,12 +18709,12 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="3102-3cfb-ca48-1bea" name="Vanquisher Battle Cannon" hidden="false" collective="false" import="true" targetId="5901-34d7-fb83-0e4a" type="selectionEntry"/>
+        <entryLink id="3102-3cfb-ca48-1bea" name="Turret-mounted Vanquisher Battle Cannon" hidden="false" collective="false" import="true" targetId="5901-34d7-fb83-0e4a" type="selectionEntry"/>
         <entryLink id="0f8f-4aeb-a9a5-263d" name="Turret-mounted Punisher Gatling Cannon" hidden="false" collective="false" import="true" targetId="7205-1c2b-23e2-5c6b" type="selectionEntry"/>
-        <entryLink id="61ef-a8cb-fe23-c1ed" name="Exterminator Autocannon" hidden="false" collective="false" import="true" targetId="7bb3-24e8-431d-6bca" type="selectionEntry"/>
+        <entryLink id="61ef-a8cb-fe23-c1ed" name="Turret-mounted Exterminator Autocannon" hidden="false" collective="false" import="true" targetId="7bb3-24e8-431d-6bca" type="selectionEntry"/>
         <entryLink id="c12b-3f58-a9b3-bc1b" name="Turret-mounted Executioner Plasma Cannon" hidden="false" collective="false" import="true" targetId="3a4b-c307-894e-3e63" type="selectionEntry"/>
         <entryLink id="c657-e6a9-1217-f746" name="Turret-mounted Eradicator Nova Cannon" hidden="false" collective="false" import="true" targetId="f342-97f0-feb4-882c" type="selectionEntry"/>
-        <entryLink id="1e0e-aae7-3358-a27b" name="Turret-mounted Demolisher Siege Cannon" hidden="false" collective="false" import="true" targetId="7def-3d84-3d31-afba" type="selectionEntry"/>
+        <entryLink id="1e0e-aae7-3358-a27b" name="Turret-mounted Demolisher Battle Cannon" hidden="false" collective="false" import="true" targetId="7def-3d84-3d31-afba" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="1f55-4ee0-5c0e-5b35" name="Regimental Doctrines" hidden="false" collective="false" import="true">
@@ -18866,7 +19051,7 @@ attack is considered to have been made with an unmodified wound roll of 6.</char
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
-            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2fcb-22c9-d86a-96e3" type="notInstanceOf"/>
+            <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ae9d-34d2-e8f7-62df" type="notInstanceOf"/>
           </conditions>
         </modifier>
       </modifiers>
@@ -18876,7 +19061,7 @@ attack is considered to have been made with an unmodified wound roll of 6.</char
       <selectionEntries>
         <selectionEntry id="795a-7a5e-f7b3-d635" name="Veteran Commandeer" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ef2-b3f6-07f3-e3a5" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0ef2-b3f6-07f3-e3a5" type="max"/>
           </constraints>
           <profiles>
             <profile id="58ea-f5c7-8796-f4ff" name="Veteran Commandeer" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -18893,7 +19078,7 @@ attack is considered to have been made with an unmodified wound roll of 6.</char
         </selectionEntry>
         <selectionEntry id="498e-d29a-1cf4-28bd" name="Master of Camouflage" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d28-f444-6473-49d0" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="8d28-f444-6473-49d0" type="max"/>
           </constraints>
           <profiles>
             <profile id="96f2-eeb3-4a6d-ad41" name="Master of Camouflage" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -18910,7 +19095,7 @@ attack is considered to have been made with an unmodified wound roll of 6.</char
         </selectionEntry>
         <selectionEntry id="548e-fc71-9a67-9226" name="Vaunted Praetorian" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c9bd-6337-2ee4-da9f" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c9bd-6337-2ee4-da9f" type="max"/>
           </constraints>
           <profiles>
             <profile id="dfc9-26fe-2f96-0cc5" name="Vaunted Praetorian" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -18927,7 +19112,7 @@ attack is considered to have been made with an unmodified wound roll of 6.</char
         </selectionEntry>
         <selectionEntry id="d766-6efb-cb6d-8f70" name="Steel Commissar" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ef9f-bef9-a880-db5b" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="ef9f-bef9-a880-db5b" type="max"/>
           </constraints>
           <profiles>
             <profile id="1295-2395-9e5e-4375" name="Steel Commissar" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -18944,7 +19129,7 @@ attack is considered to have been made with an unmodified wound roll of 6.</char
         </selectionEntry>
         <selectionEntry id="7fab-d14b-0e07-3870" name="Mechanical Pack Rat" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b54-2fb6-2ae4-0a87" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="9b54-2fb6-2ae4-0a87" type="max"/>
           </constraints>
           <profiles>
             <profile id="de82-41b8-076b-9317" name="Mechanical Pack Rat" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -18961,7 +19146,7 @@ attack is considered to have been made with an unmodified wound roll of 6.</char
         </selectionEntry>
         <selectionEntry id="2dfa-7dc0-cb38-c6d8" name="Meticulous Calibrator" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc91-6b95-b0c9-5017" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="dc91-6b95-b0c9-5017" type="max"/>
           </constraints>
           <profiles>
             <profile id="9ec7-bf7b-19dc-9f80" name="Meticulous Calibrator" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -18979,7 +19164,7 @@ receive the benefits of cover against that attack.&quot;</characteristic>
         </selectionEntry>
         <selectionEntry id="f616-744b-b223-102f" name="Knight of Piety" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bfa-1048-6ac2-4970" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1bfa-1048-6ac2-4970" type="max"/>
           </constraints>
           <profiles>
             <profile id="0a93-cbc8-dadb-3c74" name="Knight of Piety" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -18994,133 +19179,6 @@ mortal wound, roll one D6: on a 5+, that wound is not lost.&quot;</characteristi
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
             <cost name="pts" typeId="points" value="25.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-    </selectionEntryGroup>
-    <selectionEntryGroup id="ab32-8146-6b3d-3ca7" name="Tempestus Regiment" hidden="false" collective="false" import="true">
-      <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ff4-3a99-305d-1d7e" type="max"/>
-      </constraints>
-      <selectionEntries>
-        <selectionEntry id="4fdd-f6f2-4f85-fcd9" name="54th Psian Jackals" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d59e-0c3b-41c9-68f8" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="0e9d-0f40-59c9-0a35" name="54th Psian Jackals" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“Each model destroyed by an attack made by a model with this doctrine in your Shooting phase is treated as 2 destroyed models in the following Morale phase</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="2ed5-9369-adca-05fd" name="32nd Thetoid Eagles" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="755e-c8b3-d70f-e119" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="674f-a7d6-ec2e-4120" name="32nd Thetoid Eagles" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“When resolving an attack made with a ranged weapon by a model with this doctrine against a unit that is within half range, an unmodified hit roll of 6 scores 1 additional hit.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="c180-9110-58a1-51dc" name="133rd Lambdan Lions" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c46-2686-9a79-c46f" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="354d-294f-0f8b-abd0" name="133rd Lambdan Lions" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“Improve the Armour Penetration characteristic of weapons models with this doctrine are equipped with by 1 (e.g. AP 0 becomes AP -1).”</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="05d3-4163-cfb9-5288" name="43rd Iotan Dragons" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c96f-59aa-6b3a-522b" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="4dc6-6a34-3b2b-89e6" name="43rd Iotan Dragons" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“Add 6&quot; to the Range characteristic of Rapid Fire weapons models with this doctrine are equipped with”</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="e7d3-614e-cf26-f161" name="55th Kappic Eagles" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c833-5ba5-a7a6-8804" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="893e-91d4-d172-519a" name="55th Kappic Eagles" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“INFANTRY models with this doctrine do not suffer the penalty for moving and firing Heavy weapons. When resolving an attack made by a model with this doctrine in a turn in which it disembarked from a TRANSPORT, add 1 to the hit roll.”
-</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="3931-794a-b0a8-4299" name="9th Iotan Gorgonnes" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d931-87ea-3c01-4bb5" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="e885-81ad-aec6-3aeb" name="9th Iotan Gorgonnes" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">“When resolving an attack made with a ranged weapon by an INFANTRYmodel with this doctrine against the closest enemy unit, an unmodified hit roll of 6 scores 1 additional hit.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="94df-ec40-640d-a1e1" name="Storm Troopers" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a726-4feb-e58a-5fd1" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="85cf-c6c0-0a40-b23d" name="Storm Troopers" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If a model with this doctrine is shooting a target at half range or less, it can make an extra shot with the same weapon, at the same target, for each hit roll of 6+ you make for that model. These extra shots do not themselves generate any more additional shots.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
       </selectionEntries>
@@ -19875,6 +19933,182 @@ receive the benefits of cover against that attack.&quot;</characteristic>
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
+    <selectionEntryGroup id="3ba3-a817-04f2-0282" name="Sponson Weapons" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0203-3370-8be8-9366" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="f9f6-12a1-bc96-a166" name="2 Lascannons [Legends]" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3c49-5c8f-23e5-ea8d" type="max"/>
+          </constraints>
+          <costs>
+            <cost name="pts" typeId="points" value="10.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="173c-1f6c-7afd-32bd" name="2 Heavy Flamers" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fe54-2e85-21e3-731e" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="998f-0c60-7d9e-2666" name="Heavy flamer" hidden="false" collective="false" import="true" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aff8-82c4-7e89-1948" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5dfd-7396-a07f-cf57" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="10.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="69f2-1435-0a6f-d5f1" name="2 Multi-meltas" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4012-cfed-26ba-889f" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="0689-56e1-8f0d-d8e5" name="Multi-melta" hidden="false" collective="false" import="true" targetId="2b37-65ee-9443-b4ef" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0a3-2439-762f-a723" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="61a4-ea34-ade1-6ee2" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="30.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="92ff-9bad-e7b4-477c" name="2 Militarum Plasma Cannons" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f40-ba8d-9e07-f514" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="19e4-4ea1-cd6e-23a8" name="Militarum Plasma Cannon - Standard" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">36&quot;</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D3</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">7</characteristic>
+                <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="c564-dc8b-7ba2-066b" name="Militarum Plasma Cannon - Supercharge" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">36&quot;</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D3</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">8</characteristic>
+                <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. Each time an unmodified hit roll of 1 is made for an attack with this weapon profile, the bearer suffers 1 mortal wound after shooting with this weapon.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="20.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="64a2-ea1a-433e-1f2e" name="2 Heavy Bolters" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cb5b-c685-d7d0-f49f" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="1104-0fce-7b8c-e010" name="Heavy bolter" hidden="false" collective="false" import="true" targetId="05ab-e7cc-e856-c36f" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e433-0916-069c-2a14" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c07-0b2d-ba8b-f370" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="10.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="e5ea-94cb-40bf-722b" name="Rogal Dorn Equipment List" publicationId="53e9d88f--pubN88319" page="129" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3f8-0020-e032-8065" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1fe1-5f01-98d2-6a9c" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="37e6-179c-f9e3-4360" name="Armoured Tracks" publicationId="e831-8627-fbc7-5b35" page="82" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e4d-a415-fbdc-ea6a" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="421b-b35b-2131-350b" name="Armoured Tracks" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+              <characteristics>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">The bearer gains the ARMOURED keyword, and each time a ranged attack with a Damage characteristic of 1 is allocated to the bearer, add 1 to the armour saving throw made against that attack.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="809c-35f5-e84b-7065" name="Basilisk Hull Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="6ecf-4bae-2526-8fed">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d651-33f5-e777-2d5f" type="min"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8dae-c08f-34de-be59" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="cc33-8f68-aabd-dc91" name="Heavy Bolter" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="points" value="10.0">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8b0c-1be4-4ae4-23a3" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8c51-252d-dfc5-6362" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="f792-21ec-6828-4b37" name="Heavy bolter" hidden="false" targetId="e2b0-b9f1-6c38-584c" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="6ecf-4bae-2526-8fed" name="Heavy Flamer" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="points" value="10.0">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8b0c-1be4-4ae4-23a3" type="instanceOf"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7bc8-f97d-2824-72da" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="6af7-cf46-c5ef-1096" name="Heavy flamer" hidden="false" targetId="2608-8425-4f4f-7f41" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="75fd-ec16-c371-a3e7" name="Acts of Faith" publicationId="53e9d88f--pubN88319" page="99" hidden="false">
@@ -20284,6 +20518,23 @@ can shoot its turret weapon twice in the following Shooting phase (the turret we
         <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time a model is selected to shoot with this weapon:
 - If this model is within Engagement Range of any enemy units, it can still target and resolve attacks against enemy units that are not within Engagement Range of it with this weapon. When making such attacks, you must still subtract 1 from hit rolls due to enemy models being within Engagement Range
 - Each time this model makes an attack with this weapon, add 1 to that attack&apos;s hit roll.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="90d5-721a-d654-2783" name="Co-axial Autocannon" publicationId="e831-8627-fbc7-5b35" page="103" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+      <characteristics>
+        <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">48&quot;</characteristic>
+        <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 2</characteristic>
+        <characteristic name="S" typeId="59b1-319e-ec13-d466">7</characteristic>
+        <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
+        <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
+        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Turret Weapon (pg 75)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="175c-fee4-4229-5628" name="Regimental Tactics" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If every model from your army (excluding AGENT OF THE IMPERIUM and UNALIGNED models) has the ASTRA MILITARUM keyword:
+• Each time an OFFICER from your army issues a Regimental or Prefectus Order to a unit with this ability, you can select one or more other friendly PLATOON units within 6&quot; of that unit; those PLATOON units are also affected by that Order. 
+• Each time an OFFICER from your army issues a Mechanised Order to a unit with this ability, you can select one or more other friendly SQUADRON units within 6&quot; of that unit; those SQUADRON units are also affected by that Order.</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>


### PR DESCRIPTION
Added: 
Rogal Dorn Battle Tank
Regimental Category
Smoke Category
Squadron Category
Platoon Category
Regimental Tactics Ability Shared Profile
Field Ordnance Battery

Removed:
Tempestus Regiment-Specific Warlord Traits
Veterans Unit
Pure Militarum Tempestus/Auxiliary Detachment requirements in preparation for update Special Weapons Squads

Updated:
Heavy Weapons Squad
Shared Heavy Weapons Team profile
Leman Russ Battle Tanks
Tank Aces to only allow 1 of each skill per roster Leman Russ Pintle Mounted Weapon points
Russ Sponson costs
Russ Turret Weapon costs
Basilisk no longer a squadron unit
Unlinked Earthshaker cannon from FW earthshaker choices Basilisk categories
Heavy Support Damage profiles
Hydra
Manticore
Wyvern
Deathstrike and its abilities