### PR TITLE
0.06 - Command Squads and HQs Update

### DIFF
--- a/Imperial_Guard_9th_Ed.cat
+++ b/Imperial_Guard_9th_Ed.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="53e9d88f-7463-8c27-fe67-e1a0d1ed0287" name="Imperium - Imperial Guard 9th Ed" revision="314" battleScribeVersion="2.03" authorName="" authorContact="" authorUrl="" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="53e9d88f-7463-8c27-fe67-e1a0d1ed0287" name="Imperium - Imperial Guard 9th Ed" revision="315" battleScribeVersion="2.03" authorName="" authorContact="" authorUrl="" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <entryLinks>
     <entryLink id="99a162d9-4854-cc3b-c35e-b0c3a3cc77d6" name="Commissar Yarrick" hidden="false" collective="false" import="true" targetId="5dac-1ff6-7352-3745" type="selectionEntry">
       <modifiers>
@@ -18,9 +18,9 @@
         <categoryLink id="5d41-34d8-2e83-0553-848a6ff2-0def-4c72-8433-ff7da70e6bc7" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="5f44-129d-c825-aa50" name="Command Squad" hidden="false" collective="false" import="true" targetId="3b7d-927b-8856-e8b7" type="selectionEntry">
+    <entryLink id="5f44-129d-c825-aa50" name="Platoon Command Squad" hidden="false" collective="false" import="true" targetId="3b7d-927b-8856-e8b7" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="c41d-16a1-f950-68e1" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
+        <categoryLink id="21a9-6382-077d-611e" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="8d90-63c4-a710-0ee0" name="Ogryns" hidden="false" collective="false" import="true" targetId="e722-8d0c-7ed1-d08b" type="selectionEntry">
@@ -51,11 +51,6 @@
     <entryLink id="3ef9-2a24-4dc5-7d5f" name="Company Commander" hidden="false" collective="false" import="true" targetId="716d-5866-fe42-6511" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="977f-d01e-2cbd-e3e8" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="ced1-f367-1044-62b0" name="Platoon Commander" hidden="false" collective="false" import="true" targetId="6499-885c-a205-d0e1" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="379d-3625-48ac-ca86" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ad22-0104-d3a9-f32f" name="Infantry Squad" hidden="false" collective="false" import="true" targetId="7905-3074-b98d-ce54" type="selectionEntry">
@@ -132,7 +127,7 @@
     </entryLink>
     <entryLink id="b574-8a55-28b7-d3af" name="Militarum Tempestus Command Squad" hidden="false" collective="false" import="true" targetId="1f64-1ce0-19ac-6c18" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="301c-f0df-7b99-ce7e" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
+        <categoryLink id="f25e-45b8-92c8-b8fb" name="HQ" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="29fd-b780-fec3-7f64" name="Taurox" hidden="false" collective="false" import="true" targetId="f8ad-8cb3-9d8d-0ce5" type="selectionEntry">
@@ -150,11 +145,6 @@
         <categoryLink id="5ec7-b6ba-d831-2f76" name="New CategoryLink" hidden="false" targetId="c274d0b0-5866-44bc-9810-91c136ae7438" primary="true"/>
         <categoryLink id="d72c-bfa4-1f14-20b4" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
         <categoryLink id="7a14-43de-1632-994c" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
-      </categoryLinks>
-    </entryLink>
-    <entryLink id="94f7-c7f7-defa-4070" name="Tempestor Prime" hidden="false" collective="false" import="true" targetId="2dd7-6771-c9ba-cdb4" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="f15d-5625-1100-8dea" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="08a6-d005-611b-51e7" name="Stormlord" hidden="false" collective="false" import="true" targetId="8e95-af10-b229-cd6d" type="selectionEntry">
@@ -678,7 +668,7 @@
     </entryLink>
     <entryLink id="1ba8-4e15-0911-8927" name="Lord Solar Leontus" hidden="false" collective="false" import="true" targetId="0fcd-d6ee-231e-920e" type="selectionEntry">
       <categoryLinks>
-        <categoryLink id="2be1-7271-db7e-4a23" name="HQ" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="false"/>
+        <categoryLink id="2be1-7271-db7e-4a23" name="HQ" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
       </categoryLinks>
     </entryLink>
     <entryLink id="ba6f-7219-826c-7a15" name="Kasrkin" hidden="false" collective="false" import="true" targetId="0609-08fb-cd8a-8b1e" type="selectionEntry">
@@ -694,6 +684,20 @@
     <entryLink id="425f-762b-9856-7a33" name="Field Ordnance Battery" hidden="false" collective="false" import="true" targetId="7e79-96d0-b25b-e3ed" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="dcc2-5547-43c1-c02f" name="New CategoryLink" hidden="false" targetId="abf5fd55-9ac7-4263-8bc1-a9fb0a8fa6a6" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="3b51-bb36-c08b-e599" name="Cadian Castellan" publicationId="e831-8627-fbc7-5b35" page="81" hidden="false" collective="false" import="true" targetId="7746-0a7f-e844-2e37" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="bd41-81e7-72f0-8660" name="HQ" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
+      </categoryLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="3.0"/>
+        <cost name="pts" typeId="points" value="50.0"/>
+      </costs>
+    </entryLink>
+    <entryLink id="b8c9-a1d6-e13c-edd2" name="&apos;Iron Hand&apos; Straken" hidden="false" collective="false" import="true" targetId="53ba-61e3-806e-9f94" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="ff88-623a-c86c-ad4d" name="New CategoryLink" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>
@@ -853,116 +857,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="afc2-4a4a-5427-a7cd" name="Colonel &apos;Iron Hand&apos; Straken" publicationId="53e9d88f--pubN88319" page="57" hidden="false" collective="false" import="true" type="model">
-      <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="bb07-1691-71c2-b2ef" type="max"/>
-      </constraints>
-      <profiles>
-        <profile id="7d2e-3766-a963-5e7b" name="Colonel &apos;Iron Hand&apos; Straken" publicationId="53e9d88f--pubN88319" page="57" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
-          <characteristics>
-            <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
-            <characteristic name="WS" typeId="e7f0-1278-0250-df0c">2+</characteristic>
-            <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
-            <characteristic name="S" typeId="2218-aa3c-265f-2939">6</characteristic>
-            <characteristic name="T" typeId="9c9f-9774-a358-3a39">4</characteristic>
-            <characteristic name="W" typeId="f330-5e6e-4110-0978">5</characteristic>
-            <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">4</characteristic>
-            <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">9</characteristic>
-            <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="c513-fca7-d6e4-9db6" name="Been There, Seen It, Killed It" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-          <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">You can re-roll failed wound rolls made for Colonel &apos;Iron Hand&apos; Straken in the Fight phase when targeting enemy MONSTERS.</characteristic>
-          </characteristics>
-        </profile>
-        <profile id="ea68-ab7f-07a3-699a" name="Cold Steel and Courage" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-          <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">All models in friendly CATACHAN units within 6&quot; of Colonel &apos;Iron Hand&apos; Straken at the start of the Fight phase can make 1 additional attack each time they fight during that phase.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="c203-a12b-18a1-73eb" name="Voice of Command" hidden="false" targetId="2ff26b94-8048-d15d-c541-fd4da0f49571" type="profile"/>
-        <infoLink id="2e02-f965-c092-fb09" name="Senior Officer" hidden="false" targetId="f34c8090-4e32-bd27-df37-1b714a4288d2" type="profile"/>
-        <infoLink id="9cb8-c27e-a261-cfb4" name="Refractor Field" hidden="false" targetId="783d-d067-2d7f-d2a1" type="profile"/>
-      </infoLinks>
-      <categoryLinks>
-        <categoryLink id="2dd8-39eb-47ec-ebaf" name="Catachan" hidden="false" targetId="6218-425e-33cf-6ec3" primary="false"/>
-        <categoryLink id="22fe-4023-f5c7-771b" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
-        <categoryLink id="1ea6-ffff-d547-657e" name="Colonel &apos;Iron Hand&apos; Straken" hidden="false" targetId="9145-1d3b-9057-7a17" primary="false"/>
-        <categoryLink id="6285-68e5-88d3-cce3" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
-        <categoryLink id="4807-1e86-a422-e14e" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
-        <categoryLink id="d396-603b-57ca-b6a8" name="Officer" hidden="false" targetId="dd6e-7055-ca6b-b711" primary="false"/>
-        <categoryLink id="f637-8ca8-f5f8-db6f" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
-      </categoryLinks>
-      <selectionEntries>
-        <selectionEntry id="bc87-3df5-8996-3124" name="Bionic Arm with Devil&apos;s Claw" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f857-7fc0-da14-39f4" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c53-598c-59b1-8526" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="8fc4-5f9f-6db1-4079" name="Bionic Arm with Devil&apos;s Claw" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-              <characteristics>
-                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">-</characteristic>
-                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Melee</characteristic>
-                <characteristic name="S" typeId="59b1-319e-ec13-d466">User</characteristic>
-                <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
-                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
-                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"/>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="448b-a25b-53d7-5045" name="Shotgun" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27c8-508b-ee6a-c2c8" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e9ae-cada-9ca0-c190" type="min"/>
-          </constraints>
-          <infoLinks>
-            <infoLink id="4218-1132-da6e-c66f" name="New InfoLink" hidden="false" targetId="07cb-70d7-15c3-5117" type="profile"/>
-          </infoLinks>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <entryLinks>
-        <entryLink id="98a9-858b-baef-9eaf" name="Plasma pistol" hidden="false" collective="false" import="true" targetId="83be-1ba9-c326-4760" type="selectionEntry">
-          <modifiers>
-            <modifier type="set" field="points" value="0.0"/>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e872-7ca1-a17f-a781" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6cc0-8cb5-b001-6e02" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="bdb2-9d56-953d-65cf" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="bb78-534a-7b77-edbc" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="021b-a637-71fe-c57b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cdc-6d3b-1a04-6f8a" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="f82a-ecde-6a99-7cf4" name="Display Astra Militarum Orders" hidden="false" collective="false" import="true" targetId="af30-711d-1707-fcdc" type="selectionEntry"/>
-        <entryLink id="a914-2557-bdc5-2a8b" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
-        <entryLink id="2b0c-f0ed-95b9-92ab" name="Character Stratagems (Named)" hidden="false" collective="false" import="true" targetId="ed7a-3deb-4d62-b2a9" type="selectionEntryGroup"/>
-        <entryLink id="bd19-1d3b-80bf-475b" name="Warlord Traits (Named)" hidden="false" collective="false" import="true" targetId="6871-2805-7938-980c" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="80.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="d00e-97c5-c7a0-e712" name="Colour Sergeant Kell" publicationId="53e9d88f--pubN88319" page="56" hidden="false" collective="false" import="true" type="model">
+    <selectionEntry id="d00e-97c5-c7a0-e712" name="Colour Sergeant Kell" publicationId="53e9d88f--pubN88319" page="56" hidden="true" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6d73-499f-152c-bfc2" type="max"/>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a0fd-2315-e4a7-353d" type="max"/>
@@ -1066,7 +961,6 @@
         <infoLink id="1fc8-9844-9293-d8e3" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="8ca4-d951-1e81-ecf6" name="New CategoryLink" hidden="false" targetId="218e-c8a1-cea3-8377" primary="false"/>
         <categoryLink id="4d57-c1e4-c9de-de42" name="Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
         <categoryLink id="0990-9a65-d41f-7e8f" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
         <categoryLink id="d34f-cd86-973e-186e" name="Faction: Militarum Tempestus" hidden="false" targetId="3984-854b-4603-be64" primary="false"/>
@@ -1238,7 +1132,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="483a-ffe8-5024-c337" name="Knight Commander Pask" page="0" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="483a-ffe8-5024-c337" name="Knight Commander Pask" page="0" hidden="true" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1921-4c8b-5c97-5136" type="max"/>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="68ad-2b95-bb15-c470" type="max"/>
@@ -1326,7 +1220,7 @@
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3576-85f0-e9d7-6919" name="Gotfret de Montbard" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="3576-85f0-e9d7-6919" name="Gotfret de Montbard" hidden="true" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>

--- a/Imperium_-_Imperial_Guard_9th_Ed_Library.cat
+++ b/Imperium_-_Imperial_Guard_9th_Ed_Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a2d9-e3b7-13cc-6f15" name="Imperium - Imperial Guard - 9th Ed - Library" revision="107" battleScribeVersion="2.03" authorName="denny, TheHalfinStream" authorContact="" authorUrl="" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a2d9-e3b7-13cc-6f15" name="Imperium - Imperial Guard - 9th Ed - Library" revision="108" battleScribeVersion="2.03" authorName="denny, TheHalfinStream" authorContact="" authorUrl="" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <publications>
     <publication id="53e9d88f--pubN88319" name="Codex: Astra Militarum"/>
     <publication id="53e9d88f--pubN183884" name="GW Datasheet"/>
@@ -57,9 +57,8 @@
     <categoryEntry id="7fc5b655-812e-45ed-98ff-db8847d356da" name="Primary Detachment" hidden="false"/>
     <categoryEntry id="b332-b046-7171-5059" name="Faction: Cadian" hidden="false"/>
     <categoryEntry id="6218-425e-33cf-6ec3" name="Faction: Catachan" hidden="false"/>
-    <categoryEntry id="5988-2982-1dde-215b" name="Faction: Officio Prefectus" hidden="false"/>
-    <categoryEntry id="218e-c8a1-cea3-8377" name="Faction: Tempestus Scions" hidden="false"/>
-    <categoryEntry id="fabd-67cb-befb-8f75" name="Faction: Militarum Auxilla" hidden="false"/>
+    <categoryEntry id="5988-2982-1dde-215b" name="Officio Prefectus" hidden="false"/>
+    <categoryEntry id="fabd-67cb-befb-8f75" name="Militarum Auxilla" hidden="false"/>
     <categoryEntry id="2135-9abb-5c57-5391" name="Faction: Aeronautica Imperialis" hidden="false"/>
     <categoryEntry id="ab16-2b7a-6dfe-9072" name="Armoured Sentinel" hidden="false"/>
     <categoryEntry id="60e9-5690-bdb9-21cd" name="Baneblade" hidden="false"/>
@@ -68,12 +67,12 @@
     <categoryEntry id="7d7c-9011-2791-72d9" name="Basilisk" hidden="false"/>
     <categoryEntry id="33c6-d3e1-8afc-6d5a" name="Bullgryns" hidden="false"/>
     <categoryEntry id="0ed3-ca73-4800-91a7" name="Chimera" hidden="false"/>
-    <categoryEntry id="9145-1d3b-9057-7a17" name="Colonel &apos;Iron Hand&apos; Straken" hidden="false"/>
+    <categoryEntry id="9145-1d3b-9057-7a17" name="&apos;Iron Hand&apos; Straken" hidden="false"/>
     <categoryEntry id="092e-5104-6d53-e1e1" name="Colour Sergeant Kell" hidden="false"/>
     <categoryEntry id="33c0-8496-22d0-08e9" name="Command Squad" hidden="false"/>
     <categoryEntry id="fa52-8fb7-1c87-80e6" name="Commissar" hidden="false"/>
     <categoryEntry id="24d2-da10-88cf-0c73" name="Commissar Yarrick" hidden="false"/>
-    <categoryEntry id="c315-2646-6ce0-36a0" name="Company Commander" hidden="false"/>
+    <categoryEntry id="c315-2646-6ce0-36a0" name="Cadian Commander" hidden="false"/>
     <categoryEntry id="6048-305b-52c9-b696" name="Conscript" hidden="false"/>
     <categoryEntry id="53b9-ff6c-bca7-8e1c" name="Deathstrike" hidden="false"/>
     <categoryEntry id="eb0a-0ae9-3f49-5679" name="Doomhammer" hidden="false"/>
@@ -94,7 +93,7 @@
     <categoryEntry id="dd6e-7055-ca6b-b711" name="Officer" hidden="false"/>
     <categoryEntry id="8d2c-36a7-e1b9-a6e9" name="Officer of the Fleet" hidden="false"/>
     <categoryEntry id="295e-c5d9-428c-105d" name="Ogryn" hidden="false"/>
-    <categoryEntry id="2146-87ec-415f-6461" name="Platoon Commander" hidden="false"/>
+    <categoryEntry id="2146-87ec-415f-6461" name="Commander" hidden="false"/>
     <categoryEntry id="cb37-8069-8985-01b7" name="Ratlings" hidden="false"/>
     <categoryEntry id="464f-0238-9365-4967" name="Rough Riders" hidden="false"/>
     <categoryEntry id="91ce-fd28-b4de-0951" name="Scout Sentinels" hidden="false"/>
@@ -212,11 +211,11 @@
     <categoryEntry id="ef6b-a0e8-dbc9-c510" name="Quartermaster Cadre" hidden="false"/>
     <categoryEntry id="0dae-9d66-decb-c59c" name="Faction: Elysian Drop Troops" hidden="false"/>
     <categoryEntry id="43d3-ff10-c92c-69b3" name="Mukaali Riders" hidden="false"/>
-    <categoryEntry id="a6ad-f9a6-4026-8d54" name="Faction: Tallarn" hidden="false"/>
+    <categoryEntry id="a6ad-f9a6-4026-8d54" name="Tallarn" hidden="false"/>
     <categoryEntry id="cace-70cc-a64e-480c" name="Storm Chimera" hidden="false"/>
     <categoryEntry id="556d-7939-05db-34f1" name="Death Korps Marshal" hidden="false"/>
     <categoryEntry id="8a48-22fc-3bf4-43d4" name="Death Korps Marshal Karis Venner" hidden="false"/>
-    <categoryEntry id="7289-ad8d-d326-02b6" name="Faction: Tanith" hidden="false"/>
+    <categoryEntry id="7289-ad8d-d326-02b6" name="Tanith" hidden="false"/>
     <categoryEntry id="3bb8-2f9a-48de-c16f" name="Gaunt&apos;s Ghosts" hidden="false"/>
     <categoryEntry id="e877-5452-e7f3-cd31" name="Whiteshields" hidden="false"/>
     <categoryEntry id="81e5-0f46-a4ab-4211" name="Cadian Warlord" hidden="false"/>
@@ -230,18 +229,13 @@
     <categoryEntry id="60d7-cb82-ac4f-fb9b" name="Field Ordnance Battery" hidden="false"/>
     <categoryEntry id="9401-e2e7-bd2c-b3cf" name="Armoured" hidden="false"/>
     <categoryEntry id="15e6-b4e1-a0a6-1098" name="Dozer Blade" hidden="false"/>
+    <categoryEntry id="b0a3-c8e2-b036-6794" name="Commandant" publicationId="e831-8627-fbc7-5b35" hidden="false"/>
+    <categoryEntry id="4c76-2538-8ab3-a595" name="Regimental Standard" hidden="false"/>
+    <categoryEntry id="fbb7-9dac-2467-aa9a" name="Attaché" hidden="false"/>
+    <categoryEntry id="086d-e3ba-a17b-01bd" name="Vox-Caster" hidden="false"/>
+    <categoryEntry id="f89d-fb99-97ed-bc39" name="Medic" hidden="false"/>
+    <categoryEntry id="c6c7-5322-42d3-0d07" name="Lord Solar Leontus" publicationId="e831-8627-fbc7-5b35" page="79" hidden="false"/>
   </categoryEntries>
-  <entryLinks>
-    <entryLink id="51b8-3c82-e721-0940" name="Cadian Castellan" publicationId="e831-8627-fbc7-5b35" page="81" hidden="false" collective="false" import="true" targetId="7746-0a7f-e844-2e37" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="5ce4-13a8-cdae-8f08" name="HQ" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
-      </categoryLinks>
-      <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="3.0"/>
-        <cost name="pts" typeId="points" value="50.0"/>
-      </costs>
-    </entryLink>
-  </entryLinks>
   <rules>
     <rule id="431d-d055-dd6e-d714" name="Defenders of Humanity" hidden="false">
       <description>If your army is Battle-forged, all Troops units in ASTRA MILITARUM Detachments and all LEMAN RUSS units in Spearhead Detachments gain this ability. Such a unit that is within range of an objective marker (as specified in the mission) controls the objective marker even if there are more enemy models within range of it. If an enemy unit within range of the same objective marker has a similar ability, then the objective marker is controlled by the player who has the most models in range as normal.</description>
@@ -6025,15 +6019,17 @@ This WARLORD knows those Orders in addition to any others it knows.</characteris
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="1fff-d44f-98e9-609c" name="WT (Catachan): Lead From the Front" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="1fff-d44f-98e9-609c" name="WT: Front-Line Combatant" publicationId="e831-8627-fbc7-5b35" page="68" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d00c-f7d0-7729-a5b1" type="max"/>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="f59c-8f3e-3bb6-02ac" type="max"/>
       </constraints>
       <profiles>
-        <profile id="b44d-8ee2-9398-1c98" name="Lead From the Front" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+        <profile id="b44d-8ee2-9398-1c98" name="Front-Line Combatant" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This Warlord can perform a Heroic Intervention if, after the enemy has completed all their charge moves, they are within 6&quot; of any enemy units. This Warlord can move up to 6&quot; when performing a Heroic Intervention, so long as they end the move closer to the nearest enemy model. In addition, if your Warlord charged, was charged or performed a Heroic Intervention, then until the end of the turn you can re-roll failed hit rolls made for them.</characteristic>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time this WARLORD makes a melee attack:
+- An unmodified hit roll of 6 scores 2 additional hits.
+- Add 1 to that attack&apos;s wound roll.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -8903,35 +8899,160 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3b7d-927b-8856-e8b7" name="Command Squad" publicationId="53e9d88f--pubN88319" page="30" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="increment" field="2e43-0469-15bf-32e7" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c315-2646-6ce0-36a0" repeats="1" roundUp="false"/>
-            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="078d-3b57-a663-33c8" repeats="1" roundUp="false"/>
-            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="556d-7939-05db-34f1" repeats="1" roundUp="false"/>
-            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="9145-1d3b-9057-7a17" repeats="1" roundUp="false"/>
-            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="935b-1502-0bb5-6fb7" repeats="1" roundUp="false"/>
-            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3d6b-fb42-442f-cd3f" repeats="1" roundUp="false"/>
-            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8a48-22fc-3bf4-43d4" repeats="1" roundUp="false"/>
-            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ed50-206a-b564-921b" repeats="1" roundUp="false"/>
-            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2146-87ec-415f-6461" repeats="1" roundUp="false"/>
-          </repeats>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2e43-0469-15bf-32e7" type="max"/>
-      </constraints>
+    <selectionEntry id="3b7d-927b-8856-e8b7" name="Platoon Command Squad" publicationId="e831-8627-fbc7-5b35" page="83" hidden="false" collective="false" import="true" type="unit">
+      <infoLinks>
+        <infoLink id="7813-a2a2-93be-9b77" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="1f49-55ce-ea3c-ceeb" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
-        <categoryLink id="af60-bc93-9828-1f8d" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
         <categoryLink id="bcc7-30c9-c947-9bb9" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
         <categoryLink id="0ad0-43b4-9f06-0f8b" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
-        <categoryLink id="0c2e-10da-adfb-713b" name="Veterans" hidden="false" targetId="8895-4b63-cbc0-2d8b" primary="false"/>
         <categoryLink id="1c00-63a1-e626-9190" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="3fb7-5fba-676a-93e6" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="bff2-9ebc-0912-a1b3" name="Platoon Commander" publicationId="53e9d88f--pubN88319" page="0" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="append" field="name" value="[Legends]">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="self" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6ea7-1195-7144-438e" type="atLeast"/>
+                    <condition field="selections" scope="self" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3292-34e6-f679-d5b9" type="atLeast"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9676-7c69-b181-6145" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7d1f-aed6-2d2f-4922" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="79b2-4639-76d8-f317" name="Platoon Commander" publicationId="28ec-711c-pubN77581" page="14" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+              <characteristics>
+                <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
+                <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
+                <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
+                <characteristic name="W" typeId="f330-5e6e-4110-0978">3</characteristic>
+                <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">3</characteristic>
+                <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
+                <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">5+</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="14e0-0f6e-faaa-a96a" name="Voice of Command" publicationId="e831-8627-fbc7-5b35" page="75" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+              <characteristics>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Commanding Authority: The Platoon Commander model knows Regimental Orders. In your command phase, it can issue one order</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="a2c2-be50-168c-9922" name="Refractor Field" hidden="false" targetId="783d-d067-2d7f-d2a1" type="profile"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="200b-dfef-704e-8c65" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
+            <categoryLink id="eea0-8cee-3d95-69c7" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
+            <categoryLink id="30d9-e882-786f-cae0" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+            <categoryLink id="10fb-90bc-43a1-95af" name="Officer" hidden="false" targetId="dd6e-7055-ca6b-b711" primary="false"/>
+            <categoryLink id="2f01-bb20-cba6-8ef7" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+            <categoryLink id="947d-d109-3740-abfa" name="Platoon Commander" hidden="false" targetId="2146-87ec-415f-6461" primary="false"/>
+          </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="7cf8-4f80-a995-ba44" name="Chainsword" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="240a-5660-33f3-3229" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="379e-63aa-75f5-17d2" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="d8bd-ed3c-31c7-594a" name="Power axe" hidden="false" collective="false" import="true" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="59f8-f9c9-1a73-ae5a" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="12af-c209-4585-fcdc" name="Power fist" hidden="false" collective="false" import="true" targetId="f122-3720-fa32-4215" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c97-8fef-3080-c4a8" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="7dde-8551-a740-0a3a" name="Power sword" hidden="false" collective="false" import="true" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ae16-67cd-5e9a-190f" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="d66e-6fc9-fdc1-da8d" name="Power maul" hidden="false" collective="false" import="true" targetId="6ea7-1195-7144-438e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d42-cdc1-e9f3-0f21" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="c34b-e080-868f-94e5" name="Chainsword" hidden="false" collective="false" import="true" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94d0-4221-d858-e3fe" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="a490-0598-f196-cd41" name="Laspistol" hidden="false" collective="false" import="true" defaultSelectionEntryId="0738-bb71-168d-25c8">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b79a-f495-1e3b-4db7" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52d2-e2ed-1768-6190" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="0ab8-62a1-3cdc-4d5f" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="0334-f487-8229-0c1a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ec0-3f73-dd55-ecf5" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="20df-33b4-64fe-86c5" name="Boltgun" hidden="false" collective="false" import="true" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa9b-9f42-0eb0-28d5" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="68e0-9e5c-aa9d-23ed" name="Plasma pistol" hidden="false" collective="false" import="true" targetId="83be-1ba9-c326-4760" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c992-7585-af14-3a84" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0738-bb71-168d-25c8" name="Laspistol" hidden="false" collective="false" import="true" targetId="c10b-e1a4-c913-ae15" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eafb-26ca-4d82-3b86" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="e0f7-2d5a-6b09-06c0" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9e8-496c-2c93-41ca" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d482-6abc-408a-bf12" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="03ae-cf17-a837-cc48" name="Display Regimental Orders" hidden="false" collective="false" import="true" targetId="af30-711d-1707-fcdc" type="selectionEntry"/>
+            <entryLink id="6afa-cd37-b873-8e18" name="Heirlooms of Conquest" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup"/>
+            <entryLink id="2a3e-678e-1da4-bff2" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2334-3e03-6363-66ef" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="e178-7a47-be72-0fdc" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
+            <entryLink id="d59d-fb8d-2149-8222" name="Field Commander" hidden="false" collective="false" import="true" targetId="c7d5-e7b4-87d5-c29a" type="selectionEntry"/>
+            <entryLink id="c8d8-8980-2418-c301" name="Character Stratagems" hidden="false" collective="false" import="true" targetId="2527-4b0c-1e18-38b3" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
-        <selectionEntryGroup id="63d7-bde8-3642-cf68" name="Veterans" hidden="false" collective="false" import="true" defaultSelectionEntryId="03d8-db91-4130-4884">
+        <selectionEntryGroup id="63d7-bde8-3642-cf68" name="Veteran Guardsmen" hidden="false" collective="false" import="true" defaultSelectionEntryId="03d8-db91-4130-4884">
           <modifiers>
             <modifier type="decrement" field="c5d4-46cf-cbe0-ef07" value="1.0">
               <conditions>
@@ -8948,45 +9069,62 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0328-256d-9b58-e881" type="min"/>
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c5d4-46cf-cbe0-ef07" type="max"/>
           </constraints>
+          <categoryLinks>
+            <categoryLink id="3c0b-07cd-ad57-7b81" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+            <categoryLink id="52fc-05f9-9dd8-56a1" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+            <categoryLink id="88b4-1d3b-4003-af5f" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+          </categoryLinks>
           <selectionEntries>
-            <selectionEntry id="f6ef-fcd4-7c88-e3e1" name="Veteran w/ Vox-caster" page="0" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="f6ef-fcd4-7c88-e3e1" name="Veteran Guardsman w/ Master Vox" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7039-4971-4fa6-19f3" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="9887-19b1-710f-dec6" name="Veteran" hidden="false" targetId="d4f6537c-b82c-db68-b6d6-03eefe4de298" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink id="4fd5-268b-aa36-f78b" name="Vox-Caster" hidden="false" targetId="086d-e3ba-a17b-01bd" primary="false"/>
+                <categoryLink id="3be3-e889-d470-5a70" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+                <categoryLink id="e239-0d89-cb5e-d2c3" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+                <categoryLink id="c6eb-334a-2129-82b7" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+              </categoryLinks>
               <selectionEntryGroups>
-                <selectionEntryGroup id="213b-23da-2967-6630" name="Lasgun" hidden="false" collective="false" import="true">
+                <selectionEntryGroup id="9fec-5dfd-e513-0f7a" name="Lasgun" hidden="false" collective="false" import="true" defaultSelectionEntryId="76ac-5fe8-1811-071f">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b94-071f-c21a-8c54" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="580f-f5cb-0fec-2571" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="058e-bc75-f28f-cec0" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d4f-29a5-7850-7082" type="min"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="dc38-71ed-21f6-3abb" name="Lasgun" hidden="false" collective="false" import="true" targetId="7236-b28a-2b6e-ded7" type="selectionEntry">
+                    <entryLink id="76ac-5fe8-1811-071f" name="Lasgun" hidden="false" collective="false" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c28-8b06-d67f-8aa4" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9540-b673-e791-fcb9" type="max"/>
                       </constraints>
                     </entryLink>
-                    <entryLink id="5719-75d6-2a5f-2890" name="Laspistol and Chainsword" hidden="false" collective="false" import="true" targetId="f798-8c16-e640-929b" type="selectionEntry">
+                    <entryLink id="d9e5-a0a5-2cbb-099a" name="Chainsword" hidden="false" collective="false" import="true" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="87eb-b7a3-b2ce-1f25" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4c4-f228-b8af-4e26" type="max"/>
                       </constraints>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="dda2-b983-d127-689d" name="Vox-caster" hidden="false" collective="false" import="true" targetId="9ce2-5815-93dd-2918" type="selectionEntry">
+                <entryLink id="dda2-b983-d127-689d" name="Master Vox" hidden="false" collective="false" import="true" targetId="c218-a3fc-0271-197a" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dadf-c738-5427-850b" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a890-edc8-a714-fe2e" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="958e-20fc-acf2-8730" name="Frag grenade" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
+                <entryLink id="958e-20fc-acf2-8730" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d2b-99de-8138-5329" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27a4-ac3a-9fdc-22dc" type="min"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="6da8-d7b6-10f7-f45a" name="Laspistol" hidden="false" collective="false" import="true" targetId="c10b-e1a4-c913-ae15" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e420-bc33-7876-23f2" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e62-6673-1b1b-1525" type="min"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -8996,24 +9134,44 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="03d8-db91-4130-4884" name="Veteran w/ lasgun" page="0" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="03d8-db91-4130-4884" name="Veteran Guardsman" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8709-d1a5-da38-0a49" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="a0e2-e79f-ccfb-e8cc" name="Veteran" hidden="false" targetId="d4f6537c-b82c-db68-b6d6-03eefe4de298" type="profile"/>
               </infoLinks>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="816b-aab3-e0f0-ae9e" name="Lasgun" hidden="false" collective="false" import="true" defaultSelectionEntryId="03e0-db0a-93a4-b013">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e02c-6c9d-4ac6-e171" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b78f-d48c-d06a-f51c" type="min"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="03e0-db0a-93a4-b013" name="Lasgun" hidden="false" collective="false" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f333-85a9-ba88-4a6c" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="aa28-778d-8b7f-a581" name="Chainsword" hidden="false" collective="false" import="true" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="812f-f640-e146-ee64" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="ccb5-81df-8085-4e13" name="Frag Grenades" hidden="false" collective="false" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
+                <entryLink id="ccb5-81df-8085-4e13" name="Frag grenades" hidden="false" collective="false" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39c4-1cd4-2ce9-4c14" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e7f-0fc7-2015-4539" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="3919-df6b-5955-9ac2" name="Lasgun" hidden="false" collective="false" import="true" targetId="7236-b28a-2b6e-ded7" type="selectionEntry">
+                <entryLink id="2289-3d02-aa85-b84d" name="Laspistol" hidden="false" collective="false" import="true" targetId="c10b-e1a4-c913-ae15" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db20-1847-beca-3981" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="566a-b8f7-42b4-6a03" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f560-23a5-fe2b-1f59" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0d8-c6f6-bd03-e82c" type="min"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -9023,28 +9181,34 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="8ab7-b9c8-e037-7b5a" name="Veteran w/ Medi-pack" page="0" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="8ab7-b9c8-e037-7b5a" name="Veteran Guardsman w/ Medi-pack" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="89c4-33c9-9985-6aa1" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="264a-9f8f-6d17-a793" name="Veteran" hidden="false" targetId="d4f6537c-b82c-db68-b6d6-03eefe4de298" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink id="548c-f5c0-861e-1a56" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+                <categoryLink id="bfc0-b9b7-6bee-c6b5" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+                <categoryLink id="9f9f-0b6f-0d08-eaed" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+                <categoryLink id="51f1-9c4d-e340-924f" name="Medic" hidden="false" targetId="f89d-fb99-97ed-bc39" primary="false"/>
+              </categoryLinks>
               <selectionEntryGroups>
-                <selectionEntryGroup id="de30-fd97-b832-fed5" name="Lasgun" hidden="false" collective="false" import="true">
+                <selectionEntryGroup id="2414-7a73-1165-d896" name="Lasgun" hidden="false" collective="false" import="true" defaultSelectionEntryId="512b-4e60-86ae-6cdc">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f69d-dcca-3966-c121" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd7b-1ceb-39d9-0be9" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b62-f9d5-9990-7d9e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7d9-5406-a716-50ce" type="min"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="2131-44b5-dc84-c796" name="Lasgun" hidden="false" collective="false" import="true" targetId="7236-b28a-2b6e-ded7" type="selectionEntry">
+                    <entryLink id="512b-4e60-86ae-6cdc" name="Lasgun" hidden="false" collective="false" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b0f-23f1-0f4c-6de1" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ada-42a8-d6c9-88df" type="max"/>
                       </constraints>
                     </entryLink>
-                    <entryLink id="7291-c1b7-fb3b-9968" name="Laspistol and Chainsword" hidden="false" collective="false" import="true" targetId="f798-8c16-e640-929b" type="selectionEntry">
+                    <entryLink id="90cb-78c2-414d-ecad" name="Chainsword" hidden="false" collective="false" import="true" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d272-e4f3-2576-f9d9" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2c4-6277-431f-4761" type="max"/>
                       </constraints>
                     </entryLink>
                   </entryLinks>
@@ -9057,10 +9221,16 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3572-f97d-367b-82e4" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="2aa4-c3b3-9c1a-6782" name="Frag grenade" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
+                <entryLink id="2aa4-c3b3-9c1a-6782" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa60-4f11-6827-9577" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc45-522e-8ae2-3177" type="min"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="c67f-13ca-8e9c-9a3e" name="Laspistol" hidden="false" collective="false" import="true" targetId="c10b-e1a4-c913-ae15" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb68-4bdb-8d30-0c7a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acb6-7c66-f7d5-289d" type="min"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -9070,26 +9240,37 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="7a14-c953-72c9-5b46" name="Veteran w/ Regimental Standard" page="0" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="7a14-c953-72c9-5b46" name="Veteran Guardsman w/ Regimental Standard" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ff54-0ee0-95ba-a9b6" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="3598-7c09-7a5d-db78" name="Veteran" hidden="false" targetId="d4f6537c-b82c-db68-b6d6-03eefe4de298" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink id="3289-6d7c-4b97-b881" name="Regimental Standard" hidden="false" targetId="4c76-2538-8ab3-a595" primary="false"/>
+                <categoryLink id="56f0-9738-634a-629f" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+                <categoryLink id="d98d-f011-31e9-3bad" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+                <categoryLink id="0bc0-2eeb-97ed-0f94" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+              </categoryLinks>
               <selectionEntries>
                 <selectionEntry id="e611-893d-76dd-4885" name="Regimental Standard" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f776-45d6-4319-748b" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58d8-fbea-2368-11da" type="max"/>
                   </constraints>
-                  <profiles>
-                    <profile id="65c6-6861-f6f2-0a1d" name="Regimental Standard" publicationId="53e9d88f--pubN88319" page="0" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-                      <characteristics>
-                        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">All friendly &lt;REGIMENT&gt; units add 1 to their Leadership whilst they are within 6&quot; of any &lt;REGIMENT&gt; Veteran with a regimental standard.</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
+                  <infoLinks>
+                    <infoLink id="3828-7f35-90ab-19a6" name="Regimental Standard (Aura)" hidden="false" targetId="eb4d-1660-544a-18db" type="profile">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditions>
+                            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="lessThan"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                    <infoLink id="c103-383e-22da-3baf" name="Regimental Standard " hidden="false" targetId="0456-0086-5490-3e04" type="profile"/>
+                  </infoLinks>
                   <costs>
                     <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
                     <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
@@ -9098,60 +9279,36 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                 </selectionEntry>
               </selectionEntries>
               <selectionEntryGroups>
-                <selectionEntryGroup id="07ca-e618-bce5-6cf0" name="Lasgun" hidden="false" collective="false" import="true" defaultSelectionEntryId="2f86-f8ea-21c1-c92b">
+                <selectionEntryGroup id="9e97-a22d-7e07-3efd" name="Lasgun" hidden="false" collective="false" import="true" defaultSelectionEntryId="c2b2-fac2-834a-fb6f">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1ba4-a5f2-1764-d83e" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2f49-c2e2-1dbe-61ec" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="af0c-913a-a5de-020c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfb4-31a5-d8a0-e3cb" type="min"/>
                   </constraints>
                   <entryLinks>
-                    <entryLink id="2f86-f8ea-21c1-c92b" name="Lasgun" hidden="false" collective="false" import="true" targetId="7236-b28a-2b6e-ded7" type="selectionEntry">
+                    <entryLink id="c2b2-fac2-834a-fb6f" name="Lasgun" hidden="false" collective="false" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="daf8-9ea0-59f3-bf22" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6af-75b1-8657-b752" type="max"/>
                       </constraints>
                     </entryLink>
-                    <entryLink id="fa37-6aa9-24a1-1dac" name="Laspistol and Chainsword" hidden="false" collective="false" import="true" targetId="f798-8c16-e640-929b" type="selectionEntry">
+                    <entryLink id="b77d-ef4e-4dac-6045" name="Chainsword" hidden="false" collective="false" import="true" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4514-8f7d-89d6-8ebe" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f539-be2b-f427-26e6" type="max"/>
                       </constraints>
                     </entryLink>
                   </entryLinks>
                 </selectionEntryGroup>
               </selectionEntryGroups>
               <entryLinks>
-                <entryLink id="3874-e8c4-0547-536d" name="Frag grenade" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
+                <entryLink id="3874-e8c4-0547-536d" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca4a-c3ae-78b7-d4dd" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f7b-389f-7c00-780c" type="min"/>
                   </constraints>
                 </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="0c75-ed21-5db8-c565" name="Veteran w/ Heavy Flamer" page="0" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="02fc-52c1-dee3-82bb" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="08da-4f8b-992f-801d" name="Veteran" hidden="false" targetId="d4f6537c-b82c-db68-b6d6-03eefe4de298" type="profile"/>
-              </infoLinks>
-              <entryLinks>
-                <entryLink id="b93b-808b-aa6c-e1a1" name="Heavy flamer" hidden="false" collective="false" import="true" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
+                <entryLink id="5a9d-68be-0bcf-25e7" name="Laspistol" hidden="false" collective="false" import="true" targetId="c10b-e1a4-c913-ae15" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="18cd-9b10-8d59-e8d9" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="005d-9017-57d9-2370" type="max"/>
-                  </constraints>
-                  <costs>
-                    <cost name="pts" typeId="points" value="10.0"/>
-                  </costs>
-                </entryLink>
-                <entryLink id="0ddd-0b08-0d42-60b8" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c62b-536f-794f-88c6" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dce7-f59b-8919-fccc" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="038c-89be-425b-3cc4" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d8b-509d-7bcc-6bf1" type="min"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -9161,25 +9318,59 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="59c3-6965-4419-5456" name="Veteran w/ Special Weapon" page="0" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="59c3-6965-4419-5456" name="Veteran Guardsman w/ Grenade Launcher" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="95b6-161b-1362-55ac" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="95b6-161b-1362-55ac" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="3cff-ffac-a99b-e3f5" name="Veteran" hidden="false" targetId="d4f6537c-b82c-db68-b6d6-03eefe4de298" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink id="0945-5a0d-54fe-3b75" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+                <categoryLink id="6b75-3ed3-317f-a484" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+                <categoryLink id="2a0b-f891-ebc2-01b6" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+              </categoryLinks>
+              <selectionEntries>
+                <selectionEntry id="8f6d-bb27-eaba-87a1" name="Grenade Launcher" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c01f-4edd-0519-5fac" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acc1-b691-06b2-5417" type="min"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="9404-d94c-82bb-526a" name="Grenade Launcher (Frag)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+                        <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault D6</characteristic>
+                        <characteristic name="S" typeId="59b1-319e-ec13-d466">3</characteristic>
+                        <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
+                        <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+                        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast.</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile id="8e2f-7af7-c1bb-8071" name="Grenade Launcher (Krak)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+                        <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault 1</characteristic>
+                        <characteristic name="S" typeId="59b1-319e-ec13-d466">6</characteristic>
+                        <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
+                        <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
+                        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <costs>
+                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
               <entryLinks>
-                <entryLink id="b714-6176-96be-32b9" name="Frag grenade" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
+                <entryLink id="b714-6176-96be-32b9" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8191-d711-dfc5-f803" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4966-2119-182b-2328" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="5c1d-53e4-c215-11c4" name="Astra Militarum Special Weapons BS3" hidden="false" collective="false" import="true" targetId="b146-ea4c-c9d2-b16a" type="selectionEntryGroup">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="78c6-e317-e99d-613b" type="min"/>
-                  </constraints>
-                </entryLink>
               </entryLinks>
               <costs>
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
@@ -9187,16 +9378,21 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="8c3a-6617-ae01-8e19" name="Veteran Weapon Team" page="0" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="8c3a-6617-ae01-8e19" name="Veteran Heavy Weapons Team" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ddc6-cdf4-c486-7cb0" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="6d6a-a382-e810-e23d" name="New InfoLink" hidden="false" targetId="61bc-299a-28c5-bbd5" type="profile"/>
+                <infoLink id="6d6a-a382-e810-e23d" name="Veteran Heavy Weapons Team" hidden="false" targetId="61bc-299a-28c5-bbd5" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink id="8e62-9273-1acb-333a" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+                <categoryLink id="946f-413e-408f-2a1d" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+                <categoryLink id="3cc8-5c01-70e6-ab33" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+              </categoryLinks>
               <entryLinks>
                 <entryLink id="92fb-a4b2-49ea-69cb" name="Astra Militarum Heavy Weapons" hidden="false" collective="false" import="true" targetId="29c3-5475-96d1-6a44" type="selectionEntryGroup"/>
-                <entryLink id="72b7-642d-c195-54de" name="Frag grenade" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
+                <entryLink id="72b7-642d-c195-54de" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c87-d55c-0f9b-7f7c" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="38f4-9d60-da01-0f51" type="min"/>
@@ -9209,24 +9405,157 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="0f37-f527-5afc-30ec" name="Veteran w/ laspistol and chainsword" page="0" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="f3b4-c847-979e-2f29" name="Veteran Guardsman w/ Heavy Flamer" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
-                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="719c-721c-a9a5-26e4" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6c5d-a9a9-9bb4-59d7" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="bd2c-f5a9-3b61-8dbb" name="Veteran" hidden="false" targetId="d4f6537c-b82c-db68-b6d6-03eefe4de298" type="profile"/>
+                <infoLink id="b8f5-d11f-8e96-b457" name="Veteran" hidden="false" targetId="d4f6537c-b82c-db68-b6d6-03eefe4de298" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink id="c8a0-06d0-9fd5-729c" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+                <categoryLink id="cdb4-3753-db5a-9b96" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+                <categoryLink id="3c70-15ba-7363-706f" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+              </categoryLinks>
               <entryLinks>
-                <entryLink id="db1b-1a52-4906-3a63" name="Frag grenades" hidden="false" collective="false" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
+                <entryLink id="a6a7-458e-2f36-0dd0" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a1b-d43d-d714-5736" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="903a-22f0-7b44-cecf" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="46a9-62f0-6e1f-bd3c" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1979-be99-8b95-0972" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="3492-829f-e6d1-5b65" name="Laspistol and Chainsword" hidden="false" collective="false" import="true" targetId="f798-8c16-e640-929b" type="selectionEntry">
+                <entryLink id="8338-da59-910d-ccaf" name="Heavy flamer" hidden="false" collective="false" import="true" targetId="18bc-b335-29c2-2ae2" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="41e8-7791-20f1-ad68" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8491-41a4-464b-c744" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c7d-de9c-af03-797f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bf2-8df9-fb5d-51fa" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="541a-fb21-cd7d-07cf" name="Veteran Guardsman w/ Flamer" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5c65-a100-f81f-e63c" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="61d5-913d-627a-c2fb" name="Veteran" hidden="false" targetId="d4f6537c-b82c-db68-b6d6-03eefe4de298" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="92de-c548-1581-b742" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+                <categoryLink id="4ace-65b7-396f-59db" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+                <categoryLink id="cd78-117e-1897-352e" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="bb14-b1cf-98a6-f56b" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc89-1fd6-6783-664f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3497-c19c-ce28-ce30" type="min"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="1d7a-6d20-d6e0-7ff1" name="Flamer" hidden="false" collective="false" import="true" targetId="fd22-6743-2d4c-dd62" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2c1-30ab-dfd1-af49" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb44-b949-a030-3b9d" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e709-5491-ae43-5574" name="Veteran Guardsman w/ Meltagun" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e9ec-0161-5cfd-3bb0" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c185-a333-a1b0-2429" name="Veteran" hidden="false" targetId="d4f6537c-b82c-db68-b6d6-03eefe4de298" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="da44-1956-fb54-14c2" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+                <categoryLink id="88eb-51d8-ec96-273b" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+                <categoryLink id="a029-73cb-e034-2595" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="9543-11f5-28b4-d254" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9be1-4967-f4af-1696" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e98-db8f-f35e-6aa2" type="min"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="e623-ac42-2fa6-fb4c" name="Meltagun" hidden="false" collective="false" import="true" targetId="efc8-c51d-5b02-a3a2" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4787-368a-8cce-5c16" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e964-672e-2239-8ddd" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="219f-eee9-c282-2b85" name="Veteran Guardsman w/ Plasma Gun" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="33c8-7365-57f9-c569" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="bb77-86d4-6639-f37a" name="Veteran" hidden="false" targetId="d4f6537c-b82c-db68-b6d6-03eefe4de298" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="2c54-1969-34b4-9ef9" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+                <categoryLink id="0e87-131a-ebef-dff2" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+                <categoryLink id="4e22-1e2f-59ad-1d98" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="8f6d-f77c-e52e-91dd" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c44-4fd9-39fc-8bf3" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e7b-ce43-3daa-588b" type="min"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="bdb6-8db5-bcb8-17c9" name="Plasma gun" hidden="false" collective="false" import="true" targetId="8c14-22cc-93ce-b85a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4a7-81a7-5e09-1273" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fc03-89df-6735-128c" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="4230-9a6d-e02f-c99c" name="Veteran Guardsman w/ Sniper Rifle" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ce42-6c5c-6d47-c8e2" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="2295-a6e2-1c1c-b62a" name="Veteran" hidden="false" targetId="d4f6537c-b82c-db68-b6d6-03eefe4de298" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="6628-8816-fabd-1c4f" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+                <categoryLink id="80da-c85b-22ed-b1a8" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+                <categoryLink id="5485-7785-af27-73d3" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="db7b-0386-e375-9cb3" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e780-c3e1-c663-e71d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb07-61cc-3d88-95a8" type="min"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="a6b2-c4b7-95da-35e4" name="Sniper Rifle" hidden="false" collective="false" import="true" targetId="d4fd-c131-723b-350b" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6122-5d9d-76ae-85c6" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7f0-4fd3-5a53-3f28" type="min"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -9240,8 +9569,8 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="2.0"/>
-        <cost name="pts" typeId="points" value="25.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
+        <cost name="pts" typeId="points" value="75.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -9371,7 +9700,7 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="af30-711d-1707-fcdc" name="Display Astra Militarum Orders" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="af30-711d-1707-fcdc" name="Display Regimental Orders" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="baba-23c2-9e22-4d86" type="max"/>
       </constraints>
@@ -9503,7 +9832,7 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="716d-5866-fe42-6511" name="Company Commander" publicationId="53e9d88f--pubN88319" page="0" hidden="false" collective="false" import="true" type="model">
+    <selectionEntry id="716d-5866-fe42-6511" name="Cadian Command Squad" publicationId="53e9d88f--pubN88319" page="0" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="append" field="name" value="[Legends]">
           <conditionGroups>
@@ -9516,127 +9845,538 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
           </conditionGroups>
         </modifier>
       </modifiers>
-      <profiles>
-        <profile id="43c3-2189-4f58-a269" name="Company Commander" publicationId="53e9d88f--pubN88319" page="30" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
-          <characteristics>
-            <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
-            <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
-            <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
-            <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
-            <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
-            <characteristic name="W" typeId="f330-5e6e-4110-0978">4</characteristic>
-            <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">3</characteristic>
-            <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">8</characteristic>
-            <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">5+</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
       <infoLinks>
-        <infoLink id="fb54-a7e9-178e-ac8c" name="Voice of Command" hidden="false" targetId="2ff26b94-8048-d15d-c541-fd4da0f49571" type="profile"/>
-        <infoLink id="0b7a-2c9c-bc36-7641" name="New InfoLink" hidden="false" targetId="783d-d067-2d7f-d2a1" type="profile"/>
-        <infoLink id="80da-0c59-ea83-1578" name="" hidden="false" targetId="f34c8090-4e32-bd27-df37-1b714a4288d2" type="profile"/>
+        <infoLink id="80da-0c59-ea83-1578" name="Senior Officer (Aura)" hidden="false" targetId="f34c8090-4e32-bd27-df37-1b714a4288d2" type="profile"/>
+        <infoLink id="ee2f-c036-f1c6-03e0" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="275d-f3a7-8ba8-7834" name="Officer" hidden="false" targetId="dd6e-7055-ca6b-b711" primary="false"/>
         <categoryLink id="10fd-96b9-47a7-76b1" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
-        <categoryLink id="bdff-ea1f-8dd4-d791" name="Company Commander" hidden="false" targetId="c315-2646-6ce0-36a0" primary="false"/>
-        <categoryLink id="fbc2-d977-6cda-418a" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
         <categoryLink id="3ca6-720e-d2c9-37c0" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
-        <categoryLink id="5b97-30af-84a5-f26f" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
         <categoryLink id="ed78-32f2-99d9-b70b" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="ec3e-1ec8-0b99-7a16" name="Cadian" hidden="false" targetId="b332-b046-7171-5059" primary="false"/>
       </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="f75b-f419-5e2b-ee11" name="Chainsword" hidden="false" collective="false" import="true">
+      <selectionEntries>
+        <selectionEntry id="20d1-d4c6-1dea-fe19" name="Cadian Commander" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1605-b432-acdb-c1c1" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f053-19ba-b67b-6dc8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2da7-6b1c-9021-8c1d" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="823f-e247-2144-7dbd" type="min"/>
           </constraints>
+          <profiles>
+            <profile id="9411-f529-7f80-dbe0" name="Voice of Command" publicationId="e831-8627-fbc7-5b35" page="75" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+              <characteristics>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Commanding Authority: The Cadian Commander model knows Regimental Orders. In your command phase, it can issue one order</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="f8df-ac0f-5cc0-238a" name="Cadian Commander" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+              <characteristics>
+                <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
+                <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
+                <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
+                <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
+                <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">2</characteristic>
+                <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
+                <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">5+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="31d4-17bd-8337-fc6c" name="Refractor Field" hidden="false" targetId="783d-d067-2d7f-d2a1" type="profile"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="f81a-df1d-0604-28f3" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+            <categoryLink id="9409-f1f7-2823-d3c4" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
+            <categoryLink id="a5e6-9b3d-b1c6-6e33" name="Officer" hidden="false" targetId="dd6e-7055-ca6b-b711" primary="false"/>
+            <categoryLink id="ed33-4507-9106-69cb" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+            <categoryLink id="4a9b-681c-bf45-824d" name="Cadian Commander" hidden="false" targetId="c315-2646-6ce0-36a0" primary="false"/>
+          </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="acf3-2f52-c029-85fd" name="Laspistol" hidden="false" collective="false" import="true" defaultSelectionEntryId="9bde-8740-95b3-016f">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f577-a7ae-b60a-e790" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="99bb-b577-d9ad-be03" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="1307-01f4-0b0c-8221" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="0334-f487-8229-0c1a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20f1-7142-e637-da80" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="f31b-3471-4562-3b12" name="Plasma pistol" hidden="false" collective="false" import="true" targetId="83be-1ba9-c326-4760" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="5.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd0b-c89c-c51d-8226" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="9bde-8740-95b3-016f" name="Laspistol" hidden="false" collective="false" import="true" targetId="c10b-e1a4-c913-ae15" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d9c-7612-e032-b281" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="d484-a1bb-991f-c1d4" name="Chainsword" hidden="false" collective="false" import="true" defaultSelectionEntryId="2cf1-2152-417a-6365">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="488e-1c46-3995-21ed" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ca8-e711-fae2-2c12" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="4dff-a5d9-93bb-1d22" name="Power axe" hidden="false" collective="false" import="true" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="288b-0e7e-5a26-5613" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="bed9-0c42-15ae-007e" name="Power fist" hidden="false" collective="false" import="true" targetId="f122-3720-fa32-4215" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="5.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a284-7f19-c319-12b2" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1896-3555-59b3-a442" name="Power sword" hidden="false" collective="false" import="true" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f814-20a4-1a9d-3e64" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="82b7-1465-a8bf-f259" name="Power maul" hidden="false" collective="false" import="true" targetId="6ea7-1195-7144-438e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4769-63fe-b413-d6eb" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="4.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="2cf1-2152-417a-6365" name="Chainsword" hidden="false" collective="false" import="true" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="984e-3efd-e930-6e6c" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="25c1-d26b-95a3-bfc0" name="Power axe" hidden="false" collective="false" import="true" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
+            <entryLink id="a9d1-b8da-f3cb-6da2" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a7de-12e2-aeba-1175" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="d70a-ac57-f691-25e4" name="Power fist" hidden="false" collective="false" import="true" targetId="f122-3720-fa32-4215" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="91af-3085-676d-ed49" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="5cbf-8d2e-181c-a5e1" name="Power sword" hidden="false" collective="false" import="true" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9fd4-3770-09df-6225" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e2f-0f24-d5aa-dbc3" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c411-6d89-7a18-a40c" type="min"/>
               </constraints>
             </entryLink>
-            <entryLink id="a7a4-5f92-91f9-c890" name="Power maul" hidden="false" collective="false" import="true" targetId="6ea7-1195-7144-438e" type="selectionEntry">
+            <entryLink id="f45a-2a15-740d-b989" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
+            <entryLink id="fb61-7f36-cb56-3a99" name="Heirlooms of Conquest" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup"/>
+            <entryLink id="0d62-0913-dee3-6601" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="258f-3c1b-8620-f498" name="Cadian Veteran Guardsman (Medi-pack)" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcde-42a3-cc68-af7e" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94fb-3fe7-826d-5632" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="582b-6fdd-e9d9-34b7" name="Cadian Veteran Guardsman" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+              <characteristics>
+                <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
+                <characteristic name="BS" typeId="381b-eb28-74c3-df5f">4+</characteristic>
+                <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
+                <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
+                <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">2</characteristic>
+                <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
+                <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">5+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <categoryLinks>
+            <categoryLink id="e5bd-acae-a41a-58a4" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+            <categoryLink id="4296-0a85-4091-d778" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+            <categoryLink id="fd43-5da8-c4e9-20c3" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+          </categoryLinks>
+          <entryLinks>
+            <entryLink id="8ef7-82c6-8e89-9b59" name="Lasgun" hidden="false" collective="false" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4b8-8190-7395-ef3d" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0fb-127b-88f9-9e04" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a99-c1b7-bfd1-621a" type="max"/>
               </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="4.0"/>
-              </costs>
             </entryLink>
-            <entryLink id="f4b5-1aa8-4230-0683" name="Chainsword" hidden="false" collective="false" import="true" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
+            <entryLink id="4fd1-1311-be21-5f81" name="Medi-pack" hidden="false" collective="false" import="true" targetId="1443-a52b-6953-c648" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2024-0989-743f-4c3e" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="871c-0d5c-01f1-bc22" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="265d-60df-3857-94e9" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="34fe-034c-df8e-c653" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9060-0edc-5c73-d0a8" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca7c-5686-63e7-5076" type="min"/>
               </constraints>
             </entryLink>
           </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="683d-ab47-e585-a4e8" name="Laspistol" hidden="false" collective="false" import="true" defaultSelectionEntryId="642f-f5f0-9353-a72c">
+          <costs>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1efb-4330-9fb9-b9d9" name="Cadian Veteran Guardsman (Melee Weapon)" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d4b-bb78-28ff-934c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9cb-47b4-7738-eabc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3d5a-c33b-5ff2-8383" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2ef-2875-a1d8-b949" type="max"/>
           </constraints>
+          <profiles>
+            <profile id="71ce-d313-a688-ab8e" name="Cadian Veteran Guardsman" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+              <characteristics>
+                <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
+                <characteristic name="BS" typeId="381b-eb28-74c3-df5f">4+</characteristic>
+                <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
+                <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
+                <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">2</characteristic>
+                <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
+                <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">5+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <categoryLinks>
+            <categoryLink id="b5ba-baf6-0cb2-74c2" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+            <categoryLink id="800f-0aae-318c-5c97" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+            <categoryLink id="516f-aeb1-c605-2c39" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+          </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="fea3-53c9-ff73-1cb0" name="Laspistol" hidden="false" collective="false" import="true" defaultSelectionEntryId="5680-d032-5dc1-666d">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1294-f4f8-116d-2ff9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8941-87b9-ee75-464a" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="11bd-cbc3-fcd9-a1e1" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="0334-f487-8229-0c1a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5b3-301b-1537-1414" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="fc88-4eb6-aa52-e218" name="Plasma pistol" hidden="false" collective="false" import="true" targetId="83be-1ba9-c326-4760" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="5.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b6d-ab24-cac1-efc4" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="5680-d032-5dc1-666d" name="Laspistol" hidden="false" collective="false" import="true" targetId="c10b-e1a4-c913-ae15" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8046-2ada-6b81-f0bc" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+            <selectionEntryGroup id="fd39-da93-5446-a570" name="Chainsword" hidden="false" collective="false" import="true" defaultSelectionEntryId="ccbc-6201-21cb-46c5">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35bf-0f53-adac-9803" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40ac-2091-d3bc-b729" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="11d3-bf29-c6a5-7f30" name="Power axe" hidden="false" collective="false" import="true" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7eb8-0734-b6ad-a15f" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="b68c-3e9a-b571-5d6a" name="Power fist" hidden="false" collective="false" import="true" targetId="f122-3720-fa32-4215" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="5.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e928-6bc2-a047-59e5" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="1e8e-b1cb-4b40-544c" name="Power sword" hidden="false" collective="false" import="true" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fd7-fc47-8407-bb98" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="a782-54aa-0171-f293" name="Power maul" hidden="false" collective="false" import="true" targetId="6ea7-1195-7144-438e" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ab56-6468-1c73-5814" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="4.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="ccbc-6201-21cb-46c5" name="Chainsword" hidden="false" collective="false" import="true" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ebc-8160-ccad-729b" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="c626-26fb-c810-0598" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="0334-f487-8229-0c1a" type="selectionEntry">
+            <entryLink id="8664-a221-6ff9-486d" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9765-b1aa-8a4c-f997" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="d688-57da-c024-e069" name="Boltgun" hidden="false" collective="false" import="true" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90a3-e7a9-22be-f49a" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="27d3-2be7-6705-cbc5" name="Plasma pistol" hidden="false" collective="false" import="true" targetId="83be-1ba9-c326-4760" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="points" value="5"/>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0c8d-2bc1-3169-2754" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="642f-f5f0-9353-a72c" name="Laspistol" hidden="false" collective="false" import="true" targetId="c10b-e1a4-c913-ae15" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c762-1352-b97e-8d97" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9444-395a-517b-9596" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a1d-b3f7-a141-2e5f" type="min"/>
               </constraints>
             </entryLink>
           </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
+          <costs>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="39ec-1afb-b31d-83d3" name="Cadian Veteran Guardsman (Master Vox)" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1804-0dff-0818-a485" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="516b-716d-869b-3294" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="208e-d48a-cf77-aaba" name="Cadian Veteran Guardsman" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+              <characteristics>
+                <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
+                <characteristic name="BS" typeId="381b-eb28-74c3-df5f">4+</characteristic>
+                <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
+                <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
+                <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">2</characteristic>
+                <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
+                <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">5+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <categoryLinks>
+            <categoryLink id="28ac-51f9-1d37-9459" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+            <categoryLink id="2a82-c6b0-86f5-7ca9" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+            <categoryLink id="8c14-8cd8-73c2-d207" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+          </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="6fd2-0880-3a90-9e4f" name="Laspistol" hidden="false" collective="false" import="true" defaultSelectionEntryId="907e-3f5d-3f10-c538">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c1b3-79c8-8f40-8302" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ecee-589e-4729-05bc" type="min"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="db89-61a9-af08-4f3c" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="0334-f487-8229-0c1a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="184d-c4a8-327c-1d16" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="ae39-034d-6e51-6bb3" name="Plasma pistol" hidden="false" collective="false" import="true" targetId="83be-1ba9-c326-4760" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="5.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35e1-57e7-d907-9944" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="907e-3f5d-3f10-c538" name="Laspistol" hidden="false" collective="false" import="true" targetId="c10b-e1a4-c913-ae15" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd83-b53c-5059-cf2b" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="c04f-f0f2-aab6-c2ac" name="Master Vox" hidden="false" collective="false" import="true" targetId="c218-a3fc-0271-197a" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7655-797c-498f-ed9c" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4a9-fe85-f29a-051e" type="min"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5443-7451-8026-85b0" name="Master Vox" hidden="false" targetId="09e2-faa3-9206-a45e" type="profile"/>
+              </infoLinks>
+            </entryLink>
+            <entryLink id="e7a4-528e-e054-9184" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3a9-5a8e-59fe-4e30" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1b7-9a31-32c4-4101" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="24e4-24d0-6817-0864" name="Cadian Veteran Guardsman (Regimental Standard/Special Weapon)" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3f0b-1d8c-7ffb-90a3" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a5ec-9f0a-0100-61e2" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="eec0-e024-8fcc-a89d" name="Cadian Veteran Guardsman" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+              <characteristics>
+                <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
+                <characteristic name="BS" typeId="381b-eb28-74c3-df5f">4+</characteristic>
+                <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
+                <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
+                <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">2</characteristic>
+                <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
+                <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">5+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <categoryLinks>
+            <categoryLink id="3efa-1efd-cefc-ebf2" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+            <categoryLink id="d0bf-2edf-b110-17d4" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+            <categoryLink id="13c6-3357-dbfc-7d03" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+          </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="367f-799b-4aee-abaa" name="Lasgun &amp; Regimental Standard" hidden="false" collective="false" import="true" defaultSelectionEntryId="abd0-52a2-c2f2-306f">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9c9-dddd-69eb-b1fc" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6802-f30e-2fd6-b556" type="min"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="abd0-52a2-c2f2-306f" name="Lasgun &amp; Regimental Standard" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="remove" field="category" value="4c76-2538-8ab3-a595">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="lessThan"/>
+                      </conditions>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a796-e769-16e0-f949" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="27c9-7fe3-0647-c446" name="Regimental Standard " hidden="false" targetId="0456-0086-5490-3e04" type="profile"/>
+                    <infoLink id="b2cf-52b0-a9f8-64a5" name="Regimental Standard (Aura)" hidden="false" targetId="eb4d-1660-544a-18db" type="profile">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="true">
+                          <conditions>
+                            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="lessThan"/>
+                          </conditions>
+                        </modifier>
+                      </modifiers>
+                    </infoLink>
+                  </infoLinks>
+                  <categoryLinks>
+                    <categoryLink id="90c8-72f9-3bd4-f7bc" name="Regimental Standard" hidden="false" targetId="4c76-2538-8ab3-a595" primary="false"/>
+                  </categoryLinks>
+                  <entryLinks>
+                    <entryLink id="4d7c-9fef-78ff-6622" name="Lasgun" hidden="false" collective="false" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cbe7-1e7a-898e-9841" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43fc-4929-55ac-5620" type="min"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <selectionEntryGroups>
+                <selectionEntryGroup id="e5ba-80f1-1c71-c4e3" name="Special Weapon" hidden="false" collective="false" import="true">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ccbd-6043-981c-7f21" type="max"/>
+                  </constraints>
+                  <selectionEntries>
+                    <selectionEntry id="2704-f901-68bb-d8a1" name="Grenade Launcher" hidden="false" collective="false" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f7c-2445-d4b1-675b" type="max"/>
+                      </constraints>
+                      <profiles>
+                        <profile id="1bc1-d6da-bad7-ab5c" name="Grenade Launcher (Frag)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                          <characteristics>
+                            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+                            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault D6</characteristic>
+                            <characteristic name="S" typeId="59b1-319e-ec13-d466">3</characteristic>
+                            <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
+                            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+                            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast.</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile id="7c70-998b-6de3-0b75" name="Grenade Launcher (Krak)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                          <characteristics>
+                            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+                            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault 1</characteristic>
+                            <characteristic name="S" typeId="59b1-319e-ec13-d466">6</characteristic>
+                            <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
+                            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
+                            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <costs>
+                        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                        <cost name="pts" typeId="points" value="5.0"/>
+                        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="5601-96cb-0213-8364" name="Plasma gun" hidden="false" collective="false" import="true" targetId="8c14-22cc-93ce-b85a" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8c0-c497-762f-1a9a" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="01b8-59c3-4a71-6838" name="Meltagun" hidden="false" collective="false" import="true" targetId="efc8-c51d-5b02-a3a2" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb15-745c-4fdf-b3ec" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="e90c-81ba-3a9f-38c2" name="Flamer" hidden="false" collective="false" import="true" targetId="fd22-6743-2d4c-dd62" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a8a0-5d5b-a9ae-9368" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="points" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntryGroup>
+              </selectionEntryGroups>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="5706-8c83-e09a-c3f3" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1b1-faca-8754-a204" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="174e-0202-03d5-3142" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <entryLinks>
-        <entryLink id="17a6-8884-d2d3-7498" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f326-bf6c-33d0-e898" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8422-4369-3062-ecd2" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="41ab-5dd7-0797-8a12" name="Display Astra Militarum Orders" hidden="false" collective="false" import="true" targetId="af30-711d-1707-fcdc" type="selectionEntry"/>
-        <entryLink id="06a6-4604-8ec4-6b89" name="Heirlooms of Conquest" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup"/>
-        <entryLink id="2a13-14bc-55c4-c65f" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
-        <entryLink id="11c7-53b2-7286-49ec" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
-        <entryLink id="0c3b-bbab-9f3e-d1a5" name="Field Commander" hidden="false" collective="false" import="true" targetId="c7d5-e7b4-87d5-c29a" type="selectionEntry"/>
-        <entryLink id="5187-99be-9e53-a77f" name="Character Stratagems" hidden="false" collective="false" import="true" targetId="2527-4b0c-1e18-38b3" type="selectionEntryGroup"/>
+        <entryLink id="41ab-5dd7-0797-8a12" name="Display Regimental Orders" hidden="false" collective="false" import="true" targetId="af30-711d-1707-fcdc" type="selectionEntry"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="35.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="2.0"/>
+        <cost name="pts" typeId="points" value="75.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -10462,7 +11202,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="94c2-3728-b48d-6713" name="Aradia Madellan" hidden="false" collective="false" import="true" type="model">
+    <selectionEntry id="94c2-3728-b48d-6713" name="Aradia Madellan" hidden="true" collective="false" import="true" type="model">
       <modifiers>
         <modifier type="set" field="hidden" value="true">
           <conditions>
@@ -12587,137 +13327,6 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="6499-885c-a205-d0e1" name="Platoon Commander" publicationId="53e9d88f--pubN88319" page="0" hidden="false" collective="false" import="true" type="model">
-      <modifiers>
-        <modifier type="append" field="name" value="[Legends]">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="self" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6ea7-1195-7144-438e" type="atLeast"/>
-                <condition field="selections" scope="self" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3292-34e6-f679-d5b9" type="atLeast"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <profiles>
-        <profile id="f865-8a87-7c86-35cb" name="Platoon Commander" publicationId="28ec-711c-pubN77581" page="14" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
-          <characteristics>
-            <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
-            <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
-            <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
-            <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
-            <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
-            <characteristic name="W" typeId="f330-5e6e-4110-0978">3</characteristic>
-            <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">3</characteristic>
-            <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
-            <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">5+</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="7d67-ba02-c3ad-7610" name="Refractor Field" hidden="false" targetId="783d-d067-2d7f-d2a1" type="profile"/>
-        <infoLink id="0036-0846-9ea8-a58d" name="Voice of Command" hidden="false" targetId="2ff26b94-8048-d15d-c541-fd4da0f49571" type="profile"/>
-      </infoLinks>
-      <categoryLinks>
-        <categoryLink id="c9a8-abba-6a39-8902" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
-        <categoryLink id="2380-ff56-e6b8-10f8" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
-        <categoryLink id="d3ff-b208-29ed-6346" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
-        <categoryLink id="7b72-79c6-e7d1-9a19" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
-        <categoryLink id="6c21-1013-eed1-3e5b" name="Officer" hidden="false" targetId="dd6e-7055-ca6b-b711" primary="false"/>
-        <categoryLink id="994a-3616-0ea9-9166" name="Platoon Commander" hidden="false" targetId="2146-87ec-415f-6461" primary="false"/>
-        <categoryLink id="616d-042b-9df1-805a" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
-      </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="3b0a-6db3-e11e-d0f0" name="Chainsword" hidden="false" collective="false" import="true" defaultSelectionEntryId="0561-24f3-c709-30f6">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ffe-5ff7-936b-8c1a" type="max"/>
-            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcff-3933-98f3-5f48" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="8e18-bfb5-bf53-1b29" name="Power axe" hidden="false" collective="false" import="true" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0f74-e05a-42ca-51ca" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="2981-84d5-e6d6-b539" name="Power fist" hidden="false" collective="false" import="true" targetId="f122-3720-fa32-4215" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="525a-f8ac-3ad8-0c2b" type="max"/>
-              </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
-            </entryLink>
-            <entryLink id="e546-dcd7-9920-9c26" name="Power sword" hidden="false" collective="false" import="true" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eec4-5ff2-3fac-1eae" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="66f3-88e2-6d6d-8f51" name="Power maul" hidden="false" collective="false" import="true" targetId="6ea7-1195-7144-438e" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47a3-6947-5900-ca2e" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="0561-24f3-c709-30f6" name="Chainsword" hidden="false" collective="false" import="true" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1557-d95f-eae4-76e1" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="bb49-9d12-8452-95a3" name="Laspistol" hidden="false" collective="false" import="true" defaultSelectionEntryId="318d-7029-89b8-e16a">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e5a4-67eb-0c9a-856f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f77-ac26-754a-13fe" type="min"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="0bf8-8177-f6ee-891b" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="0334-f487-8229-0c1a" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a8b-5949-b685-463d" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="0820-721b-61e5-4914" name="Boltgun" hidden="false" collective="false" import="true" targetId="b61f-a3c1-827d-c5b6" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1099-69aa-158e-31f5" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="4bcc-f6c7-f60a-de26" name="Plasma pistol" hidden="false" collective="false" import="true" targetId="83be-1ba9-c326-4760" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb1e-a668-7414-b63a" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="318d-7029-89b8-e16a" name="Laspistol" hidden="false" collective="false" import="true" targetId="c10b-e1a4-c913-ae15" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e16-a6ec-b763-b32b" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="1f2e-a1f3-bc0f-74aa" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3457-a67b-9de9-b2cd" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d04-37cd-2049-2847" type="min"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="ad3d-ce79-ac4b-4239" name="Display Astra Militarum Orders" hidden="false" collective="false" import="true" targetId="af30-711d-1707-fcdc" type="selectionEntry"/>
-        <entryLink id="de96-7b36-1496-277f" name="Heirlooms of Conquest" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup"/>
-        <entryLink id="0963-1fc7-ebcf-891c" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="2a03-a805-4788-a9ab" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="06de-cb3f-41bb-5fb1" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
-        <entryLink id="bc83-befc-a4d2-7d0a" name="Field Commander" hidden="false" collective="false" import="true" targetId="c7d5-e7b4-87d5-c29a" type="selectionEntry"/>
-        <entryLink id="1a5d-1a66-44d1-577e" name="Character Stratagems" hidden="false" collective="false" import="true" targetId="2527-4b0c-1e18-38b3" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="25.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="2.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-      </costs>
-    </selectionEntry>
     <selectionEntry id="6180-83df-5874-095a" name="Praetor" hidden="false" collective="false" import="true" type="model">
       <profiles>
         <profile id="98b7-2ea4-885c-e219" name="Praetor [1] (11-20+ wounds remaining)" publicationId="7573-8d1b-acdf-2de8" page="72" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -12853,27 +13462,21 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         </profile>
         <profile id="6a8a-2497-ef32-e21e" name="Psyker" hidden="false" typeId="bc97-dea9-9e88-bb7d" typeName="Psyker">
           <characteristics>
-            <characteristic name="Cast" typeId="5afb-9914-904b-d3b3">1</characteristic>
+            <characteristic name="Cast" typeId="5afb-9914-904b-d3b3">2</characteristic>
             <characteristic name="Deny" typeId="b5ac-9c20-5d5a-6f9b">1</characteristic>
-            <characteristic name="Powers Known" typeId="69d7-b45e-00a2-7e46">Smite &amp; 2 Psykana</characteristic>
+            <characteristic name="Powers Known" typeId="69d7-b45e-00a2-7e46">Smite &amp; 2 Psykana Powers</characteristic>
             <characteristic name="Other" typeId="c2e2-f115-0003-5d7b"/>
-          </characteristics>
-        </profile>
-        <profile id="8f19-c2ed-93aa-1dcd" name="It&apos;s For Your Own Good" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-          <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If this model is slain as a result of Perils of the Warp whilst within 6&quot; of a friendly COMMISSAR they are executed before anything untoward can happen -- the power they were attempting still fails, but units within 6&quot; of them do not suffer D3 mortal wounds as normal.</characteristic>
           </characteristics>
         </profile>
       </profiles>
       <categoryLinks>
         <categoryLink id="18d1-8445-cb76-6875" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
-        <categoryLink id="ee53-cd5a-a9ae-63fd" name="Faction: Astra Telepathica" hidden="false" targetId="fac9-80d5-a022-1805" primary="false"/>
         <categoryLink id="10ae-7bcc-7184-6ae7" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
-        <categoryLink id="8ad5-32f1-3022-0e2f" name="Faction: Scholastica Psykana" hidden="false" targetId="e33e-8d7c-5155-72e9" primary="false"/>
         <categoryLink id="2b94-00a6-d92d-cf26" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
         <categoryLink id="b858-7699-35cd-f53a" name="Primaris Psyker" hidden="false" targetId="75a7-e5c7-78de-739b" primary="false"/>
         <categoryLink id="e92c-0b18-72c7-34eb" name="Psyker" hidden="false" targetId="e691-aad7-d21c-1023" primary="false"/>
         <categoryLink id="5bb7-659e-25ad-a7b9" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="3722-23ad-1b09-44ac" name="Faction: Militarum Auxilla" hidden="false" targetId="fabd-67cb-befb-8f75" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="97a3-138b-4ad0-7253" name="Force Stave" publicationId="53e9d88f--pubN88319" page="92" hidden="false" collective="false" import="true" type="upgrade">
@@ -12936,7 +13539,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         <entryLink id="77bf-ac48-a0cf-e946" name="Character Stratagems" hidden="false" collective="false" import="true" targetId="2527-4b0c-1e18-38b3" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="50.0"/>
+        <cost name="pts" typeId="points" value="60.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="3.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -15170,26 +15773,158 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       </costs>
     </selectionEntry>
     <selectionEntry id="1f64-1ce0-19ac-6c18" name="Militarum Tempestus Command Squad" page="0" hidden="false" collective="false" import="true" type="unit">
-      <modifiers>
-        <modifier type="increment" field="3857-f814-d084-a119" value="1.0">
-          <repeats>
-            <repeat field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2dd7-6771-c9ba-cdb4" repeats="1" roundUp="false"/>
-          </repeats>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="3857-f814-d084-a119" type="max"/>
-      </constraints>
       <infoLinks>
         <infoLink id="d497-7401-d506-2d24" name="Aerial Drop" hidden="false" targetId="0a6c-a8e0-8fd8-b3f0" type="profile"/>
+        <infoLink id="2829-acbe-b204-b6b5" name="Storm Troopers" hidden="false" targetId="4406-f18f-b2df-5f01" type="profile"/>
+        <infoLink id="597a-ecde-b2cf-2a3e" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="19a5-02dd-8c60-2dad" name="New CategoryLink" hidden="false" targetId="218e-c8a1-cea3-8377" primary="false"/>
         <categoryLink id="aa86-0282-c675-3f97" name="Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
         <categoryLink id="57b6-3a19-3363-ef4d" name="Faction: Militarum Tempestus" hidden="false" targetId="3984-854b-4603-be64" primary="false"/>
         <categoryLink id="05ca-d597-cb42-13ee" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
-        <categoryLink id="ce3f-d9f0-54f5-fdde" name="Tempestus Command Squad" hidden="false" targetId="f0fa-71b1-5ec2-e534" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="9af0-2061-d963-dc8d" name="Tempestor Prime" page="0" hidden="false" collective="false" import="true" type="model">
+          <modifiers>
+            <modifier type="append" field="name" value="[Legends]">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="self" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6ea7-1195-7144-438e" type="atLeast"/>
+                    <condition field="selections" scope="self" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3292-34e6-f679-d5b9" type="atLeast"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8295-f2ec-e3f8-3a4d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30f2-5b1a-a0c6-3057" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="b069-d01b-fb41-6f25" name="Tempestor Prime" publicationId="53e9d88f--pubN88319" page="39" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+              <characteristics>
+                <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
+                <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
+                <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
+                <characteristic name="W" typeId="f330-5e6e-4110-0978">4</characteristic>
+                <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">3</characteristic>
+                <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">8</characteristic>
+                <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">4+</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="71b1-b236-5150-2546" name="Voice of Command" publicationId="e831-8627-fbc7-5b35" page="75" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+              <characteristics>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Commanding Authority: The Tempestor Prime model knows Regimental Orders. In your command phase, it can issue one order.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="33a7-3db7-3c7a-c8aa" name="Aerial Drop" hidden="false" targetId="0a6c-a8e0-8fd8-b3f0" type="profile"/>
+            <infoLink id="99c5-2c8e-cbd8-e81c" name="Refractor Field" hidden="false" targetId="783d-d067-2d7f-d2a1" type="profile"/>
+          </infoLinks>
+          <categoryLinks>
+            <categoryLink id="f516-a45f-7b1d-f3fb" name="Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+            <categoryLink id="fdb5-971d-19ee-152b" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
+            <categoryLink id="5ea6-4ac0-c519-f6d8" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
+            <categoryLink id="1eb0-f3ce-18dd-b4bc" name="Faction: Militarum Tempestus" hidden="false" targetId="3984-854b-4603-be64" primary="false"/>
+            <categoryLink id="0c45-f24a-1b14-c0c5" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+            <categoryLink id="6fd7-bf47-eea6-e071" name="Officer" hidden="false" targetId="dd6e-7055-ca6b-b711" primary="false"/>
+            <categoryLink id="04b7-e1f9-c23d-c89d" name="Tempestor Prime" hidden="false" targetId="2aba-e4e7-1d91-1a77" primary="false"/>
+          </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="116c-480b-6d1c-2156" name="Bolt Pistol" hidden="false" collective="false" import="true" defaultSelectionEntryId="1948-d51a-67d2-3e0a">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b74e-34ec-aabb-6678" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e12-e0f1-886a-8475" type="min"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="1948-d51a-67d2-3e0a" name="Bolt Pistol" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bdb7-e7c7-4204-4ed5" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="595b-6387-6925-0b4e" name="Bolt pistol" hidden="false" targetId="e6d5-677a-d8ed-f6a5" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="eccd-9020-76f8-8f84" name="Plasma Pistol" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="points" value="5.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e29-6096-fc9a-b6ba" type="max"/>
+                  </constraints>
+                  <infoLinks>
+                    <infoLink id="d6a0-147d-c043-5d6f" name="Plasma pistol, Standard" hidden="false" targetId="ff12-161a-ca85-339f" type="profile"/>
+                    <infoLink id="daa8-e049-40c0-515f" name="Plasma pistol, Supercharge" hidden="false" targetId="5779-2931-fe17-2b27" type="profile"/>
+                  </infoLinks>
+                  <costs>
+                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="bbfa-3d51-f820-be11" name="Tempestus Command Rod" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="points" value="5.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1b7-f793-97b2-7c9e" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="216e-e294-a37f-0944" name="Tempestus Command Rod" publicationId="e831-8627-fbc7-5b35" page="77" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+                      <characteristics>
+                        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">The bearer knows Prefectus Orders in addition to Regimental Orders. The bearer can only issue Prefectus Orders to TEMPESTUS SCIONS units, when doing so, for the purposes of the Regimental Tactics ability, you can only select other friendly TEMPESTUS SCIONS units within 6&quot; of the unit originally selected for that Order to also be affected by that Order.
+
+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <costs>
+                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="8866-d90f-5ae3-cc56" name="Hot-shot Laspistol" hidden="false" collective="false" import="true" targetId="be4e-87d9-3bb2-4ecd" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="0.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0aec-29e1-7327-1dc6" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="1d49-bf6b-6259-9e1d" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3a6-6b0c-c4cf-9e29" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f130-7ac9-613e-7ae3" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="b967-d8db-a4fd-c33d" name="Display Astra Militarum Orders" hidden="false" collective="false" import="true" targetId="af30-711d-1707-fcdc" type="selectionEntry"/>
+            <entryLink id="d1c0-2fc2-ef52-8e4e" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
+            <entryLink id="d97d-c9fa-12ad-8419" name="Heirlooms of Conquest" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup"/>
+            <entryLink id="1342-39cf-ec78-9ef2" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
+            <entryLink id="bca2-268b-0a51-cfe6" name="Field Commander" hidden="false" collective="false" import="true" targetId="c7d5-e7b4-87d5-c29a" type="selectionEntry"/>
+            <entryLink id="231e-02c5-7d4c-fdd1" name="Character Stratagems" hidden="false" collective="false" import="true" targetId="2527-4b0c-1e18-38b3" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
       <selectionEntryGroups>
         <selectionEntryGroup id="75fd-17d6-d4fa-6ddd" name="Scions" hidden="false" collective="false" import="true" defaultSelectionEntryId="ef90-654a-a62f-cd85">
           <constraints>
@@ -15197,102 +15932,31 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
             <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3ae6-f05b-ac5a-ace5" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="ef90-654a-a62f-cd85" name="Tempestus Scion" page="0" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="ef90-654a-a62f-cd85" name="Tempestus Scion" page="0" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a8f9-7ebf-1439-5cb9" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="3e35-b78f-745d-1429" name="Tempestus Scion" hidden="false" targetId="f51905c4-7ffb-3a41-ad86-de14eba93ba3" type="profile"/>
               </infoLinks>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="9876-78a5-eb96-c1c6" name="Hotshot Lasgun" hidden="false" collective="false" import="true" defaultSelectionEntryId="f518-47f8-5302-48e1">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c96-79ec-aa0a-062e" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54d7-0ad7-e250-9570" type="min"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="eecd-e2d2-9ee0-1c5a" name="Grenade Launcher" hidden="false" collective="false" import="true" type="upgrade">
-                      <modifiers>
-                        <modifier type="set" field="points" value="5.0"/>
-                      </modifiers>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d46f-251f-9020-4cbc" type="max"/>
-                      </constraints>
-                      <profiles>
-                        <profile id="8253-e2bb-c19f-778b" name="Grenade Launcher (Frag)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-                          <characteristics>
-                            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
-                            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault D6</characteristic>
-                            <characteristic name="S" typeId="59b1-319e-ec13-d466">3</characteristic>
-                            <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
-                            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
-                            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast.</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile id="5a52-456d-41e2-1381" name="Grenade Launcher (Krak)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-                          <characteristics>
-                            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
-                            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault 1</characteristic>
-                            <characteristic name="S" typeId="59b1-319e-ec13-d466">6</characteristic>
-                            <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
-                            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
-                            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"/>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <costs>
-                        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                        <cost name="pts" typeId="points" value="5.0"/>
-                        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <entryLinks>
-                    <entryLink id="4f48-f22a-75fc-dda1" name="Plasma gun" hidden="false" collective="false" import="true" targetId="8c14-22cc-93ce-b85a" type="selectionEntry">
-                      <modifiers>
-                        <modifier type="set" field="points" value="10.0"/>
-                      </modifiers>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06f4-2beb-9d48-1d61" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="97f2-fbf8-0231-6c0b" name="Meltagun" hidden="false" collective="false" import="true" targetId="efc8-c51d-5b02-a3a2" type="selectionEntry">
-                      <modifiers>
-                        <modifier type="set" field="points" value="10.0"/>
-                      </modifiers>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="461d-9f0d-4f7b-0d1a" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="3d38-c092-55b3-ff27" name="Flamer" hidden="false" collective="false" import="true" targetId="fd22-6743-2d4c-dd62" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b06-8bd2-574e-f9ef" type="max"/>
-                      </constraints>
-                      <costs>
-                        <cost name="pts" typeId="points" value="5.0"/>
-                      </costs>
-                    </entryLink>
-                    <entryLink id="f518-47f8-5302-48e1" name="Hot-Shot Lasgun" hidden="false" collective="false" import="true" targetId="5188-4b26-73ac-1160" type="selectionEntry">
-                      <modifiers>
-                        <modifier type="set" field="points" value="0"/>
-                      </modifiers>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5e3-5ba2-1fff-0a46" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="6e69-1992-ee87-b434" name="Hot-shot Volley Gun" hidden="false" collective="false" import="true" targetId="5d8d-f53d-1a4c-fabb" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="400e-4e97-8db2-b1a8" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
+              <categoryLinks>
+                <categoryLink id="f52c-e623-84e1-6743" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+                <categoryLink id="c994-90ea-1335-f016" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+              </categoryLinks>
               <entryLinks>
                 <entryLink id="f350-fa46-e4e8-7e7e" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96a5-0625-511a-5fcf" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a47-e25b-0354-e2c9" type="min"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="cc62-210f-a10e-f78f" name="Hot-Shot Lasgun" hidden="false" collective="false" import="true" targetId="5188-4b26-73ac-1160" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="0.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2ac-e7f9-fa08-df54" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fba5-9d4b-3e47-d767" type="min"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -15302,32 +15966,32 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="7d52-314d-5403-d56f" name="Tempestus Scion w/ Vox-caster" page="0" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="7d52-314d-5403-d56f" name="Tempestus Scion w/ Master Vox" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0ba1-b605-fca6-ce80" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="0d80-78eb-d4af-62d1" name="Tempestus Scion" hidden="false" targetId="f51905c4-7ffb-3a41-ad86-de14eba93ba3" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink id="ad90-933d-c513-db29" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+                <categoryLink id="480c-ef7b-7bca-8cfd" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+                <categoryLink id="5f86-8ee8-e9f5-654b" name="Vox-Caster" hidden="false" targetId="086d-e3ba-a17b-01bd" primary="false"/>
+              </categoryLinks>
               <entryLinks>
-                <entryLink id="9fde-0cbe-8e6a-5a28" name="Vox-caster" hidden="false" collective="false" import="true" targetId="9ce2-5815-93dd-2918" type="selectionEntry">
+                <entryLink id="9fde-0cbe-8e6a-5a28" name="Master Vox" hidden="false" collective="false" import="true" targetId="c218-a3fc-0271-197a" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c84c-5fcb-d234-0b94" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a145-fcb4-490f-2c19" type="min"/>
                   </constraints>
+                  <categoryLinks>
+                    <categoryLink id="4817-0d4e-a1e7-5d01" name="Vox-Caster" hidden="false" targetId="086d-e3ba-a17b-01bd" primary="false"/>
+                  </categoryLinks>
                 </entryLink>
                 <entryLink id="9bd7-c77f-c054-ea02" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e989-70f8-a6f0-fe52" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fee6-3035-1579-33de" type="min"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="2a85-0a3d-3de5-bbe0" name="Hot-Shot Lasgun" hidden="false" collective="false" import="true" targetId="5188-4b26-73ac-1160" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="points" value="0"/>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efde-970d-29ce-f1ac" type="max"/>
                   </constraints>
                 </entryLink>
                 <entryLink id="0f3c-eb49-bf89-0d76" name="Hot-shot Laspistol" hidden="false" collective="false" import="true" targetId="be4e-87d9-3bb2-4ecd" type="selectionEntry">
@@ -15353,6 +16017,11 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
               <infoLinks>
                 <infoLink id="116a-f07a-0afa-6a9f" name="Tempestus Scion" hidden="false" targetId="f51905c4-7ffb-3a41-ad86-de14eba93ba3" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink id="d73a-0cfa-a879-fea6" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+                <categoryLink id="563d-7d7e-3027-0ea6" name="Medic" hidden="false" targetId="f89d-fb99-97ed-bc39" primary="false"/>
+                <categoryLink id="5d03-8e27-a721-6fba" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+              </categoryLinks>
               <entryLinks>
                 <entryLink id="a073-5b6e-1333-3ea3" name="Medi-pack" hidden="false" collective="false" import="true" targetId="1443-a52b-6953-c648" type="selectionEntry">
                   <constraints>
@@ -15364,14 +16033,6 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="82b7-f64e-5c8e-4cc4" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96f7-756f-3c08-8db7" type="min"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="128e-e2bc-8b2e-706b" name="Hot-Shot Lasgun" hidden="false" collective="false" import="true" targetId="5188-4b26-73ac-1160" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="points" value="0"/>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06bc-abcb-87cb-e9db" type="max"/>
                   </constraints>
                 </entryLink>
                 <entryLink id="b878-0bed-0738-6f3b" name="Hot-shot Laspistol" hidden="false" collective="false" import="true" targetId="be4e-87d9-3bb2-4ecd" type="selectionEntry">
@@ -15390,26 +16051,27 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="a7b7-b474-c07a-101f" name="Tempestus Scion w/ Platoon Standard" page="0" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="a7b7-b474-c07a-101f" name="Tempestus Scion w/ Regimental Standard" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="811d-81ef-efb5-ea26" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="3578-5a68-2ab2-e493" name="Tempestus Scion" hidden="false" targetId="f51905c4-7ffb-3a41-ad86-de14eba93ba3" type="profile"/>
               </infoLinks>
+              <categoryLinks>
+                <categoryLink id="b0d2-e134-d490-c9f4" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+                <categoryLink id="c75f-e148-7010-fa0e" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+              </categoryLinks>
               <selectionEntries>
-                <selectionEntry id="8e26-a9e2-f3f8-b16a" name="Platoon Standard" hidden="false" collective="false" import="true" type="upgrade">
+                <selectionEntry id="8e26-a9e2-f3f8-b16a" name="Regimental Standard" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7c0e-b713-a826-238f" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="153b-f0b9-34da-5e9b" type="max"/>
                   </constraints>
-                  <profiles>
-                    <profile id="49ca-6f70-ecc3-1fa6" name="Platoon Standard" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-                      <characteristics>
-                        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">All MILITARUM TEMPESTUS within 6&quot; of any friendly units with a platoon standard may add 1 to their Leadership when taking morale tests</characteristic>
-                      </characteristics>
-                    </profile>
-                  </profiles>
+                  <infoLinks>
+                    <infoLink id="9e7e-e0e8-a82f-6e8b" name="Regimental Standard " hidden="false" targetId="0456-0086-5490-3e04" type="profile"/>
+                    <infoLink id="ac4d-b96c-afd8-6ed6" name="Regimental Standard (Aura)" hidden="false" targetId="eb4d-1660-544a-18db" type="profile"/>
+                  </infoLinks>
                   <costs>
                     <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
                     <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
@@ -15418,19 +16080,221 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 </selectionEntry>
               </selectionEntries>
               <entryLinks>
-                <entryLink id="d6f6-c947-4900-96c7" name="Hot-Shot Lasgun" hidden="false" collective="false" import="true" targetId="5188-4b26-73ac-1160" type="selectionEntry">
-                  <modifiers>
-                    <modifier type="set" field="points" value="0"/>
-                  </modifiers>
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3fa-a506-35d4-d15e" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e6a-28cf-f011-32ac" type="min"/>
-                  </constraints>
-                </entryLink>
                 <entryLink id="148b-a7d9-0dc1-8a31" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="229f-a690-a7b6-50fe" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9e0c-10f5-9726-bf92" type="min"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="1a63-b0c4-e480-ab73" name="Hot-Shot Lasgun" hidden="false" collective="false" import="true" targetId="5188-4b26-73ac-1160" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8e8-7bd7-6e98-2d44" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03e8-f0ed-de00-8db8" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5b18-fec0-61d2-0ac7" name="Tempestus Scion w/ Flamer" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cdf9-6e92-4b15-155b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7fbc-502c-deae-09cf" name="Tempestus Scion" hidden="false" targetId="f51905c4-7ffb-3a41-ad86-de14eba93ba3" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="3739-86c2-781a-69ad" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+                <categoryLink id="1729-3071-1af5-31a1" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="e973-e125-df5c-e482" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0464-b8d1-7d74-2110" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="10e1-5afe-3abd-8b55" type="min"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="c79a-8484-452b-7cbe" name="Flamer" hidden="false" collective="false" import="true" targetId="fd22-6743-2d4c-dd62" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="0.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="aeeb-d5d7-3357-e9a2" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3519-2371-3e64-571e" type="min"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="306f-fb2c-c059-70a8" name="Tempestus Scion w/ Grenade Launcher" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a01a-17b1-8c6b-1106" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7808-7c65-1c18-10a6" name="Tempestus Scion" hidden="false" targetId="f51905c4-7ffb-3a41-ad86-de14eba93ba3" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="775e-f729-1ce8-63b7" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+                <categoryLink id="6c7d-120b-8b5e-f5c6" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+              </categoryLinks>
+              <selectionEntries>
+                <selectionEntry id="a4a7-7ef4-9e03-ecd1" name="Grenade Launcher" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="points" value="0.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b6d-eba7-cd82-2e1d" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4161-83cf-4923-d180" type="min"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="796e-10ac-65cc-ab31" name="Grenade Launcher (Frag)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+                        <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault D6</characteristic>
+                        <characteristic name="S" typeId="59b1-319e-ec13-d466">3</characteristic>
+                        <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
+                        <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+                        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast.</characteristic>
+                      </characteristics>
+                    </profile>
+                    <profile id="cd6a-500e-b64d-afbc" name="Grenade Launcher (Krak)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+                        <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault 1</characteristic>
+                        <characteristic name="S" typeId="59b1-319e-ec13-d466">6</characteristic>
+                        <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
+                        <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
+                        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"/>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <costs>
+                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+              <entryLinks>
+                <entryLink id="d053-df0f-a1aa-5336" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cf2b-5408-20ca-b9db" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4760-25da-4e08-2ebd" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="e4b7-d891-fcfc-1651" name="Tempestus Scion w/ Hot-Shot Volley Gun" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fe41-1870-c75c-478e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="23bd-5484-0fe9-be9d" name="Tempestus Scion" hidden="false" targetId="f51905c4-7ffb-3a41-ad86-de14eba93ba3" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="f26c-9f7d-76d7-7f2a" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+                <categoryLink id="280c-21e3-2f5e-d618" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="8a7d-0eac-4c07-7690" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e70-e889-ed9d-504a" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afa1-0ae7-274c-6892" type="min"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="f24e-e3de-43b5-88c2" name="Hot-shot Volley Gun" hidden="false" collective="false" import="true" targetId="5d8d-f53d-1a4c-fabb" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="0.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="493d-0d3a-19a8-9aba" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="654a-38c1-e41a-ce07" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="5ca0-7dc4-c5f3-0cd5" name="Tempestus Scion w/ Meltagun" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f462-04ff-c149-6a95" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="6f8b-d4a9-e408-6630" name="Tempestus Scion" hidden="false" targetId="f51905c4-7ffb-3a41-ad86-de14eba93ba3" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="4155-c452-d7e7-8694" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+                <categoryLink id="6a37-2819-b14a-4278" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="7411-fa1d-28fd-e0eb" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d887-c195-0cab-ff29" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7806-f3af-419c-1667" type="min"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="5dc7-5801-1488-13a4" name="Meltagun" hidden="false" collective="false" import="true" targetId="efc8-c51d-5b02-a3a2" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="0.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a651-9bb9-2716-9bec" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e78f-bcdc-4f02-b2b2" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="6003-69bd-16ee-33a3" name="Tempestus Scion w/ Plasma gun" page="0" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d6aa-6a6a-e9a7-94d8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="dde7-4cad-023c-595d" name="Tempestus Scion" hidden="false" targetId="f51905c4-7ffb-3a41-ad86-de14eba93ba3" type="profile"/>
+              </infoLinks>
+              <categoryLinks>
+                <categoryLink id="17b0-be80-f3bc-1df2" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+                <categoryLink id="d987-8966-d86c-8e56" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+              </categoryLinks>
+              <entryLinks>
+                <entryLink id="158e-0956-6dde-7e6b" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d8b2-b05a-c4a5-1203" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="656b-82b4-06a8-bd92" type="min"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="a8b6-229e-76ec-80b9" name="Plasma gun" hidden="false" collective="false" import="true" targetId="8c14-22cc-93ce-b85a" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="0.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="5163-1bd8-351e-e9c3" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53ea-7758-6faf-55a3" type="min"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -15444,8 +16308,8 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         </selectionEntryGroup>
       </selectionEntryGroups>
       <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="3.0"/>
-        <cost name="pts" typeId="points" value="40.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
+        <cost name="pts" typeId="points" value="95.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -15471,7 +16335,6 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         <infoLink id="37a9-2720-356a-3538" name="Aerial Drop" hidden="false" targetId="0a6c-a8e0-8fd8-b3f0" type="profile"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="574c-9613-dd4e-f801" name="New CategoryLink" hidden="false" targetId="218e-c8a1-cea3-8377" primary="false"/>
         <categoryLink id="25fd-b542-b5bb-9ca2" name="Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
         <categoryLink id="0039-65fc-1d48-34e7" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
         <categoryLink id="9386-11d9-e83e-79bc" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
@@ -15583,7 +16446,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2c60-ffd7-db28-6d09" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="5896-2106-ef48-b180" hidden="false" targetId="f51905c4-7ffb-3a41-ad86-de14eba93ba3" type="profile"/>
+                <infoLink id="5896-2106-ef48-b180" name="Tempestus Scion" hidden="false" targetId="f51905c4-7ffb-3a41-ad86-de14eba93ba3" type="profile"/>
               </infoLinks>
               <selectionEntryGroups>
                 <selectionEntryGroup id="5ff2-6f7e-20d7-dff0" name="Special Weapon" hidden="false" collective="false" import="true">
@@ -15751,155 +16614,6 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="3.0"/>
         <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="2dd7-6771-c9ba-cdb4" name="Tempestor Prime" page="0" hidden="false" collective="false" import="true" type="model">
-      <modifiers>
-        <modifier type="append" field="name" value="[Legends]">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="self" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6ea7-1195-7144-438e" type="atLeast"/>
-                <condition field="selections" scope="self" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3292-34e6-f679-d5b9" type="atLeast"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <profiles>
-        <profile id="8a4f-a5ba-48b8-8565" name="Tempestor Prime" publicationId="53e9d88f--pubN88319" page="39" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
-          <characteristics>
-            <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
-            <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
-            <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
-            <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
-            <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
-            <characteristic name="W" typeId="f330-5e6e-4110-0978">4</characteristic>
-            <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">3</characteristic>
-            <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">8</characteristic>
-            <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">4+</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <infoLinks>
-        <infoLink id="c1c5-faf0-4814-0178" name="Aerial Drop" hidden="false" targetId="0a6c-a8e0-8fd8-b3f0" type="profile"/>
-        <infoLink id="fd0c-1e7b-7fe5-df88" name="Voice of Command" hidden="false" targetId="2ff26b94-8048-d15d-c541-fd4da0f49571" type="profile"/>
-      </infoLinks>
-      <categoryLinks>
-        <categoryLink id="e44d-e3b9-0df4-79c4" name="New CategoryLink" hidden="false" targetId="218e-c8a1-cea3-8377" primary="false"/>
-        <categoryLink id="81e8-a54f-f2d8-2d30" name="Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
-        <categoryLink id="4f79-e870-2794-7aa2" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
-        <categoryLink id="1dac-dd08-0de3-f801" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
-        <categoryLink id="4a18-0336-8816-a0b5" name="Faction: Militarum Tempestus" hidden="false" targetId="3984-854b-4603-be64" primary="false"/>
-        <categoryLink id="fe0d-85a6-2e0e-8d5e" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
-        <categoryLink id="70fc-e851-37c1-3afc" name="Officer" hidden="false" targetId="dd6e-7055-ca6b-b711" primary="false"/>
-        <categoryLink id="b64b-bd2f-b330-4c02" name="Tempestor Prime" hidden="false" targetId="2aba-e4e7-1d91-1a77" primary="false"/>
-      </categoryLinks>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="f423-b1d0-17e1-8189" name="Hot-shot Laspistol" hidden="false" collective="false" import="true" defaultSelectionEntryId="6e1c-77d3-2519-04aa">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dc98-9aad-ed39-b34b" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6721-18e1-ef6f-e17d" type="min"/>
-          </constraints>
-          <selectionEntries>
-            <selectionEntry id="7bd7-1db9-58f8-6729" name="Bolt Pistol" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0e80-42d1-e7f4-95d2" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="fb70-9e22-18ed-0ed3" name="Bolt pistol" hidden="false" targetId="e6d5-677a-d8ed-f6a5" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="65e9-2cf9-5e63-6bb9" name="Plasma Pistol" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d534-0096-d6fe-cfb3" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="753a-3000-efcf-e09a" name="New InfoLink" hidden="false" targetId="ff12-161a-ca85-339f" type="profile"/>
-                <infoLink id="afa2-f658-4420-292b" name="New InfoLink" hidden="false" targetId="5779-2931-fe17-2b27" type="profile"/>
-              </infoLinks>
-              <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6cf3-e842-f637-beff" name="Tempestus Command Rod" hidden="false" collective="false" import="true" type="upgrade">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3902-776f-3b44-2129" type="max"/>
-              </constraints>
-              <profiles>
-                <profile id="ec90-0e46-3ddb-fef5" name="Tempestus Command Rod" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-                  <characteristics>
-                    <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">A model with a Tempestus command rod may use the Voice of Command ability twice in each of your turns.  Resolve the effects of the first order before issuing the second.</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-          </selectionEntries>
-          <entryLinks>
-            <entryLink id="6e1c-77d3-2519-04aa" name="Hot-shot Laspistol" hidden="false" collective="false" import="true" targetId="be4e-87d9-3bb2-4ecd" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="points" value="0.0"/>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47c2-6f86-97c5-f5a9" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-        <selectionEntryGroup id="cd8f-9187-9a7f-7a92" name="Chainsword" hidden="false" collective="false" import="true" defaultSelectionEntryId="76ed-9a1e-0e12-e5a7">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1992-44f7-127a-cf52" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="5708-feae-6ba8-4a93" name="Astra Militarum Melee Weapons" hidden="false" collective="false" import="true" targetId="7622-e68e-c5e5-c8e7" type="selectionEntryGroup"/>
-            <entryLink id="76ed-9a1e-0e12-e5a7" name="Chainsword" hidden="false" collective="false" import="true" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1bde-c7f3-2251-0502" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="1c1f-549d-1510-c47b" name="Power axe" hidden="false" collective="false" import="true" targetId="3292-34e6-f679-d5b9" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94ce-7ce5-cd99-abc1" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="0334-b170-5fc3-9536" name="Power maul" hidden="false" collective="false" import="true" targetId="6ea7-1195-7144-438e" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e6e3-2522-6641-97b3" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
-      <entryLinks>
-        <entryLink id="eb50-ba66-2c19-3948" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bfbf-5a60-6278-1958" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b74-4b7c-a010-92cf" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="77d7-a4be-2079-be85" name="Display Astra Militarum Orders" hidden="false" collective="false" import="true" targetId="af30-711d-1707-fcdc" type="selectionEntry"/>
-        <entryLink id="d53b-bd1e-c144-5a07" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
-        <entryLink id="b757-43e5-a78c-ba5d" name="Heirlooms of Conquest" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup"/>
-        <entryLink id="9e85-2d87-283e-6548" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
-        <entryLink id="75db-a198-586d-bf84" name="Field Commander" hidden="false" collective="false" import="true" targetId="c7d5-e7b4-87d5-c29a" type="selectionEntry"/>
-        <entryLink id="ab36-6302-57bc-ef59" name="Character Stratagems" hidden="false" collective="false" import="true" targetId="2527-4b0c-1e18-38b3" type="selectionEntryGroup"/>
-      </entryLinks>
-      <costs>
-        <cost name="pts" typeId="points" value="40.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="3.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -16630,12 +17344,15 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
       </costs>
     </selectionEntry>
     <selectionEntry id="0fcd-d6ee-231e-920e" name="Lord Solar Leontus" hidden="false" collective="false" import="true" type="model">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0428-37ce-a41a-d05c" type="max"/>
+      </constraints>
       <profiles>
         <profile id="13eb-694f-b1b9-3f5b" name="Lord Solar Leontus" publicationId="e831-8627-fbc7-5b35" page="79" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
-            <characteristic name="M" typeId="0bdf-a96e-9e38-7779">12</characteristic>
-            <characteristic name="WS" typeId="e7f0-1278-0250-df0c">2</characteristic>
-            <characteristic name="BS" typeId="381b-eb28-74c3-df5f">2</characteristic>
+            <characteristic name="M" typeId="0bdf-a96e-9e38-7779">12&quot;</characteristic>
+            <characteristic name="WS" typeId="e7f0-1278-0250-df0c">2+</characteristic>
+            <characteristic name="BS" typeId="381b-eb28-74c3-df5f">2+</characteristic>
             <characteristic name="S" typeId="2218-aa3c-265f-2939">6</characteristic>
             <characteristic name="T" typeId="9c9f-9774-a358-3a39">4</characteristic>
             <characteristic name="W" typeId="f330-5e6e-4110-0978">8</characteristic>
@@ -16656,17 +17373,12 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         </profile>
         <profile id="16d5-dae6-27c5-23ab" name="Lord Commander Solar" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228"/>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Lord Commander Solar: In your Command phase, you can select one friendly ASTRA MILITARUM CORE, ASTRA MILITARUM CHARACTER or ASTRA MILITARUM BATTLE TANK unit within 6&quot; of this model. Until the start of your next Command phase, each time a model in that unit makes an attack, you can re-roll the hit roll (if that unit is a CORE unit, you can also re-roll the wound roll).</characteristic>
           </characteristics>
         </profile>
         <profile id="e7b0-6320-2fc1-b382" name="Heroic Senior Officer (Aura)" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228"/>
-          </characteristics>
-        </profile>
-        <profile id="4736-1106-28ba-7ccd" name="Commanding Authority" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-          <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228"/>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Heroic Senior Officer (Aura): While a friendly ASTRA MILITARUM CORE unit is within 6&quot; of this model, each time a model in that unit makes an attack, re-roll a hit roll of 1 and re-roll a wound roll of 1.</characteristic>
           </characteristics>
         </profile>
         <profile id="7f90-e47c-5bd0-129e" name="Sol&apos;s Righteous Gaze" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
@@ -16689,12 +17401,31 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
             <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"/>
           </characteristics>
         </profile>
+        <profile id="20d4-324b-c15c-8a48" name="Voice of Command" publicationId="e831-8627-fbc7-5b35" page="79" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Commanding Authority: This model knows Regimental Orders, Prefectus Orders and Mechanised Orders . In your Command phase, it can issue up to three Orders. In addition to the normal units that can be selected for Regimental and Prefectus Orders, this model can issue Regimental and Prefectus Orders to friendly INFANTRY OFFICER and MILITARUM AUXILLA units. In addition to the normal units that can be selected for Mechanised Orders, this model can issue Mechanised Orders to friendly VEHICLE OFFICER and SUPER-HEAVY units.
+
+</characteristic>
+          </characteristics>
+        </profile>
       </profiles>
+      <infoLinks>
+        <infoLink id="919a-3d34-6cf4-5ab2" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+      </infoLinks>
       <categoryLinks>
-        <categoryLink id="a45d-ddc2-1479-6f29" name="HQ" hidden="false" targetId="848a6ff2-0def-4c72-8433-ff7da70e6bc7" primary="true"/>
+        <categoryLink id="8fed-d0c2-1ecd-e848" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
+        <categoryLink id="4006-744c-462b-a1ab" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="8a44-8f4d-a763-e7e1" name="Cavalry" hidden="false" targetId="ad01-caec-17d9-cb8d" primary="false"/>
+        <categoryLink id="4b51-116e-6f6e-f76c" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
+        <categoryLink id="7413-e7d3-ecdd-a021" name="Supreme Commander" hidden="false" targetId="5750-de0a-589d-eacf" primary="false"/>
+        <categoryLink id="8f8c-ddea-0d22-cb64" name="Officer" hidden="false" targetId="dd6e-7055-ca6b-b711" primary="false"/>
+        <categoryLink id="864c-22ae-e599-3254" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+        <categoryLink id="6f9c-f04a-08d0-8499" name="Lord Solar Leontus" hidden="false" targetId="c6c7-5322-42d3-0d07" primary="false"/>
       </categoryLinks>
       <entryLinks>
         <entryLink id="764b-6320-991f-62b1" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
+        <entryLink id="6711-2876-2277-c45c" name="Warlord Traits (Named)" hidden="false" collective="false" import="true" targetId="6871-2805-7938-980c" type="selectionEntryGroup"/>
+        <entryLink id="36f1-de1f-d97e-d294" name="Character Stratagems (Named)" hidden="false" collective="false" import="true" targetId="ed7a-3deb-4d62-b2a9" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="9.0"/>
@@ -16704,7 +17435,6 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
     </selectionEntry>
     <selectionEntry id="0609-08fb-cd8a-8b1e" name="Kasrkin" page="0" hidden="false" collective="false" import="true" type="unit">
       <categoryLinks>
-        <categoryLink id="49af-af1f-afcc-116b" name="New CategoryLink" hidden="false" targetId="218e-c8a1-cea3-8377" primary="false"/>
         <categoryLink id="431c-3750-bbb6-8db1" name="Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
         <categoryLink id="1a58-7c34-dbe7-8ff7" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
         <categoryLink id="a27f-ee25-80ca-ff4e" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
@@ -17086,6 +17816,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         <infoLink id="9951-8504-4c92-09f4" name="Explodes (6+/6&quot;/D6)" hidden="false" targetId="7525-aa8c-bea2-9691" type="profile"/>
         <infoLink id="b05c-b12f-7578-9579" name="Heavy stubber" hidden="false" targetId="0031-0314-5b36-a220" type="profile"/>
         <infoLink id="61dd-e723-bd4c-d490" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
+        <infoLink id="1b46-128c-efaf-0bd7" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8363-d9d5-78fd-6eb6" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
@@ -17703,7 +18434,6 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
     </selectionEntry>
     <selectionEntry id="6d9f-b8f6-f2f7-b8be" name="Valkyrie" publicationId="e831-8627-fbc7-5b35" page="113" hidden="false" collective="false" import="true" type="model">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fda7-cffd-c759-be3c" type="min"/>
         <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e5c-6a3d-3e06-578f" type="max"/>
       </constraints>
       <profiles>
@@ -17874,6 +18604,142 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
+    <selectionEntry id="53ba-61e3-806e-9f94" name="&apos;Iron Hand&apos; Straken" publicationId="53e9d88f--pubN88319" page="57" hidden="false" collective="false" import="true" type="model">
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e50d-bb2b-bae4-ec71" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="4e96-41f4-2d32-b97a" name="&apos;Iron Hand&apos; Straken" publicationId="53e9d88f--pubN88319" page="57" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+          <characteristics>
+            <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+            <characteristic name="WS" typeId="e7f0-1278-0250-df0c">2+</characteristic>
+            <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
+            <characteristic name="S" typeId="2218-aa3c-265f-2939">6</characteristic>
+            <characteristic name="T" typeId="9c9f-9774-a358-3a39">4</characteristic>
+            <characteristic name="W" typeId="f330-5e6e-4110-0978">5</characteristic>
+            <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">6</characteristic>
+            <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">9</characteristic>
+            <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">3+</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="f471-2b7c-8c56-ddec" name="Been There, Seen It, Killed It" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time this model makes a melee attack against  an enemy MONSTER unit, you can re-roll the wound roll.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="6700-510a-bd7c-41f7" name="Cold Steel and Courage" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time this model issues an Order to a unit, until the start of your next Command phase, each time a model in that unit makes a melee attack, unless the target of that attack is a VEHICLE unit, an unmodified hit roll of 6 automatically wounds the target. Note that this ability only affects the original target of that Order, and not any additional units that are affected by that Order using the Regimental Tactics ability.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="9845-993a-ee3a-6a13" name="Extensive Bionics" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model has a 4+ invulnerable save.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="2059-d184-10f6-51e8" name="Voice of Command" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Commanding Authority: This model knows Regimental Orders. In your Command phase, it can issue up to two Orders</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="8654-9afa-0409-880a" name="Senior Officer (Aura)" hidden="false" targetId="f34c8090-4e32-bd27-df37-1b714a4288d2" type="profile"/>
+        <infoLink id="6ab5-ced6-74f9-3026" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="acbe-6971-042d-8483" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
+        <categoryLink id="4762-d6b9-1b00-77b0" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
+        <categoryLink id="addc-c466-6278-b53f" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+        <categoryLink id="34f5-0306-ddbf-591e" name="Officer" hidden="false" targetId="dd6e-7055-ca6b-b711" primary="false"/>
+        <categoryLink id="b5f1-0235-75a9-77ce" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="e634-567d-c7e2-7e18" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+        <categoryLink id="fcc5-8a2e-88e5-cbc6" name="Colonel &apos;Iron Hand&apos; Straken" hidden="false" targetId="9145-1d3b-9057-7a17" primary="false"/>
+        <categoryLink id="88f2-c35b-ec17-29f4" name="Faction: Catachan" hidden="false" targetId="6218-425e-33cf-6ec3" primary="false"/>
+        <categoryLink id="30b8-1957-3395-6b8f" name="Commandant" hidden="false" targetId="b0a3-c8e2-b036-6794" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="b86e-b011-fe4c-67b0" name="Bionic Arm with Devil&apos;s Claw" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c658-3411-528e-4cdb" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9541-ab15-5a66-dd90" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f858-ce15-7618-a05f" name="Bionic Arm with Devil&apos;s Claw" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">-</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Melee</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">User</characteristic>
+                <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="279f-ccea-94d1-2eac" name="Auto Shotgun" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="badf-1787-46b4-18dd" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec44-cf47-35a8-c4d7" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="c433-6107-9a94-3f83" name="Auto Shotgun" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">12&quot;</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault 3</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
+                <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="e0c6-ab7b-2a82-693d" name="Plasma pistol" hidden="false" collective="false" import="true" targetId="83be-1ba9-c326-4760" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="0.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="58bd-1a1c-ad0d-a2bc" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f6f-c409-2363-fa40" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="9126-af7d-9fbf-9d08" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="bb78-534a-7b77-edbc" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c19-0fef-35ae-2411" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1db2-5ea9-0d85-2a0b" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="71a2-db7e-627c-917d" name="Display Regimental Orders" hidden="false" collective="false" import="true" targetId="af30-711d-1707-fcdc" type="selectionEntry"/>
+        <entryLink id="2a3a-142e-760f-f4fd" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
+        <entryLink id="c1e0-780f-1a19-71c5" name="Character Stratagems (Named)" hidden="false" collective="false" import="true" targetId="ed7a-3deb-4d62-b2a9" type="selectionEntryGroup"/>
+        <entryLink id="e9c0-7d37-4265-5ba8" name="Warlord Traits (Named)" hidden="false" collective="false" import="true" targetId="6871-2805-7938-980c" type="selectionEntryGroup"/>
+      </entryLinks>
+      <costs>
+        <cost name="pts" typeId="points" value="75.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="c218-a3fc-0271-197a" name="Master Vox" hidden="false" collective="false" import="true" type="upgrade">
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
   </sharedSelectionEntries>
   <sharedSelectionEntryGroups>
     <selectionEntryGroup id="9ef3-0f17-2aeb-436e" name="Astra Militarum Ranged Weapons" hidden="false" collective="false" import="true">
@@ -18004,10 +18870,10 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
               <characteristics>
                 <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">48&quot;</characteristic>
                 <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D6</characteristic>
-                <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">5</characteristic>
                 <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
                 <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
-                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. This weapon can target units that are not visible to the firer.</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. This weapon can target units that are not visible to the bearer.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -18738,7 +19604,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1314-fbc0-86b4-7b7e" type="max"/>
           </constraints>
           <profiles>
-            <profile id="cd33-8078-8da3-64f9" name="5) Mental Fortitude" hidden="false" typeId="ae70-4738-0161-bec0" typeName="Psychic Power">
+            <profile id="cd33-8078-8da3-64f9" name="5) Mental Shackles" hidden="false" typeId="ae70-4738-0161-bec0" typeName="Psychic Power">
               <characteristics>
                 <characteristic name="Warp Charge" typeId="5ffd-b800-c317-532a">6</characteristic>
                 <characteristic name="Range" typeId="fd64-cbc4-94de-24cc">18&quot;</characteristic>
@@ -20261,7 +21127,7 @@ receive the benefits of cover against that attack.&quot;</characteristic>
         </modifier>
       </modifiers>
       <entryLinks>
-        <entryLink id="3755-c8b6-08fe-659c" name="WT (Catachan): Lead From the Front" hidden="false" collective="false" import="true" targetId="1fff-d44f-98e9-609c" type="selectionEntry">
+        <entryLink id="3755-c8b6-08fe-659c" name="WT: Front-Line Combatant" hidden="false" collective="false" import="true" targetId="1fff-d44f-98e9-609c" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="2ef0-4c34-37c7-bffe" value="1.0">
               <conditions>
@@ -20295,8 +21161,6 @@ receive the benefits of cover against that attack.&quot;</characteristic>
                     </conditionGroup>
                     <conditionGroup type="and">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9ef3-50ee-426d-597b" type="notInstanceOf"/>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7014-e6c3-eb98-a590" type="notInstanceOf"/>
                         <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="9145-1d3b-9057-7a17" type="notInstanceOf"/>
                       </conditions>
                     </conditionGroup>
@@ -20448,6 +21312,53 @@ receive the benefits of cover against that attack.&quot;</characteristic>
           <constraints>
             <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea00-935e-6f54-7fc3" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7316-a025-7397-40e1" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="beef-c3c3-7220-3794" name="WT: Grand Strategist" hidden="false" collective="false" import="true" targetId="9f7a-4c34-8d0c-e3c7" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="245a-bd23-be96-5afd" value="1.0">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="871a-0c5d-8d92-cd67" type="equalTo"/>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="6771-6ab3-1672-6a39" type="equalTo"/>
+                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1f07-a468-bda8-fd3f" type="equalTo"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1f07-a468-bda8-fd3f" type="greaterThan"/>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c6c7-5322-42d3-0d07" type="notInstanceOf"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="245a-bd23-be96-5afd" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="119e-4890-781e-4418" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
@@ -20692,16 +21603,14 @@ Spirit of the Martyr: One model in the unit recovers D3 lost wounds, or you can 
         <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model has a 5+ invulnerable save.</characteristic>
       </characteristics>
     </profile>
-    <profile id="f34c8090-4e32-bd27-df37-1b714a4288d2" name="Senior Officer" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+    <profile id="f34c8090-4e32-bd27-df37-1b714a4288d2" name="Senior Officer (Aura)" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
         <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">While a friendly ASTRA MILITARUM CORE unit is within 6&quot; of this model, each time a model in that unit makes an attack, re-roll a hit roll of 1.</characteristic>
       </characteristics>
     </profile>
     <profile id="2ff26b94-8048-d15d-c541-fd4da0f49571" name="Voice of Command" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This unit may issue one order per turn to the soldiers under their command at the start of their Shooting phase. Orders may only be issued to INFANTRY units within 6&quot; of this unit that have the same &lt;REGIMENT&gt; keyword as this unit. To issue an order, pick a target unit and choose which order you wish to issue from the table below. A unit may only be affected by one order per turn.
-
-Each time a &lt;Regiment&gt; unit with the Voice of Command ability issues one of the following orders to a &lt;REGIMENT&gt; INFANTRY unit, that same order can be issued to one or more other friendly &lt;REGIMENT&gt; INFANTRY units (excluding OFFICER units) that are within 6&quot; of the unit that order was originally issued to: Take Aim!; First Rank, Fire! Second Rank, Fire!; Bring it Down!; Forwards, for the Emperor!; Get Back in the Fight!; Fix Bayonets!</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228"/>
       </characteristics>
     </profile>
     <profile id="d4f6537c-b82c-db68-b6d6-03eefe4de298" name="Veteran" publicationId="53e9d88f--pubN88319" page="30" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -20737,7 +21646,8 @@ Each time a &lt;Regiment&gt; unit with the Voice of Command ability issues one o
     </profile>
     <profile id="3508-2ef3-22d7-b5b9" name="Medi-pack" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the end of any of your Movement phases, a model with a medi-pack can attempt to heal a single model.  Select a friendly ASTRA MILITARUM INFANTRY unit within 3&quot; and roll a D6.  On a roll of a 4+, one model in the unit recovers a wound it lost earlier in the battle (if the model has a Wounds characteristic of 1, one model slain earlier in the battle is returned to the unit instead).  A unit can only be the target of this ability once in each turn.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Medi-pack
+The bearer gains the MEDIC keyword. Each time a model in this unit would lose a wound, roll one D6: on a 5+, that wound is not lost.</characteristic>
       </characteristics>
     </profile>
     <profile id="3635-257d-26f1-26e8" name="Guardsman" publicationId="53e9d88f--pubN88319" page="36" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -20783,7 +21693,7 @@ Each time a &lt;Regiment&gt; unit with the Voice of Command ability issues one o
     </profile>
     <profile id="0a6c-a8e0-8fd8-b3f0" name="Aerial Drop" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">During deployment, you can set up this model in a high altitude transport, ready to deploy via grav-chute, instead of placing it on the battlefield.  At the end of any of your movement phases the model can make an aerial drop - set it up anywhere on the battlefield that is more than 9&quot; away from any enemy models.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">During deployment, you can set up this unit high in the skies instead of setting it up on the battlefield. If you do so, then in the Reinforcements step of one of your Movement phases you can set up this unit anywhere on the battlefield that is more than 9&quot; away from any enemy models.</characteristic>
       </characteristics>
     </profile>
     <profile id="59561fd3-8437-5e2e-1080-fe4d29ae4a60" name="Leman Russ" publicationId="e831-8627-fbc7-5b35" page="105" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -20915,8 +21825,8 @@ Each time a &lt;Regiment&gt; unit with the Voice of Command ability issues one o
     </profile>
     <profile id="5826-273f-d8f2-b1d0" name="Hot-Shot Volley Gun" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
       <characteristics>
-        <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
-        <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 4</characteristic>
+        <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">30&quot;</characteristic>
+        <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Rapid Fire 2</characteristic>
         <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
         <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
         <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
@@ -21051,6 +21961,33 @@ Each time a &lt;Regiment&gt; unit with the Voice of Command ability issues one o
         <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If every model from your army (excluding AGENT OF THE IMPERIUM and UNALIGNED models) has the ASTRA MILITARUM keyword:
 • Each time an OFFICER from your army issues a Regimental or Prefectus Order to a unit with this ability, you can select one or more other friendly PLATOON units within 6&quot; of that unit; those PLATOON units are also affected by that Order. 
 • Each time an OFFICER from your army issues a Mechanised Order to a unit with this ability, you can select one or more other friendly SQUADRON units within 6&quot; of that unit; those SQUADRON units are also affected by that Order.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="eb4d-1660-544a-18db" name="Regimental Standard (Aura)" publicationId="e831-8627-fbc7-5b35" page="84" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">While a friendly ASTRA MILITARUM CORE unit is within 6&quot; of the bearer&apos;s unit, each time a model in that ASTRA MILITARUM CORE unit makes an attack, re-roll a wound roll of 1.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="0456-0086-5490-3e04" name="Regimental Standard " hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <modifiers>
+        <modifier type="remove" field="category" value="4c76-2538-8ab3-a595">
+          <conditions>
+            <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="lessThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">The bearer gains the REGIMENTAL STANDARD keyword and the following ability: &apos;Regimental Standard (Aura)</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="09e2-faa3-9206-a45e" name="Master Vox" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">The bearer gains the VOX-CASTER keyword. Each time an OFFICER in the bearer&apos;s unit issues an Order, you can increase the range at which that order can be issued to 24&quot;, but only if you select a friendly VOX-CASTER unit to issue that order to (all other rules for issuing Orders still apply).</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="4406-f18f-b2df-5f01" name="Storm Troopers" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time a model in this unit makes an attack, an unmodified hit roll of 6 scores 1 additional hit.</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>


### PR DESCRIPTION
0.06 - Command Squads and HQs Update 

Added
Profile for Straken's Auto Shotgun
'Display Prefectus Orders'
Attaché keyword
Regimental Tactics Keyword to Rogal Dorn Battle Tank Descriptions, keywords and named character WLT To Lord solar Leontus

Updated
Moved Straken from the Shared Selection Entries section in the Imperial Guard .Cat file over to the library as he is now no longer regiment-locked Straken's loadout and stats
Added the (Aura) prefix to the Senior Officer ability to reflect how it appears in the book Set Valkyries Min. in parent to 0
Mortars in HWTs are now strength 5
Aradia Madellan is now hidden until we get confirmation that she is still around in some form for 9th. 'Display Astra Militarum Orders' changed to 'Display Regimental Orders'. 'Display Tank Orders' changed to 'Display Mechanised Orders'. Changed the 'Lead from the Front' WLT to 'Front-Line Combatant'. Primaris Psyker stats and keywords
Edited Company Commander to be the Cadian Command Squad Updated Cadian Command squad with relevant rules, loadouts and keywords Updated the Militarum Tempestus Command Squad to now include the Tempestor prime. Updated all weapon and wargear options. Updated Platoon Command squad to include the Platoon commander and match the new loadout restrictions Fixed name for Mental Shackles Psychic power

Removed
Took out 'Faction:' from all the old faction keywords that are no longer faction keywords