### PR TITLE
0.2.1-Super-Heavies-Update

### DIFF
--- a/Imperial_Guard_9th_Ed.cat
+++ b/Imperial_Guard_9th_Ed.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="53e9d88f-7463-8c27-fe67-e1a0d1ed0287" name="Imperium - Imperial Guard 9th Ed" revision="324" battleScribeVersion="2.03" authorName="Denny &amp; TheHalfinstream" authorContact="" authorUrl="" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="53e9d88f-7463-8c27-fe67-e1a0d1ed0287" name="Imperium - Imperial Guard 9th Ed" revision="324" battleScribeVersion="2.03" authorName="3Komnenos3 &amp; TheHalfinstream" authorContact="" authorUrl="" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <readme>The BSData team is not responsible for these 9th edition updates and should not be contacted for support. Find us on the Mordian Glory Discord.
 
 This is a heavily modified version of the BSData team&apos;s Astra Militarum 8th Edition battlescribe files, and all credit goes to them for the creation of the 8th edition version which laid the foundation to our project to bring over the 9th edition codex, and an additional thanks for answering some of our questions on the BSData discord, as well as allowing us to go forward with this project.</readme>
@@ -101,9 +101,6 @@ This is a heavily modified version of the BSData team&apos;s Astra Militarum 8th
       </categoryLinks>
     </entryLink>
     <entryLink id="1788-aba7-90f8-bd2a" name="Sergeant Harker" hidden="false" collective="false" import="true" targetId="0705-6f49-57b2-7288" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="e8d1-76f3-80f5-601b" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
       </categoryLinks>
@@ -162,6 +159,7 @@ This is a heavily modified version of the BSData team&apos;s Astra Militarum 8th
       </categoryLinks>
     </entryLink>
     <entryLink id="3024-d805-795b-c4c5" name="Militarum Tempestus Scions" hidden="false" collective="false" import="true" targetId="f67e-c223-b6fe-940f" type="selectionEntry">
+      <comment>Elites  version</comment>
       <modifierGroups>
         <modifierGroup>
           <conditions>
@@ -313,7 +311,7 @@ This is a heavily modified version of the BSData team&apos;s Astra Militarum 8th
         <categoryLink id="37a5-3fa3-4edb-e1ca" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="17ed-356d-9edb-4245" name="Ministorum Priest" hidden="false" collective="false" import="true" targetId="bcc5-dce5-11ef-7d79" type="selectionEntry">
+    <entryLink id="17ed-356d-9edb-4245" name="Regimental Preacher" hidden="false" collective="false" import="true" targetId="bcc5-dce5-11ef-7d79" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="0344-5603-db17-6d2d" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
       </categoryLinks>
@@ -345,9 +343,6 @@ This is a heavily modified version of the BSData team&apos;s Astra Militarum 8th
       </categoryLinks>
     </entryLink>
     <entryLink id="8fbc-fbd5-2683-b5c8" name="Sly Marbo" hidden="false" collective="false" import="true" targetId="17d2-e653-5b72-59bf" type="selectionEntry">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true"/>
-      </modifiers>
       <categoryLinks>
         <categoryLink id="5bc3-3c77-a8c2-a69d" name="New CategoryLink" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
       </categoryLinks>
@@ -752,6 +747,7 @@ This is a heavily modified version of the BSData team&apos;s Astra Militarum 8th
       </categoryLinks>
     </entryLink>
     <entryLink id="128a-4ee4-049a-61b3" name="Militarum Tempestus Scions" hidden="false" collective="false" import="true" targetId="f67e-c223-b6fe-940f" type="selectionEntry">
+      <comment>Troops version</comment>
       <modifierGroups>
         <modifierGroup>
           <comment>This hides the Troops version of Tempestus Scions</comment>
@@ -833,6 +829,11 @@ This is a heavily modified version of the BSData team&apos;s Astra Militarum 8th
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="6.0"/>
       </costs>
     </entryLink>
+    <entryLink id="493e-a28c-f693-b155" name="Cadian Shock Troops" hidden="false" collective="false" import="true" targetId="83b0-3cc2-15cc-6d3a" type="selectionEntry">
+      <categoryLinks>
+        <categoryLink id="fd32-7816-ff3c-b88e" name="Troops" hidden="false" targetId="5d76b6f5-20ae-4d70-8f59-ade72a2add3a" primary="true"/>
+      </categoryLinks>
+    </entryLink>
   </entryLinks>
   <sharedSelectionEntries>
     <selectionEntry id="dcb74f5d-1308-fbaa-205f-3ad8fbde5b04" name="Lord Castellan Creed" publicationId="53e9d88f--pubN88319" page="56" hidden="false" collective="false" import="true" type="model">
@@ -913,7 +914,7 @@ This is a heavily modified version of the BSData team&apos;s Astra Militarum 8th
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="b16e59cf-cf9e-e4bd-ca74-2c197b354097" name="Sergeant Harker" publicationId="53e9d88f--pubN88319" page="38" hidden="false" collective="false" import="true" type="model">
+    <selectionEntry id="b16e59cf-cf9e-e4bd-ca74-2c197b354097" name="Sergeant Harker (OLD)" publicationId="53e9d88f--pubN88319" page="38" hidden="true" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="maxInRoster" type="max"/>
       </constraints>
@@ -1289,7 +1290,7 @@ Use this Act of Faith at the start of the Morale phase. If successful, the selec
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="627f-c230-9700-49a4" name="Sly Marbo" hidden="false" collective="false" import="true" type="model">
+    <selectionEntry id="627f-c230-9700-49a4" name="Sly Marbo (OLD)" hidden="true" collective="false" import="true" type="model">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="true" id="5977-be1d-8ce7-6f24" type="max"/>
       </constraints>

--- a/Imperium_-_Imperial_Guard_9th_Ed_Library.cat
+++ b/Imperium_-_Imperial_Guard_9th_Ed_Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a2d9-e3b7-13cc-6f15" name="Imperium - Imperial Guard - 9th Ed - Library" revision="118" battleScribeVersion="2.03" authorName="denny, TheHalfinStream" authorContact="" authorUrl="" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a2d9-e3b7-13cc-6f15" name="Imperium - Imperial Guard - 9th Ed - Library" revision="119" battleScribeVersion="2.03" authorName="3Komnenos3, TheHalfinStream" authorContact="" authorUrl="" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <readme>The BSData team is not responsible for these 9th edition updates and should not be contacted for support. Find us on the Mordian Glory Discord.</readme>
   <publications>
     <publication id="53e9d88f--pubN88319" name="Codex: Astra Militarum"/>
@@ -246,15 +246,34 @@
     <categoryEntry id="1436-fc28-06a8-1d8f" name="Melta Mine" hidden="false"/>
     <categoryEntry id="87c8-7328-8ca9-5e2c" name="Kasrkin" hidden="false"/>
     <categoryEntry id="2aa8-ef0c-eae7-21bc" name="Sergeant Harker" hidden="false"/>
+    <categoryEntry id="22a1-8895-f588-fc52" name="Shock Troops" hidden="false"/>
+    <categoryEntry id="ab99-87a7-c0d6-b038" name="Super-Heavy" hidden="false"/>
   </categoryEntries>
   <rules>
-    <rule id="431d-d055-dd6e-d714" name="Defenders of Humanity" hidden="false">
-      <description>If your army is Battle-forged, all Troops units in ASTRA MILITARUM Detachments and all LEMAN RUSS units in Spearhead Detachments gain this ability. Such a unit that is within range of an objective marker (as specified in the mission) controls the objective marker even if there are more enemy models within range of it. If an enemy unit within range of the same objective marker has a similar ability, then the objective marker is controlled by the player who has the most models in range as normal.</description>
-    </rule>
     <rule id="1508-5f0f-cede-970a" name="Hammer of the Emperor" publicationId="2fd5-ca70-3d14-d58c" page="2" hidden="false">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true"/>
+      </modifiers>
       <description>If every unit from your army has the ASTRA MILITARUM keyword (excluding AGENT OF THE IMPERIUM and UNALIGNED), and if every &lt;REGIMENT&gt; unit in your army is drawn from the same regiment, then each time an ASTRA MILITARUM model from your army makes a ranged attack, an unmodified hit roll of 6 automatically wounds the target.’
 
 Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they are included in an army alongside other ASTRA MILITARUM units (e.g. CADIANS units, CATACHANS units etc.) but if they are from a Tempestus Scions regiment (see Psychic Awakening: The Greater Good), they must all be from the same Tempestus Scions regiment in order to gain this rule.</description>
+    </rule>
+    <rule id="ee39-e00a-3be5-5b6d" name="Detachment Abilities" publicationId="e831-8627-fbc7-5b35" page="59" hidden="false">
+      <description>
+An ASTRA MILITARUM Detachment is one that only includes models with the ASTRA MILITARUM keyword (excluding models with the AGENT OF THE IMPERIUM or UNALIGNED keywords).
+
+
+• ASTRA MILITARUM Detachments gain the Chain of Command ability (see below).
+• REGIMENTAL units in ASTRA MILITARUM Detachments gain the Born Soldiers Regimental Doctrine (See Below). If you wish, this can be replaced with a Regimental Doctrine of your own choosing, as described on page 60.
+• If every unit in an ASTRA MILITARUM Detachment has the MILITARUM TEMPESTUS, OFFICIO PREFECTUS and/or MILITARUM AUXILLA keywords, TEMPESTUS SCIONS units in that Detachment have the Troops Battlefield Role, instead of Elites.
+• Troops units in ASTRA MILITARUM Detachments gain the Objective Secured ability (this ability is described in the Warhammer 40,000 Core Book).
+</description>
+    </rule>
+    <rule id="78d6-81e0-6785-cc3a" name="Chain of Command" publicationId="e831-8627-fbc7-5b35" page="59" hidden="false">
+      <description>
+• You cannot select an ASTRA MILITARUM CHARACTER model that is not an OFFICER to be your WARLORD if your army includes any OFFICERS.
+• You can include a maximum of one COMMANDANT in each Detachment in your army. If your army includes a COMMANDANT, you cannot select any other OFFICER to be your WARLORD (with the exception of LORD SOLAR LEONTUS, see below).
+• If your army includes LORD SOLAR LEONTUS (pg 79), that model must be your WARLORD. If more than one model from your army has a rule to this effect, then one of those models must be your WARLORD.</description>
     </rule>
   </rules>
   <sharedSelectionEntries>
@@ -412,7 +431,7 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
       <profiles>
         <profile id="d6a5-deab-71b1-1880" name="Baneblade 1" hidden="false" typeId="e6d5-85c5-7b01-a3c4" typeName="Stat Damage - M/BS/A">
           <characteristics>
-            <characteristic name="Remaining W" typeId="233c-fa78-4641-68d9">14-26+</characteristic>
+            <characteristic name="Remaining W" typeId="233c-fa78-4641-68d9">16-30+</characteristic>
             <characteristic name="Movement" typeId="fc73-9b3f-5e4b-86b9">10&quot;</characteristic>
             <characteristic name="BS" typeId="8010-b879-355a-c137">4+</characteristic>
             <characteristic name="Attacks" typeId="2e64-2e5c-f4d1-52d3">9</characteristic>
@@ -420,16 +439,16 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
         </profile>
         <profile id="33b2-a1b5-ddef-62a5" name="Baneblade 2" hidden="false" typeId="e6d5-85c5-7b01-a3c4" typeName="Stat Damage - M/BS/A">
           <characteristics>
-            <characteristic name="Remaining W" typeId="233c-fa78-4641-68d9">7-13</characteristic>
-            <characteristic name="Movement" typeId="fc73-9b3f-5e4b-86b9">7&quot;</characteristic>
+            <characteristic name="Remaining W" typeId="233c-fa78-4641-68d9">8-15</characteristic>
+            <characteristic name="Movement" typeId="fc73-9b3f-5e4b-86b9">8&quot;</characteristic>
             <characteristic name="BS" typeId="8010-b879-355a-c137">5+</characteristic>
             <characteristic name="Attacks" typeId="2e64-2e5c-f4d1-52d3">6</characteristic>
           </characteristics>
         </profile>
         <profile id="2d93-8a12-ec00-a46e" name="Baneblade 3" hidden="false" typeId="e6d5-85c5-7b01-a3c4" typeName="Stat Damage - M/BS/A">
           <characteristics>
-            <characteristic name="Remaining W" typeId="233c-fa78-4641-68d9">1-6</characteristic>
-            <characteristic name="Movement" typeId="fc73-9b3f-5e4b-86b9">4&quot;</characteristic>
+            <characteristic name="Remaining W" typeId="233c-fa78-4641-68d9">1-7</characteristic>
+            <characteristic name="Movement" typeId="fc73-9b3f-5e4b-86b9">6&quot;</characteristic>
             <characteristic name="BS" typeId="8010-b879-355a-c137">6+</characteristic>
             <characteristic name="Attacks" typeId="2e64-2e5c-f4d1-52d3">3</characteristic>
           </characteristics>
@@ -552,7 +571,7 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="3447-95ac-4721-2e48" name="Valkyries" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="3447-95ac-4721-2e48" name="Valkyries" hidden="true" collective="false" import="true" type="unit">
       <categoryLinks>
         <categoryLink id="67cd-1f5a-19c7-99ff" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
         <categoryLink id="7f89-a473-ab12-f66a" name="Faction: Aeronautica Imperialis" hidden="false" targetId="2135-9abb-5c57-5391" primary="false"/>
@@ -875,6 +894,7 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
         <infoLink id="d48c-63af-9b13-1596" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
         <infoLink id="d845-46c0-d9b2-9570" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
         <infoLink id="bbad-18ae-3c2f-4586" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="4223-5f27-3a85-2879" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1e26-f803-4a0f-08e2" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
@@ -929,8 +949,8 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
             <characteristic name="BS" typeId="381b-eb28-74c3-df5f">*</characteristic>
             <characteristic name="S" typeId="2218-aa3c-265f-2939">9</characteristic>
-            <characteristic name="T" typeId="9c9f-9774-a358-3a39">8</characteristic>
-            <characteristic name="W" typeId="f330-5e6e-4110-0978">26</characteristic>
+            <characteristic name="T" typeId="9c9f-9774-a358-3a39">9</characteristic>
+            <characteristic name="W" typeId="f330-5e6e-4110-0978">30</characteristic>
             <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">*</characteristic>
             <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">8</characteristic>
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">2+</characteristic>
@@ -938,17 +958,19 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="1d22-4421-d9a0-9c0c" name="Steel Behemoth" hidden="false" targetId="62e4-243e-c188-2d88" type="profile"/>
-        <infoLink id="7bab-b375-995c-a0f8" name="Smoke Launchers" hidden="false" targetId="c883-3078-1367-cc2c" type="profile"/>
-        <infoLink id="4c51-fd3a-0e7e-f44e" name="Explodes (Super-heavy)" hidden="false" targetId="f505-bfe1-b238-0c41" type="profile"/>
+        <infoLink id="4c51-fd3a-0e7e-f44e" name="Explodes (6+/2D6&quot;/D6)" hidden="false" targetId="f505-bfe1-b238-0c41" type="profile"/>
         <infoLink id="f4fb-1670-1896-eb01" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="ffa1-d67a-1342-dcda" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
         <categoryLink id="5854-059f-7ce5-2e07" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
         <categoryLink id="6c2a-4b49-8f6e-3723" name="Stormsword" hidden="false" targetId="de68-639e-f30d-46f6" primary="false"/>
         <categoryLink id="4c6c-43dd-4931-26ed" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
         <categoryLink id="812c-bb12-0d74-8325" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="df88-3122-e6ed-5ec5" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+        <categoryLink id="d5b0-2052-9510-5d5a" name="Smoke" hidden="false" targetId="bcf4-1bd8-9794-feaa" primary="false"/>
+        <categoryLink id="194b-489d-2f42-59ee" name="Titanic" hidden="false" targetId="bdda-36f0-4f32-1639" primary="false"/>
+        <categoryLink id="9422-36dc-201e-722b" name="Armoured" hidden="false" targetId="9401-e2e7-bd2c-b3cf" primary="false"/>
+        <categoryLink id="d17b-ebe6-77c2-b8dc" name="Super-Heavy" hidden="false" targetId="ab99-87a7-c0d6-b038" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="92d9-9e9f-8973-bc8a" name="Stormsword Siege Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -959,12 +981,12 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
           <profiles>
             <profile id="6e28-7f43-81ae-22af" name="Stormsword Siege Cannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">36&quot;</characteristic>
-                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 2D6</characteristic>
-                <characteristic name="S" typeId="59b1-319e-ec13-d466">10</characteristic>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">60&quot;</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D6+6</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">12</characteristic>
                 <characteristic name="AP" typeId="75aa-a838-b675-6484">-4</characteristic>
-                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D6</characteristic>
-                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. Units attacked by this weapon do not gain any bonus to their saving throws for being in cover. Re-roll damage rolls of 1 for this weapon.</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3+3</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. Turret Weapon (Pg 75). Each time an attack is made with this weapon, the target does not receive the benefits of Light Cover against that attack.</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -976,18 +998,13 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="06d0-3b52-3e6e-b932" name="Hunter-killer missile" hidden="false" collective="false" import="true" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3c43-2d29-9f49-63fc" type="max"/>
-          </constraints>
-        </entryLink>
         <entryLink id="d9dc-977a-a41f-7bdf" name="Adamantium Tracks" hidden="false" collective="false" import="true" targetId="7c20-256a-b607-245d" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f334-314b-8d02-f762" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f9c-fcbf-594e-ce93" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="094d-bddd-bb8b-1a91" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6e2c-4f30-b09d-c637" type="selectionEntry">
+        <entryLink id="094d-bddd-bb8b-1a91" name="Stat Damage (Baneblade)" hidden="false" collective="false" import="true" targetId="6e2c-4f30-b09d-c637" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6564-1182-18c5-770c" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="92a5-1d16-6946-42e8" type="max"/>
@@ -1000,27 +1017,35 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
           </constraints>
         </entryLink>
         <entryLink id="b29d-c427-105e-23ab" name="Baneblade Sponsons" hidden="false" collective="false" import="true" targetId="be51-49ae-9966-cfc5" type="selectionEntryGroup"/>
-        <entryLink id="e5b5-189b-a2bf-5a5b" name="New EntryLink" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
-        <entryLink id="0304-6fe0-b49b-3d14" name="Unit has battle honors?" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="d12c-0855-5e25-5275" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
-        <entryLink id="2580-3dd2-c988-0a87" name="Tank Aces" hidden="false" collective="false" import="true" targetId="998b-b53a-603f-6c5b" type="selectionEntryGroup"/>
+        <entryLink id="0304-6fe0-b49b-3d14" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="d12c-0855-5e25-5275" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="2580-3dd2-c988-0a87" name="Super Heavy Aces" hidden="false" collective="false" import="true" targetId="f14f-06c3-76c0-2c4a" type="selectionEntryGroup"/>
+        <entryLink id="1363-d00c-7e66-30ff" name="Armoured Tracks" hidden="false" collective="false" import="true" targetId="1fd9-a5e2-ad93-3a21" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="0.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d47-0dea-62c6-6d4c" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a925-2961-0b80-99a0" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="400.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="26.0"/>
+        <cost name="pts" typeId="points" value="420.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="24.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7c20-256a-b607-245d" name="Adamantium Tracks" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="7c20-256a-b607-245d" name="Adamantine Tracks" hidden="false" collective="false" import="true" type="upgrade">
       <profiles>
-        <profile id="5274-7de9-5d23-5a10" name="Adamantium Tracks" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+        <profile id="5274-7de9-5d23-5a10" name="Adamantine Tracks" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
           <characteristics>
             <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">-</characteristic>
             <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Melee</characteristic>
             <characteristic name="S" typeId="59b1-319e-ec13-d466">User</characteristic>
             <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
-            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"/>
+            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -1038,32 +1063,28 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
             <characteristic name="BS" typeId="381b-eb28-74c3-df5f">*</characteristic>
             <characteristic name="S" typeId="2218-aa3c-265f-2939">9</characteristic>
-            <characteristic name="T" typeId="9c9f-9774-a358-3a39">8</characteristic>
-            <characteristic name="W" typeId="f330-5e6e-4110-0978">26</characteristic>
+            <characteristic name="T" typeId="9c9f-9774-a358-3a39">9</characteristic>
+            <characteristic name="W" typeId="f330-5e6e-4110-0978">30</characteristic>
             <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">*</characteristic>
             <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">8</characteristic>
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">2+</characteristic>
           </characteristics>
         </profile>
-        <profile id="6ce5-c19a-bf1b-ff3e" name="Shadowsword Targeters" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-          <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Add 1 to any hit rolls you make for this model for shooting attacks that target TITANIC units.</characteristic>
-          </characteristics>
-        </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="c43b-3fac-42ca-e192" name="Steel Behemoth" hidden="false" targetId="62e4-243e-c188-2d88" type="profile"/>
-        <infoLink id="1cd5-285f-92cf-e2f8" name="Smoke Launchers" hidden="false" targetId="c883-3078-1367-cc2c" type="profile"/>
-        <infoLink id="23ef-7f90-01d4-8deb" name="Explodes (Super-heavy)" hidden="false" targetId="f505-bfe1-b238-0c41" type="profile"/>
+        <infoLink id="23ef-7f90-01d4-8deb" name="Explodes (6+/2D6&quot;/D6)" hidden="false" targetId="f505-bfe1-b238-0c41" type="profile"/>
         <infoLink id="977e-e3d0-01c3-247d" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="a2c8-6c1a-75d0-2571" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
         <categoryLink id="aa26-1f8c-9942-d144" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
         <categoryLink id="d1ef-8223-aa60-1d1b" name="Shadowsword" hidden="false" targetId="bc6d-0e9c-cff7-e52f" primary="false"/>
         <categoryLink id="fdbc-14c8-5226-35c8" name="Titanic" hidden="false" targetId="bdda-36f0-4f32-1639" primary="false"/>
         <categoryLink id="178b-2b63-fa75-e0ff" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
         <categoryLink id="c889-545b-8386-dfaa" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="2eda-f495-8b3d-f590" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+        <categoryLink id="30d3-1d71-d248-b096" name="Smoke" hidden="false" targetId="bcf4-1bd8-9794-feaa" primary="false"/>
+        <categoryLink id="8316-175d-9f2e-4360" name="Armoured" hidden="false" targetId="9401-e2e7-bd2c-b3cf" primary="false"/>
+        <categoryLink id="4c95-bde5-fb62-3c3e" name="Super-Heavy" hidden="false" targetId="ab99-87a7-c0d6-b038" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="7c5a-4c36-59f5-e398" name="Volcano Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1075,11 +1096,11 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
             <profile id="8d2b-cce8-178b-548f" name="Volcano Cannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">120&quot;</characteristic>
-                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 3D3</characteristic>
-                <characteristic name="S" typeId="59b1-319e-ec13-d466">16</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D3+3</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">18</characteristic>
                 <characteristic name="AP" typeId="75aa-a838-b675-6484">-5</characteristic>
-                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2D6</characteristic>
-                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. You can re-roll failed wound rolls when targeting TITANIC units with this weapon.</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">12</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. Turret Weapon (Pg 75).</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -1091,18 +1112,13 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="8248-78fb-32f1-2a1f" name="Hunter-killer missile" hidden="false" collective="false" import="true" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c7d-3cd4-568c-d137" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="deca-8975-8b7b-dc80" name="Adamantium Tracks" hidden="false" collective="false" import="true" targetId="7c20-256a-b607-245d" type="selectionEntry">
+        <entryLink id="deca-8975-8b7b-dc80" name="Adamantine Tracks" hidden="false" collective="false" import="true" targetId="7c20-256a-b607-245d" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="98fc-3653-5800-9f79" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c224-91fb-3da4-0ae7" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="75ec-e51a-e1b0-81d6" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6e2c-4f30-b09d-c637" type="selectionEntry">
+        <entryLink id="75ec-e51a-e1b0-81d6" name="Stat Damage (Baneblade)" hidden="false" collective="false" import="true" targetId="6e2c-4f30-b09d-c637" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="228f-38aa-abbb-6c59" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1e6e-e27a-7c76-87e3" type="max"/>
@@ -1115,14 +1131,22 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
           </constraints>
         </entryLink>
         <entryLink id="fd15-0b0c-4d86-fae7" name="Baneblade Sponsons" hidden="false" collective="false" import="true" targetId="be51-49ae-9966-cfc5" type="selectionEntryGroup"/>
-        <entryLink id="a4b4-833a-60ef-eb33" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
-        <entryLink id="b108-1880-f192-6a8b" name="Unit has battle honors?" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="671b-8b7c-f4e5-90bc" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
-        <entryLink id="3bc2-f1bc-a0cc-3d6a" name="Tank Aces" hidden="false" collective="false" import="true" targetId="998b-b53a-603f-6c5b" type="selectionEntryGroup"/>
+        <entryLink id="b108-1880-f192-6a8b" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="671b-8b7c-f4e5-90bc" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="3bc2-f1bc-a0cc-3d6a" name="Super Heavy Aces" hidden="false" collective="false" import="true" targetId="f14f-06c3-76c0-2c4a" type="selectionEntryGroup"/>
+        <entryLink id="70b2-9ab9-dbb6-691b" name="Armoured Tracks" hidden="false" collective="false" import="true" targetId="1fd9-a5e2-ad93-3a21" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="0.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="525d-9c6f-077f-7f0a" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60cb-7b73-93ee-679b" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="430.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="27.0"/>
+        <cost name="pts" typeId="points" value="450.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="26.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -1146,6 +1170,7 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
         <infoLink id="dde7-55ab-c18d-998c" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
         <infoLink id="14bd-85ce-5b5c-78fc" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
         <infoLink id="63c2-d799-c820-ff94" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="ee2c-3e08-51c8-04a4" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="81d2-ed3e-1c0a-a263" name="Basilisk" hidden="false" targetId="7d7c-9011-2791-72d9" primary="false"/>
@@ -1205,8 +1230,8 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
             <characteristic name="BS" typeId="381b-eb28-74c3-df5f">*</characteristic>
             <characteristic name="S" typeId="2218-aa3c-265f-2939">9</characteristic>
-            <characteristic name="T" typeId="9c9f-9774-a358-3a39">8</characteristic>
-            <characteristic name="W" typeId="f330-5e6e-4110-0978">26</characteristic>
+            <characteristic name="T" typeId="9c9f-9774-a358-3a39">9</characteristic>
+            <characteristic name="W" typeId="f330-5e6e-4110-0978">30</characteristic>
             <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">*</characteristic>
             <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">8</characteristic>
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">2+</characteristic>
@@ -1214,8 +1239,6 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="f41d-1a49-d220-cad1" name="Steel Behemoth" hidden="false" targetId="62e4-243e-c188-2d88" type="profile"/>
-        <infoLink id="593a-6e6e-25c7-74f5" name="New InfoLink" hidden="false" targetId="c883-3078-1367-cc2c" type="profile"/>
         <infoLink id="69ec-b200-8e35-2ecd" name="Explodes (6+/2D6&quot;/D6)" hidden="false" targetId="f505-bfe1-b238-0c41" type="profile"/>
         <infoLink id="9bf2-3efb-7b18-7a57" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
       </infoLinks>
@@ -1224,6 +1247,10 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
         <categoryLink id="a7de-ba08-a822-ce4d" name="Titanic" hidden="false" targetId="bdda-36f0-4f32-1639" primary="false"/>
         <categoryLink id="e066-359a-6935-3986" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
         <categoryLink id="df08-d070-94c7-35ca" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="e91d-ef24-b628-e0f5" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
+        <categoryLink id="eb4a-1311-6846-eafd" name="Smoke" hidden="false" targetId="bcf4-1bd8-9794-feaa" primary="false"/>
+        <categoryLink id="be65-1e12-34a6-e6d7" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+        <categoryLink id="8ea8-47ac-bc09-2d60" name="Super-Heavy" hidden="false" targetId="ab99-87a7-c0d6-b038" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b79c-9c88-256e-dcdc" name="Baneblade Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -1232,52 +1259,71 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bc2b-8c0b-f376-fba1" type="max"/>
           </constraints>
           <profiles>
-            <profile id="6789-3e02-4b1b-d1ce" name="Baneblade Cannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+            <profile id="8206-255b-d0b9-def8" name="Baneblade Cannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">72&quot;</characteristic>
                 <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 3D6</characteristic>
                 <characteristic name="S" typeId="59b1-319e-ec13-d466">9</characteristic>
                 <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
                 <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">3</characteristic>
-                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast.</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast, Turret Weapon (Pg 75).</characteristic>
               </characteristics>
             </profile>
           </profiles>
+          <selectionEntries>
+            <selectionEntry id="15b7-3ed5-81ac-4075" name="Co-Axial Autocannon" publicationId="e831-8627-fbc7-5b35" page="115" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe90-378f-f022-45d5" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9dfd-0e2e-68fc-6f4e" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="7bb8-b6f7-1f7b-fc2f" name="Co-Axial Autocannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">48&quot;</characteristic>
+                    <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">heavy 2</characteristic>
+                    <characteristic name="S" typeId="59b1-319e-ec13-d466">7</characteristic>
+                    <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
+                    <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
+                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Turret Weapon (Pg 75)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-      </selectionEntries>
-      <entryLinks>
-        <entryLink id="21a1-456f-9860-ad9d" name="Hunter-killer missile" hidden="false" collective="false" import="true" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
+        <selectionEntry id="9ff2-2406-2d81-9d1c" name="Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="set" field="points" value="0.0"/>
           </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7188-16d4-dc4c-0027" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d06-ec9f-6702-d7a9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ed8-b730-de7b-9085" type="max"/>
           </constraints>
-        </entryLink>
-        <entryLink id="48c6-07fe-38cd-4405" name="Autocannon" hidden="false" collective="false" import="true" targetId="5210-8cb2-b5a2-a04f" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3517-0620-944a-528b" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a75-0b66-5267-3170" type="max"/>
-          </constraints>
-        </entryLink>
+          <infoLinks>
+            <infoLink id="9c1c-2779-10ad-bd48" name="Heavy stubber" hidden="false" targetId="0031-0314-5b36-a220" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
         <entryLink id="4df9-d522-69fa-e2e1" name="Demolisher cannon" hidden="false" collective="false" import="true" targetId="1f7e-32c4-61af-510f" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8d3-c21f-ef81-9660" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3874-e9e0-9d1c-d4c9" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="437b-2a51-c113-2848" name="Twin heavy bolter" hidden="false" collective="false" import="true" targetId="09d8-7790-ed3f-4d6d" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8673-5b53-8d35-d2f8" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cd23-63c2-62f9-71cc" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="36c1-e925-7dcc-a050" name="Adamantium Tracks" hidden="false" collective="false" import="true" targetId="7c20-256a-b607-245d" type="selectionEntry">
+        <entryLink id="36c1-e925-7dcc-a050" name="Armoured Tracks" hidden="false" collective="false" import="true" targetId="1fd9-a5e2-ad93-3a21" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="0.0"/>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="994d-5fb3-4d2b-6a5d" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f4ef-7acf-26ca-4daf" type="max"/>
@@ -1290,27 +1336,29 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
           </constraints>
         </entryLink>
         <entryLink id="a6f8-9e3c-56f1-2b22" name="Baneblade Sponsons" hidden="false" collective="false" import="true" targetId="be51-49ae-9966-cfc5" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="b972-7a3a-62db-eb4f" value="2.0">
-              <conditions>
-                <condition field="selections" scope="3ac6-8d6e-850e-6aee" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a908-4664-11cd-f8b2" type="atLeast"/>
-              </conditions>
-            </modifier>
-            <modifier type="set" field="b972-7a3a-62db-eb4f" value="4.0">
-              <conditions>
-                <condition field="selections" scope="3ac6-8d6e-850e-6aee" value="3.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a908-4664-11cd-f8b2" type="atLeast"/>
-              </conditions>
-            </modifier>
-          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fd5-9f22-193e-dabd" type="min"/>
+          </constraints>
         </entryLink>
-        <entryLink id="49af-922a-2fa6-dc86" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
-        <entryLink id="bf26-3580-fc48-8c5b" name="Unit has battle honors?" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="b4ed-7c73-cd56-cf1d" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
-        <entryLink id="c505-4d4c-156d-a541" name="Tank Aces" hidden="false" collective="false" import="true" targetId="998b-b53a-603f-6c5b" type="selectionEntryGroup"/>
+        <entryLink id="bf26-3580-fc48-8c5b" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="b4ed-7c73-cd56-cf1d" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="c505-4d4c-156d-a541" name="Super Heavy Aces" hidden="false" collective="false" import="true" targetId="f14f-06c3-76c0-2c4a" type="selectionEntryGroup"/>
+        <entryLink id="776d-39d1-2b72-3fe9" name="Adamantine Tracks" hidden="false" collective="false" import="true" targetId="7c20-256a-b607-245d" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ba03-a819-f863-b1f7" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="249b-bdce-7784-7907" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="5ab4-61cf-b53e-62ad" name="Twin heavy bolter" hidden="false" collective="false" import="true" targetId="09d8-7790-ed3f-4d6d" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5f88-6137-de0c-2d25" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5776-7865-48ea-b1a5" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="410.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="26.0"/>
+        <cost name="pts" typeId="points" value="430.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="25.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -3158,10 +3206,11 @@ Designer’s Note: MILITARUM TEMPESTUS units will benefit from this rule if they
       <categoryLinks>
         <categoryLink id="0790-36ee-626b-abf7" name="Titanic" hidden="false" targetId="bdda-36f0-4f32-1639" primary="false"/>
         <categoryLink id="45de-2b1a-b3f2-dede" name="Stormblade" hidden="false" targetId="baa9-dbdb-8fa4-6149" primary="false"/>
-        <categoryLink id="80c9-2865-d000-4e73" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
         <categoryLink id="ba98-6cec-4803-04b0" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
         <categoryLink id="ab1b-d694-6baf-36c8" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
         <categoryLink id="1ce8-414d-51f9-4eb8" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="b004-8eb6-c4f1-948c" name="Armoured" hidden="false" targetId="9401-e2e7-bd2c-b3cf" primary="false"/>
+        <categoryLink id="94dd-28f7-091c-8a0f" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b414-01ee-6b45-9612" name="Stormblade Plasma Blastgun" hidden="false" collective="false" import="true" type="upgrade">
@@ -7516,6 +7565,7 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
           <infoLinks>
             <infoLink id="2300-cdd9-6c34-4a7a" name="Explodes (6+/3&quot;/1)" hidden="false" targetId="8810-0e85-71ad-e4e3" type="profile"/>
             <infoLink id="e656-a8e6-4839-cb4c" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+            <infoLink id="1491-77ac-9e5e-b820" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
           </infoLinks>
           <entryLinks>
             <entryLink id="31cf-662b-1738-3d99" name="Sentinel Weapon" hidden="false" collective="false" import="true" targetId="17a8-0cf1-0bbc-23b3" type="selectionEntryGroup">
@@ -7726,7 +7776,7 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
       <profiles>
         <profile id="2fa9-9041-dc92-dfff" name="Transport: Banehammer" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
           <characteristics>
-            <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model can transport 25 ASTRA MILITARUM INFANTRY models.  Each Heavy Weapons Team or Veteran Heavy Weapons Team takes the place of two other models and each OGRYN takes the space of three other models.</characteristic>
+            <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model can transport 25 ASTRA MILITARUM INFANTRY models.  Each Heavy Weapons Team or Veteran Heavy Weapons Team takes the place of 2 models. Each OGRYNS and BULLGRYNS model takes up the space of 3 models.</characteristic>
           </characteristics>
         </profile>
         <profile id="4c24-2ae4-9a95-9131" name="Banehammer" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -7735,8 +7785,8 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
             <characteristic name="BS" typeId="381b-eb28-74c3-df5f">*</characteristic>
             <characteristic name="S" typeId="2218-aa3c-265f-2939">9</characteristic>
-            <characteristic name="T" typeId="9c9f-9774-a358-3a39">8</characteristic>
-            <characteristic name="W" typeId="f330-5e6e-4110-0978">26</characteristic>
+            <characteristic name="T" typeId="9c9f-9774-a358-3a39">9</characteristic>
+            <characteristic name="W" typeId="f330-5e6e-4110-0978">28</characteristic>
             <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">*</characteristic>
             <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">8</characteristic>
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">2+</characteristic>
@@ -7744,20 +7794,21 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="c28b-5ea6-3305-7bfb" name="Steel Behemoth" hidden="false" targetId="62e4-243e-c188-2d88" type="profile"/>
-        <infoLink id="c787-2de7-8f81-7dfc" name="New InfoLink" hidden="false" targetId="c883-3078-1367-cc2c" type="profile"/>
-        <infoLink id="0c80-f4d9-ab4e-c671" name="Explodes (Super-heavy)" hidden="false" targetId="f505-bfe1-b238-0c41" type="profile"/>
-        <infoLink id="8223-df33-c87a-e87b" name="New InfoLink" hidden="false" targetId="9981-5fb9-57f6-7930" type="profile"/>
+        <infoLink id="0c80-f4d9-ab4e-c671" name="Explodes (6+/2D6&quot;/D6)" hidden="false" targetId="f505-bfe1-b238-0c41" type="profile"/>
+        <infoLink id="8223-df33-c87a-e87b" name="Firing Deck" hidden="false" targetId="9981-5fb9-57f6-7930" type="profile"/>
         <infoLink id="b154-5203-9ee7-7de8" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="021c-05ee-9c68-74db" name="Titanic" hidden="false" targetId="bdda-36f0-4f32-1639" primary="false"/>
         <categoryLink id="550b-dc79-9caf-44db" name="Banehammer" hidden="false" targetId="8152-8a8e-f1ab-87d3" primary="false"/>
-        <categoryLink id="c0ec-df0a-0132-b2be" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
         <categoryLink id="288d-421d-06bc-43a2" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
         <categoryLink id="27a1-8e1b-9ba8-a716" name="Transport" hidden="false" targetId="6cc4-1b62-8e8a-05cd" primary="false"/>
         <categoryLink id="af45-c7c2-f578-1877" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
         <categoryLink id="f9b6-a681-3618-add5" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="3501-e071-3d76-bb49" name="Smoke" hidden="false" targetId="bcf4-1bd8-9794-feaa" primary="false"/>
+        <categoryLink id="bcc5-720d-0090-dade" name="Armoured" hidden="false" targetId="9401-e2e7-bd2c-b3cf" primary="false"/>
+        <categoryLink id="44a4-d6a5-65fe-56e9" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+        <categoryLink id="2a9b-272a-4e89-7b28" name="Super-Heavy" hidden="false" targetId="ab99-87a7-c0d6-b038" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="c60c-73e6-1b75-9ae5" name="Tremor Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -7768,12 +7819,12 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
           <profiles>
             <profile id="f296-9a7a-0d14-23f7" name="Tremor Cannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">60&quot;</characteristic>
-                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 3D6</characteristic>
-                <characteristic name="S" typeId="59b1-319e-ec13-d466">8</characteristic>
-                <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">36&quot;</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 2D6+3</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">10</characteristic>
+                <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
                 <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">3</characteristic>
-                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. If a unit is hit by this weapon, in their following Movement phase they must halve their Move characteristic and cannot Advance.</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast, Turret Weapon (p75)</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -7785,38 +7836,41 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="afdc-c7c7-21ea-d55c" name="Hunter-killer missile" hidden="false" collective="false" import="true" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0eea-b79b-f101-7b96" type="max"/>
-          </constraints>
-        </entryLink>
         <entryLink id="e266-a3b5-e8a3-fa26" name="Twin heavy bolter" hidden="false" collective="false" import="true" targetId="09d8-7790-ed3f-4d6d" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bb5d-53a4-2919-443f" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4adf-c47b-70b3-3209" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="6ab8-4932-8799-1224" name="Adamantium Tracks" hidden="false" collective="false" import="true" targetId="7c20-256a-b607-245d" type="selectionEntry">
+        <entryLink id="6ab8-4932-8799-1224" name="Adamantine Tracks" hidden="false" collective="false" import="true" targetId="7c20-256a-b607-245d" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9776-b6ba-7116-96f8" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de00-420e-7b6b-d222" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="0d96-0f86-1725-ba48" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6e2c-4f30-b09d-c637" type="selectionEntry">
+        <entryLink id="0d96-0f86-1725-ba48" name="Stat Damage (Banehammer)" hidden="false" collective="false" import="true" targetId="2f89-1409-f584-dc03" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21cb-91c3-b445-bc8c" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b17e-11dc-89ad-919a" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="062c-7a99-733f-a234" name="Baneblade Sponsons" hidden="false" collective="false" import="true" targetId="be51-49ae-9966-cfc5" type="selectionEntryGroup"/>
-        <entryLink id="bc85-831b-10c7-d7ae" name="New EntryLink" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
-        <entryLink id="41df-eb7a-1b64-94d3" name="Unit has battle honors?" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="9cdd-ccbd-dd08-8ada" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
-        <entryLink id="07cd-3ebe-b630-2741" name="Tank Aces" hidden="false" collective="false" import="true" targetId="998b-b53a-603f-6c5b" type="selectionEntryGroup"/>
+        <entryLink id="41df-eb7a-1b64-94d3" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="9cdd-ccbd-dd08-8ada" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="07cd-3ebe-b630-2741" name="Super Heavy Aces" hidden="false" collective="false" import="true" targetId="f14f-06c3-76c0-2c4a" type="selectionEntryGroup"/>
+        <entryLink id="729b-cd3a-3f77-e166" name="Armoured Tracks" hidden="false" collective="false" import="true" targetId="1fd9-a5e2-ad93-3a21" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="0.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="255d-30a9-20eb-5220" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd0a-3345-1418-23c8" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="370.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="24.0"/>
+        <cost name="pts" typeId="points" value="400.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="23.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -7828,8 +7882,8 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
             <characteristic name="BS" typeId="381b-eb28-74c3-df5f">*</characteristic>
             <characteristic name="S" typeId="2218-aa3c-265f-2939">9</characteristic>
-            <characteristic name="T" typeId="9c9f-9774-a358-3a39">8</characteristic>
-            <characteristic name="W" typeId="f330-5e6e-4110-0978">26</characteristic>
+            <characteristic name="T" typeId="9c9f-9774-a358-3a39">9</characteristic>
+            <characteristic name="W" typeId="f330-5e6e-4110-0978">30</characteristic>
             <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">*</characteristic>
             <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">8</characteristic>
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">2+</characteristic>
@@ -7837,18 +7891,19 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="cb21-3bba-bcc9-6a2d" name="Steel Behemoth" hidden="false" targetId="62e4-243e-c188-2d88" type="profile"/>
-        <infoLink id="dc4a-1f34-8024-2cd9" name="New InfoLink" hidden="false" targetId="c883-3078-1367-cc2c" type="profile"/>
-        <infoLink id="ff57-13c4-5d40-f68d" name="Explodes (Super-heavy)" hidden="false" targetId="f505-bfe1-b238-0c41" type="profile"/>
+        <infoLink id="ff57-13c4-5d40-f68d" name="Explodes (6+/2D6&quot;/D6)" hidden="false" targetId="f505-bfe1-b238-0c41" type="profile"/>
         <infoLink id="ea44-a22b-7d43-6c75" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="3c39-5946-cb66-4a51" name="Titanic" hidden="false" targetId="bdda-36f0-4f32-1639" primary="false"/>
         <categoryLink id="8b8b-5420-ff32-b398" name="Banesword" hidden="false" targetId="a829-4945-0f1b-3e07" primary="false"/>
-        <categoryLink id="3962-42e4-6dcc-b796" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
         <categoryLink id="ec77-3b5f-73dc-ff86" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
         <categoryLink id="6c57-d83f-869e-f962" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
         <categoryLink id="8980-43b0-6684-f131" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="27f8-b584-8f4a-a5cb" name="Smoke" hidden="false" targetId="bcf4-1bd8-9794-feaa" primary="false"/>
+        <categoryLink id="9968-f8f0-f2e7-ecd3" name="Armoured" hidden="false" targetId="9401-e2e7-bd2c-b3cf" primary="false"/>
+        <categoryLink id="e648-a294-f7f9-9c0c" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+        <categoryLink id="e790-45c9-d223-ac6c" name="Super-Heavy" hidden="false" targetId="ab99-87a7-c0d6-b038" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b944-9ada-51b5-c35d" name="Quake Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -7859,12 +7914,12 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
           <profiles>
             <profile id="286d-f5d6-b9b9-0abb" name="Quake Cannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">140&quot;</characteristic>
-                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 2D6</characteristic>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">96&quot;</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D6+6</characteristic>
                 <characteristic name="S" typeId="59b1-319e-ec13-d466">14</characteristic>
                 <characteristic name="AP" typeId="75aa-a838-b675-6484">-4</characteristic>
-                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D6</characteristic>
-                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. When rolling for this weapon&apos;s damage, treat any rolls of 1 or 2 as 3 instead.</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">4</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. Turret Weapon (pg75)</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -7876,11 +7931,6 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="4cd8-8fd3-575b-3b66" name="Hunter-killer missile" hidden="false" collective="false" import="true" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5060-d44c-2fea-1a37" type="max"/>
-          </constraints>
-        </entryLink>
         <entryLink id="9ad3-f92f-8ae9-6580" name="Twin heavy bolter" hidden="false" collective="false" import="true" targetId="09d8-7790-ed3f-4d6d" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2ce-005e-187b-8590" type="min"/>
@@ -7893,20 +7943,20 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5580-04c7-9c14-e074" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="dca0-781d-3f70-b189" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6e2c-4f30-b09d-c637" type="selectionEntry">
+        <entryLink id="dca0-781d-3f70-b189" name="Stat Damage (Baneblade)" hidden="false" collective="false" import="true" targetId="6e2c-4f30-b09d-c637" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5cc4-6fc1-9f1b-ef71" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="727a-9908-4a78-2744" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="526d-db01-4af2-57ee" name="New EntryLink" hidden="false" collective="false" import="true" targetId="be51-49ae-9966-cfc5" type="selectionEntryGroup"/>
-        <entryLink id="89b8-6062-a4ef-b43c" name="New EntryLink" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
-        <entryLink id="d1e1-e6b6-5c6c-f55b" name="Unit has battle honors?" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="f8b4-bee6-b52f-753c" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
-        <entryLink id="6fb2-f0e1-dfff-d7d2" name="Tank Aces" hidden="false" collective="false" import="true" targetId="998b-b53a-603f-6c5b" type="selectionEntryGroup"/>
+        <entryLink id="526d-db01-4af2-57ee" name="Baneblade Sponsons" hidden="false" collective="false" import="true" targetId="be51-49ae-9966-cfc5" type="selectionEntryGroup"/>
+        <entryLink id="89b8-6062-a4ef-b43c" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
+        <entryLink id="d1e1-e6b6-5c6c-f55b" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="f8b4-bee6-b52f-753c" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="6fb2-f0e1-dfff-d7d2" name="Super Heavy Aces" hidden="false" collective="false" import="true" targetId="f14f-06c3-76c0-2c4a" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="370.0"/>
+        <cost name="pts" typeId="points" value="390.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="24.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -8456,6 +8506,7 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
         <infoLink id="8356-4b85-12d4-e93f" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
         <infoLink id="bf72-e26a-2dd9-0c61" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
         <infoLink id="9c4a-9a9f-4812-01ed" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="8c89-d5b6-2f06-4def" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="b32a-c7a6-c4dc-5e3b" name="Chimera" hidden="false" targetId="0ed3-ca73-4800-91a7" primary="false"/>
@@ -8649,6 +8700,7 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
     <selectionEntry id="3b7d-927b-8856-e8b7" name="Platoon Command Squad" publicationId="e831-8627-fbc7-5b35" page="83" hidden="false" collective="false" import="true" type="unit">
       <infoLinks>
         <infoLink id="7813-a2a2-93be-9b77" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="59a2-c7e2-c45e-385a" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1f49-55ce-ea3c-ceeb" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
@@ -9370,6 +9422,7 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
       <infoLinks>
         <infoLink id="cd56-3cb0-2177-9a59" name="Aura of Discipline" hidden="false" targetId="74b0-e2c2-29bf-2997" type="profile"/>
         <infoLink id="4f26-9caa-8b72-2b1b" name="Summary Execution" hidden="false" targetId="f5f1-324f-5ba1-c4ae" type="profile"/>
+        <infoLink id="7a8f-6944-c543-697f" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="89bc-a0f8-389d-914d" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
@@ -9533,6 +9586,7 @@ While a unit is suppressed, each time a model in that unit makes an attack, subt
       <infoLinks>
         <infoLink id="80da-0c59-ea83-1578" name="Senior Officer (Aura)" hidden="false" targetId="f34c8090-4e32-bd27-df37-1b714a4288d2" type="profile"/>
         <infoLink id="ee2f-c036-f1c6-03e0" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="b3d3-6d95-d97d-f1fe" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="10fd-96b9-47a7-76b1" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
@@ -10386,6 +10440,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         <infoLink id="9486-485f-fc70-0eda" name="Explodes (6+/6&quot;/D6)" hidden="false" targetId="7525-aa8c-bea2-9691" type="profile"/>
         <infoLink id="dddb-83cc-2a24-6567" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
         <infoLink id="dd60-7c69-f10d-5492" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="e2f5-1a3a-39b7-1375" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="daf7-11c7-4764-6d0b" name="Deathstrike" hidden="false" targetId="53b9-ff6c-bca7-8e1c" primary="false"/>
@@ -10563,7 +10618,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       <profiles>
         <profile id="91fd-c3ab-639d-7d04" name="Transport: Doomhammer" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
           <characteristics>
-            <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model can transport 25 ASTRA MILITARUM INFANTRY models.  Each Heavy Weapons Team or Veteran Heavy Weapons Team takes the place of two other models and each OGRYN takes the space of three other models.</characteristic>
+            <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model can transport 25 ASTRA MILITARUM INFANTRY models.  Each Heavy Weapons Team or Veteran Heavy Weapons Team takes the place of 2 models. Each OGRYNS and BULLGRYNS model takes up the space of 3 models.</characteristic>
           </characteristics>
         </profile>
         <profile id="4c73-7a56-4e38-87c4" name="Doomhammer" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -10572,8 +10627,8 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
             <characteristic name="BS" typeId="381b-eb28-74c3-df5f">*</characteristic>
             <characteristic name="S" typeId="2218-aa3c-265f-2939">9</characteristic>
-            <characteristic name="T" typeId="9c9f-9774-a358-3a39">8</characteristic>
-            <characteristic name="W" typeId="f330-5e6e-4110-0978">26</characteristic>
+            <characteristic name="T" typeId="9c9f-9774-a358-3a39">9</characteristic>
+            <characteristic name="W" typeId="f330-5e6e-4110-0978">28</characteristic>
             <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">*</characteristic>
             <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">8</characteristic>
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">2+</characteristic>
@@ -10581,20 +10636,21 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="612f-1594-bf90-9cf7" name="Steel Behemoth" hidden="false" targetId="62e4-243e-c188-2d88" type="profile"/>
-        <infoLink id="8179-719e-4d2c-ca39" name="New InfoLink" hidden="false" targetId="c883-3078-1367-cc2c" type="profile"/>
-        <infoLink id="f9c6-1480-00bf-f0d7" name="Explodes (Super-heavy)" hidden="false" targetId="f505-bfe1-b238-0c41" type="profile"/>
-        <infoLink id="cc6f-6dc0-85b7-7327" name="New InfoLink" hidden="false" targetId="9981-5fb9-57f6-7930" type="profile"/>
+        <infoLink id="f9c6-1480-00bf-f0d7" name="Explodes (6+/2D6&quot;/D6)" hidden="false" targetId="f505-bfe1-b238-0c41" type="profile"/>
+        <infoLink id="cc6f-6dc0-85b7-7327" name="Firing Deck" hidden="false" targetId="9981-5fb9-57f6-7930" type="profile"/>
         <infoLink id="2369-bfcd-88e4-1c04" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="6692-2ef6-1cc3-867c" name="Titanic" hidden="false" targetId="bdda-36f0-4f32-1639" primary="false"/>
         <categoryLink id="32b8-f141-fb1a-9d1d" name="Doomhammer" hidden="false" targetId="eb0a-0ae9-3f49-5679" primary="false"/>
-        <categoryLink id="4afd-8fe1-0e3e-abe0" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
         <categoryLink id="f25d-03d5-6be0-e594" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
         <categoryLink id="9aa9-f0f0-ae39-24bd" name="Transport" hidden="false" targetId="6cc4-1b62-8e8a-05cd" primary="false"/>
         <categoryLink id="b4e8-2297-a663-df89" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
         <categoryLink id="d09f-acbb-32ac-0c6b" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="8cc4-bf82-35f7-a262" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+        <categoryLink id="03fb-ee6e-b09a-83f5" name="Smoke" hidden="false" targetId="bcf4-1bd8-9794-feaa" primary="false"/>
+        <categoryLink id="90cf-6e4a-d254-a978" name="Armoured" hidden="false" targetId="9401-e2e7-bd2c-b3cf" primary="false"/>
+        <categoryLink id="10ae-cb75-84c3-2f8e" name="Super-Heavy" hidden="false" targetId="ab99-87a7-c0d6-b038" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="b13f-48b7-e222-31e1" name="Magma Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -10605,12 +10661,12 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
           <profiles>
             <profile id="1ac9-a92f-b30f-0b86" name="Magma Cannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">60&quot;</characteristic>
-                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 2D6</characteristic>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">48&quot;</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D6+3</characteristic>
                 <characteristic name="S" typeId="59b1-319e-ec13-d466">10</characteristic>
                 <characteristic name="AP" typeId="75aa-a838-b675-6484">-5</characteristic>
-                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D6</characteristic>
-                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. If the target is within half range of this weapon, roll two dice when inflicting damage with it and discard the lowest result.</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D6+2</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. Turret Weapon (pg 75). IEach time an attack made with this weapon targets a unit within half range, taht attack has a Damage characteristic of D6+4</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -10622,11 +10678,6 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="6810-ed6f-87ef-7914" name="Hunter-killer missile" hidden="false" collective="false" import="true" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5a9d-3899-357d-71ae" type="max"/>
-          </constraints>
-        </entryLink>
         <entryLink id="6352-ce71-c245-960c" name="Twin heavy bolter" hidden="false" collective="false" import="true" targetId="09d8-7790-ed3f-4d6d" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="778d-b058-c88d-b14b" type="min"/>
@@ -10639,21 +10690,29 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aff8-8532-0432-073e" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="12ac-d3d9-4eeb-0583" name="Stat Damage (Baneblade)" hidden="false" collective="false" import="true" targetId="6e2c-4f30-b09d-c637" type="selectionEntry">
+        <entryLink id="12ac-d3d9-4eeb-0583" name="Stat Damage (Banehammer)" hidden="false" collective="false" import="true" targetId="2f89-1409-f584-dc03" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="871c-04b9-b8a8-d2d0" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5153-75b4-98af-7b57" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="1b7f-da2c-3558-f3bb" name="New EntryLink" hidden="false" collective="false" import="true" targetId="be51-49ae-9966-cfc5" type="selectionEntryGroup"/>
-        <entryLink id="77ed-0740-db08-bc86" name="New EntryLink" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
-        <entryLink id="853b-aeb3-cce5-ba71" name="Unit has battle honors?" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="0b0d-a5e0-1f6b-2148" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
-        <entryLink id="ff42-b8fa-3a3b-cd70" name="Tank Aces" hidden="false" collective="false" import="true" targetId="998b-b53a-603f-6c5b" type="selectionEntryGroup"/>
+        <entryLink id="1b7f-da2c-3558-f3bb" name="Baneblade Sponsons" hidden="false" collective="false" import="true" targetId="be51-49ae-9966-cfc5" type="selectionEntryGroup"/>
+        <entryLink id="853b-aeb3-cce5-ba71" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="0b0d-a5e0-1f6b-2148" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="ff42-b8fa-3a3b-cd70" name="Super Heavy Aces" hidden="false" collective="false" import="true" targetId="f14f-06c3-76c0-2c4a" type="selectionEntryGroup"/>
+        <entryLink id="4566-d31d-27c0-a1a0" name="Armoured Tracks" hidden="false" collective="false" import="true" targetId="1fd9-a5e2-ad93-3a21" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="0.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d70a-ad6a-4acf-9101" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5fb-ebe5-6d78-0186" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
-        <cost name="pts" typeId="points" value="380.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="25.0"/>
+        <cost name="pts" typeId="points" value="420.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="24.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -11007,6 +11066,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       <infoLinks>
         <infoLink id="839d-8321-d166-9586" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
         <infoLink id="3ee4-362e-20c0-ab10" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="79ab-38c9-0dfc-cc09" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="0954-6dc6-315a-1f67" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
@@ -11063,8 +11123,8 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
             <characteristic name="WS" typeId="e7f0-1278-0250-df0c">5+</characteristic>
             <characteristic name="BS" typeId="381b-eb28-74c3-df5f">*</characteristic>
             <characteristic name="S" typeId="2218-aa3c-265f-2939">9</characteristic>
-            <characteristic name="T" typeId="9c9f-9774-a358-3a39">8</characteristic>
-            <characteristic name="W" typeId="f330-5e6e-4110-0978">26</characteristic>
+            <characteristic name="T" typeId="9c9f-9774-a358-3a39">9</characteristic>
+            <characteristic name="W" typeId="f330-5e6e-4110-0978">30</characteristic>
             <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">*</characteristic>
             <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">8</characteristic>
             <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">2+</characteristic>
@@ -11072,18 +11132,19 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="8e4a-8723-20dd-02ec" name="Steel Behemoth" hidden="false" targetId="62e4-243e-c188-2d88" type="profile"/>
-        <infoLink id="7902-8537-7c4c-231f" name="New InfoLink" hidden="false" targetId="c883-3078-1367-cc2c" type="profile"/>
-        <infoLink id="3593-f030-de64-8864" name="Explodes (Super-heavy)" hidden="false" targetId="f505-bfe1-b238-0c41" type="profile"/>
+        <infoLink id="3593-f030-de64-8864" name="Explodes (6+/2D6&quot;/D6)" hidden="false" targetId="f505-bfe1-b238-0c41" type="profile"/>
         <infoLink id="6a5f-fb61-d865-2482" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
       </infoLinks>
       <categoryLinks>
-        <categoryLink id="8bbb-2a2d-4b36-fb97" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
         <categoryLink id="9c8f-a21d-28fe-cc66" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
         <categoryLink id="17a7-3e48-c3b8-2f50" name="Hellhammer" hidden="false" targetId="17f4-39d7-4087-6c53" primary="false"/>
         <categoryLink id="ac6d-fd7f-390b-5ff4" name="Titanic" hidden="false" targetId="bdda-36f0-4f32-1639" primary="false"/>
         <categoryLink id="624a-1056-b026-db4a" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
         <categoryLink id="f38a-5c1c-8216-d937" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="0faf-f18c-476f-bd71" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+        <categoryLink id="6d79-1232-2169-7a63" name="Smoke" hidden="false" targetId="bcf4-1bd8-9794-feaa" primary="false"/>
+        <categoryLink id="ca9b-d708-7878-2be0" name="Armoured" hidden="false" targetId="9401-e2e7-bd2c-b3cf" primary="false"/>
+        <categoryLink id="d34e-2c82-1626-943f" name="Super-Heavy" hidden="false" targetId="ab99-87a7-c0d6-b038" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="6999-87aa-f8f7-f050" name="Turret-mounted Hellhammer Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -11095,43 +11156,68 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
             <profile id="3144-d256-1192-66f4" name="Hellhammer Cannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
               <characteristics>
                 <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">36&quot;</characteristic>
-                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 3D6</characteristic>
-                <characteristic name="S" typeId="59b1-319e-ec13-d466">10</characteristic>
-                <characteristic name="AP" typeId="75aa-a838-b675-6484">-4</characteristic>
-                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">3</characteristic>
-                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. Units attacked by this weapon do not gain any bonus to their saving throws for being in cover.</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 3D6+6</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">7</characteristic>
+                <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast. Turret Weapon (pg 75). Each time an attack is made with this weapon, the target does not receive the benefits of Light Cover against that attack.</characteristic>
               </characteristics>
             </profile>
           </profiles>
+          <selectionEntries>
+            <selectionEntry id="9c68-2f29-d3f1-bf94" name="Co-Axial Autocannon" publicationId="e831-8627-fbc7-5b35" page="115" hidden="false" collective="false" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e24-5bce-2217-c745" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a756-ba19-02c3-d457" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="35df-d9e6-bf26-002a" name="Co-Axial Autocannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                  <characteristics>
+                    <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">48&quot;</characteristic>
+                    <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">heavy 2</characteristic>
+                    <characteristic name="S" typeId="59b1-319e-ec13-d466">7</characteristic>
+                    <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
+                    <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
+                    <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Turret Weapon (Pg 75)</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+            </selectionEntry>
+          </selectionEntries>
           <costs>
             <cost name="pts" typeId="points" value="0.0"/>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
+        <selectionEntry id="ee0d-123b-1472-2594" name="Heavy Stubber" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="set" field="points" value="0.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a05-d370-a53c-438d" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f07c-f757-d1ce-c3c7" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="e42c-7b4a-c9a7-85d3" name="Heavy stubber" hidden="false" targetId="0031-0314-5b36-a220" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+          </costs>
+        </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="d5b6-f9fa-ccfb-1a12" name="Hunter-killer missile" hidden="false" collective="false" import="true" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9b25-e2eb-3b25-7b8e" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="940c-50b1-78cf-9796" name="Adamantium Tracks" hidden="false" collective="false" import="true" targetId="7c20-256a-b607-245d" type="selectionEntry">
+        <entryLink id="940c-50b1-78cf-9796" name="Adamantine Tracks" hidden="false" collective="false" import="true" targetId="7c20-256a-b607-245d" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e8c4-d3ae-89e0-7888" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="54ca-b704-a957-9950" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="d941-76fd-efed-0e0d" name="New EntryLink" hidden="false" collective="false" import="true" targetId="6e2c-4f30-b09d-c637" type="selectionEntry">
+        <entryLink id="d941-76fd-efed-0e0d" name="Stat Damage (Baneblade)" hidden="false" collective="false" import="true" targetId="6e2c-4f30-b09d-c637" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a408-7898-6ed6-bf2f" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea63-e5df-1937-e077" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="47fa-3415-52a1-d101" name="Autocannon" hidden="false" collective="false" import="true" targetId="5210-8cb2-b5a2-a04f" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0a2-bd58-973f-7a45" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8b92-6087-5bf4-75e3" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="439a-7d45-255b-1399" name="Demolisher cannon" hidden="false" collective="false" import="true" targetId="1f7e-32c4-61af-510f" type="selectionEntry">
@@ -11146,21 +11232,23 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eec4-2bf4-3d28-3207" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="51ac-815a-b1c0-b51e" name="New EntryLink" hidden="false" collective="false" import="true" targetId="be51-49ae-9966-cfc5" type="selectionEntryGroup"/>
-        <entryLink id="7990-1fd8-4817-62ea" name="New EntryLink" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
-        <entryLink id="32db-098f-d82b-bbf5" name="Lasgun" hidden="false" collective="false" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
+        <entryLink id="51ac-815a-b1c0-b51e" name="Baneblade Sponsons" hidden="false" collective="false" import="true" targetId="be51-49ae-9966-cfc5" type="selectionEntryGroup"/>
+        <entryLink id="b4c0-7ad6-a1a3-73e6" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+        <entryLink id="50c1-3657-51d5-fb04" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="f0fe-fcba-0b9f-0377" name="Super Heavy Aces" hidden="false" collective="false" import="true" targetId="f14f-06c3-76c0-2c4a" type="selectionEntryGroup"/>
+        <entryLink id="ed0c-6a0e-760a-c233" name="Armoured Tracks" hidden="false" collective="false" import="true" targetId="1fd9-a5e2-ad93-3a21" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="0.0"/>
+          </modifiers>
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5e3-d3c7-5019-cf51" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5fd8-5b55-b2a6-1785" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e44-4ce5-ca78-86c9" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a569-eb6d-7a04-da58" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="b4c0-7ad6-a1a3-73e6" name="Unit has battle honors?" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="50c1-3657-51d5-fb04" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
-        <entryLink id="f0fe-fcba-0b9f-0377" name="Tank Aces" hidden="false" collective="false" import="true" targetId="998b-b53a-603f-6c5b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="450.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="28.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="26.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -11291,7 +11379,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="7905-3074-b98d-ce54" name="Infantry Squad" publicationId="53e9d88f--pubN88319" page="0" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="7905-3074-b98d-ce54" name="Infantry Squad" publicationId="e831-8627-fbc7-5b35" page="90" hidden="false" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="append" field="name" value="[Legends]">
           <conditionGroups>
@@ -11305,7 +11393,8 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         </modifier>
       </modifiers>
       <infoLinks>
-        <infoLink id="98b4-eb01-e3b5-37e9" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
+        <infoLink id="670b-0164-7936-4247" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="bdb0-bb73-5a8e-19bc" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="c779-b8be-786f-0df6" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
@@ -11313,6 +11402,8 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         <categoryLink id="ad2c-4c55-74de-f7c5" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
         <categoryLink id="6741-36ba-4454-701b" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
         <categoryLink id="d572-ab3b-4eb7-e61c" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+        <categoryLink id="8f1e-254b-2a5b-dd6d" name="Core" hidden="false" targetId="08f1-d244-eb44-7e01" primary="false"/>
+        <categoryLink id="1a55-4290-8cde-9c61" name="Platoon" hidden="false" targetId="717a-8f8b-caee-189d" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="cf83-4163-2d65-cb4f" name="Sergeant" page="0" hidden="false" collective="false" import="true" type="model">
@@ -11335,6 +11426,9 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
               </characteristics>
             </profile>
           </profiles>
+          <infoLinks>
+            <infoLink id="3f30-8405-3a82-3762" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
+          </infoLinks>
           <selectionEntryGroups>
             <selectionEntryGroup id="03a5-6df4-65c7-221b" name="Chainsword" hidden="false" collective="false" import="true">
               <constraints>
@@ -11426,6 +11520,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
               </constraints>
               <infoLinks>
                 <infoLink id="5267-ef7c-3ff1-146f" name="Guardsman" hidden="false" targetId="3635-257d-26f1-26e8" type="profile"/>
+                <infoLink id="ddbf-bd4b-67a0-eaf5" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
               </infoLinks>
               <entryLinks>
                 <entryLink id="79aa-a9e9-d31c-01a7" name="Lasgun" hidden="false" collective="false" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
@@ -11456,6 +11551,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
               </constraints>
               <infoLinks>
                 <infoLink id="7fb0-164b-8f3b-9ac9" name="New InfoLink" hidden="false" targetId="3635-257d-26f1-26e8" type="profile"/>
+                <infoLink id="a8ff-59cd-7e2d-7f9f" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
               </infoLinks>
               <entryLinks>
                 <entryLink id="a6bc-abb1-a6ce-0f10" name="Lasgun" hidden="false" collective="false" import="true" targetId="7236-b28a-2b6e-ded7" type="selectionEntry">
@@ -11477,6 +11573,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
               </constraints>
               <infoLinks>
                 <infoLink id="93a2-5bd0-9411-757a" name="New InfoLink" hidden="false" targetId="3635-257d-26f1-26e8" type="profile"/>
+                <infoLink id="16f1-e18b-e119-5767" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
               </infoLinks>
               <entryLinks>
                 <entryLink id="9478-9d08-80b9-73fc" name="Astra Militarum Special Weapons" hidden="false" collective="false" import="true" targetId="a465-d3f9-68f9-2e55" type="selectionEntryGroup">
@@ -11497,6 +11594,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
               </constraints>
               <infoLinks>
                 <infoLink id="6fd7-a621-08e3-c7b3" name="New InfoLink" hidden="false" targetId="83ce-60e7-ff5a-633c" type="profile"/>
+                <infoLink id="3309-a5bf-1cc6-b403" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
               </infoLinks>
               <entryLinks>
                 <entryLink id="1cd5-9810-d401-247a" name="Astra Militarum Heavy Weapons" hidden="false" collective="false" import="true" targetId="29c3-5475-96d1-6a44" type="selectionEntryGroup">
@@ -11566,6 +11664,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 <infoLink id="d595-6557-60e3-77b9" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
                 <infoLink id="f12f-794f-0378-f6cf" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
                 <infoLink id="d339-bb79-80b0-0b65" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+                <infoLink id="4995-6f5b-cacb-72f1" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="9084-bff1-9911-3b16" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
@@ -11717,6 +11816,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 <infoLink id="0884-cc6d-2bd2-1c1d" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
                 <infoLink id="42f1-c630-5158-7c3c" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
                 <infoLink id="72c1-90ee-9ad1-f876" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+                <infoLink id="0e9e-7cc5-413b-513c" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="7c73-1ab7-cafe-52de" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
@@ -11752,6 +11852,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 <infoLink id="faba-e220-35c9-07ed" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
                 <infoLink id="332e-63f3-1706-7c18" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
                 <infoLink id="232b-0cb2-b6a3-82a4" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+                <infoLink id="b7f4-f988-ed62-6b3e" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="b543-4f7c-7117-44ee" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
@@ -11787,6 +11888,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 <infoLink id="780c-c171-0175-bd13" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
                 <infoLink id="d08f-302c-bbfe-9e87" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
                 <infoLink id="1247-2439-7ef4-4cc3" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
+                <infoLink id="78be-c0a7-c3dc-764a" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="12fb-c09f-7b39-0be4" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
@@ -11822,6 +11924,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 <infoLink id="2ad2-0d2b-cbb8-a8d9" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
                 <infoLink id="5b65-66a0-84e5-f1e2" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
                 <infoLink id="8d3e-59d6-c722-9208" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+                <infoLink id="c93a-3a05-5645-e252" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="4d06-97f3-b5e6-267c" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
@@ -11857,6 +11960,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 <infoLink id="4af0-cef5-1509-77af" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
                 <infoLink id="68a8-622a-54c5-abad" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
                 <infoLink id="1e91-fa98-8130-a14a" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+                <infoLink id="2fd0-6539-f4da-a88e" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="088a-d4d4-e27e-ed59" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
@@ -11892,6 +11996,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 <infoLink id="7fa4-9c60-07b7-15cb" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
                 <infoLink id="f5e8-0c2c-ae7f-b103" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
                 <infoLink id="aee4-9be1-6a28-65f9" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+                <infoLink id="5a3c-5ee5-827d-4eaa" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
               </infoLinks>
               <categoryLinks>
                 <categoryLink id="5c48-35f3-e5c9-78db" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
@@ -11922,8 +12027,8 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
             </selectionEntry>
           </selectionEntries>
           <entryLinks>
-            <entryLink id="177c-d773-f6b7-3ec5" name="Has Battle Honours" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-            <entryLink id="1b72-fa64-76e3-b1d1" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+            <entryLink id="177c-d773-f6b7-3ec5" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
+            <entryLink id="1b72-fa64-76e3-b1d1" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -12075,6 +12180,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       <infoLinks>
         <infoLink id="b23f-3bff-7087-4ca0" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
         <infoLink id="0a5f-5909-28ab-00ac" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="e7f0-4e22-7b9f-c83e" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="b46b-695a-ce6f-877a" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
@@ -13421,7 +13527,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="c485-dfd6-e9c8-46d7" name="Rein and Raus" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="c485-dfd6-e9c8-46d7" name="Rein and Raus" hidden="true" collective="false" import="true" type="unit">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="050c-66f9-2965-2f7a" type="max"/>
       </constraints>
@@ -13632,6 +13738,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       </profiles>
       <infoLinks>
         <infoLink id="3d62-dc0b-4eaf-e305" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="d090-b009-6891-e1fb" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="5e43-7c32-ef8b-c548" name="Cavalry" hidden="false" targetId="ad01-caec-17d9-cb8d" primary="false"/>
@@ -14119,6 +14226,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
             <infoLink id="f7aa-88ac-079f-3487" name="Explodes (6+/3&quot;/1)" hidden="false" targetId="8810-0e85-71ad-e4e3" type="profile"/>
             <infoLink id="d5b6-54b4-5af7-1c57" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
             <infoLink id="f426-d536-c955-d9c1" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+            <infoLink id="113a-e665-a4a7-afcf" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
           </infoLinks>
           <entryLinks>
             <entryLink id="d565-6308-7b23-cdf5" name="Sentinel Chainsaw" hidden="false" collective="false" import="true" targetId="8675-c6aa-5edc-6cc9" type="selectionEntry">
@@ -14520,7 +14628,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       <profiles>
         <profile id="7ccf-c1b1-9a42-7ec9" name="Transport: Stormlord" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
           <characteristics>
-            <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model can transport 40 ASTRA MILITARUM INFANTRY models.  Each Heavy Weapons Team or Veteran Heavy Weapons Team takes the place of two other models and each OGRYN takes the space of three other models.</characteristic>
+            <characteristic name="Capacity" typeId="15aa-1916-a38b-d223">This model has a transport capacity of 40 ASTRA MILITARUM INFANTRY models. Each Heavy Weapons Team or Veteran Heavy Weapons Team takes the place of 2 models. Each OGRYNS and BULLGRYNS model takes up the space of 3 models.</characteristic>
           </characteristics>
         </profile>
         <profile id="3060-40b3-5286-3d69" name="Stormlord" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -14538,20 +14646,21 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         </profile>
       </profiles>
       <infoLinks>
-        <infoLink id="3040-6f14-fa4c-de56" name="Explodes (Super-heavy)" hidden="false" targetId="f505-bfe1-b238-0c41" type="profile"/>
-        <infoLink id="60cf-0b58-63a5-8b33" name="Smoke Launchers" hidden="false" targetId="c883-3078-1367-cc2c" type="profile"/>
-        <infoLink id="b928-1c16-5e67-9f59" name="Steel Behemoth" hidden="false" targetId="62e4-243e-c188-2d88" type="profile"/>
-        <infoLink id="4b67-9f5b-50fc-16a7" name="Extended Firing Deck" hidden="false" targetId="c985-83d6-9ad6-10e2" type="profile"/>
+        <infoLink id="3040-6f14-fa4c-de56" name="Explodes (6+/2D6&quot;/D6)" hidden="false" targetId="f505-bfe1-b238-0c41" type="profile"/>
+        <infoLink id="4b67-9f5b-50fc-16a7" name="Firing Deck" hidden="false" targetId="9981-5fb9-57f6-7930" type="profile"/>
         <infoLink id="f86c-9432-00eb-7432" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8027-d59f-708e-75c2" name="Titanic" hidden="false" targetId="bdda-36f0-4f32-1639" primary="false"/>
-        <categoryLink id="1e11-7ba2-98ae-0029" name="Faction: &lt;REGIMENT&gt;" hidden="false" targetId="3e01-e6cf-1353-96f4" primary="false"/>
         <categoryLink id="5df3-bed8-6fd0-0f45" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
         <categoryLink id="68cb-7c84-83e1-0deb" name="Stormlord" hidden="false" targetId="22bb-87ee-7637-e5cc" primary="false"/>
         <categoryLink id="5bdb-361d-31f6-893c" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
         <categoryLink id="4161-a109-2747-2f77" name="Transport" hidden="false" targetId="6cc4-1b62-8e8a-05cd" primary="false"/>
         <categoryLink id="6c7f-55ba-b3e1-b175" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="3024-2bd1-6bfe-c30d" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+        <categoryLink id="d13d-2737-cc3e-510d" name="Smoke" hidden="false" targetId="bcf4-1bd8-9794-feaa" primary="false"/>
+        <categoryLink id="31a4-d173-3037-4d13" name="Armoured" hidden="false" targetId="9401-e2e7-bd2c-b3cf" primary="false"/>
+        <categoryLink id="1871-308b-9cd9-4d4a" name="Super-Heavy" hidden="false" targetId="ab99-87a7-c0d6-b038" primary="false"/>
       </categoryLinks>
       <selectionEntries>
         <selectionEntry id="772b-2873-7c37-444d" name="Hull-mounted Vulcan Mega-bolter" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -14562,12 +14671,12 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
           <profiles>
             <profile id="2d34-b6f6-95e0-bcc6" name="Hull-mounted Vulcan Mega-bolter" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
               <characteristics>
-                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">60&quot;</characteristic>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">48&quot;</characteristic>
                 <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 20</characteristic>
                 <characteristic name="S" typeId="59b1-319e-ec13-d466">6</characteristic>
                 <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
                 <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
-                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"/>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Turret Weapon (pg 75)</characteristic>
               </characteristics>
             </profile>
           </profiles>
@@ -14579,18 +14688,13 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         </selectionEntry>
       </selectionEntries>
       <entryLinks>
-        <entryLink id="e2e4-3fda-bf1c-6da0" name="Hunter-killer missile" hidden="false" collective="false" import="true" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3efa-bfee-6496-f71c" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="5ec0-d222-f8fc-54d2" name="Adamantium Tracks" hidden="false" collective="false" import="true" targetId="7c20-256a-b607-245d" type="selectionEntry">
+        <entryLink id="5ec0-d222-f8fc-54d2" name="Adamantine Tracks" hidden="false" collective="false" import="true" targetId="7c20-256a-b607-245d" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5831-3df3-55a9-a2b1" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="603b-467f-4c94-0592" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="fd5f-f241-4dd2-700a" name="Stat Damage (Baneblade)" hidden="false" collective="false" import="true" targetId="6e2c-4f30-b09d-c637" type="selectionEntry">
+        <entryLink id="fd5f-f241-4dd2-700a" name="Stat Damage (Banehammer)" hidden="false" collective="false" import="true" targetId="2f89-1409-f584-dc03" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e621-d20c-ee5b-3e9b" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c30b-2723-5757-27ef" type="max"/>
@@ -14608,15 +14712,23 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ebd7-e55b-4c08-6737" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="1dc3-8827-6885-eeb6" name="New EntryLink" hidden="false" collective="false" import="true" targetId="be51-49ae-9966-cfc5" type="selectionEntryGroup"/>
-        <entryLink id="8a66-e00c-3a75-81c9" name="New EntryLink" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
+        <entryLink id="1dc3-8827-6885-eeb6" name="Baneblade Sponsons" hidden="false" collective="false" import="true" targetId="be51-49ae-9966-cfc5" type="selectionEntryGroup"/>
         <entryLink id="8e45-a19b-3336-0e2e" name="Unit has battle honors?" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="796d-2ea8-6845-faf2" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
-        <entryLink id="efcb-1bd6-a91e-ec3d" name="Tank Aces" hidden="false" collective="false" import="true" targetId="998b-b53a-603f-6c5b" type="selectionEntryGroup"/>
+        <entryLink id="796d-2ea8-6845-faf2" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="efcb-1bd6-a91e-ec3d" name="Super Heavy Aces" hidden="false" collective="false" import="true" targetId="f14f-06c3-76c0-2c4a" type="selectionEntryGroup"/>
+        <entryLink id="cdde-4d59-dc25-656a" name="Armoured Tracks" hidden="false" collective="false" import="true" targetId="1fd9-a5e2-ad93-3a21" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="points" value="0.0"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6f84-c262-98ea-a270" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e172-a496-a167-aebf" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="430.0"/>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="27.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="25.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -14650,6 +14762,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         <infoLink id="81b9-313d-8c22-efb1" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
         <infoLink id="d2c1-74b1-a42f-aa5b" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
         <infoLink id="bf23-a5ac-6ac9-28f7" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="13fe-4cbd-a80c-df77" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="db9f-46e4-a4f6-42c5" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
@@ -15061,7 +15174,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="eee1-85bc-99e2-4144" name="Veterans" publicationId="53e9d88f--pubN88319" page="38" hidden="false" collective="false" import="true" type="unit">
+    <selectionEntry id="eee1-85bc-99e2-4144" name="Veterans" publicationId="53e9d88f--pubN88319" page="38" hidden="true" collective="false" import="true" type="unit">
       <modifiers>
         <modifier type="append" field="name" value="[Legends]">
           <conditionGroups>
@@ -15523,6 +15636,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         <infoLink id="d497-7401-d506-2d24" name="Aerial Drop" hidden="false" targetId="0a6c-a8e0-8fd8-b3f0" type="profile"/>
         <infoLink id="2829-acbe-b204-b6b5" name="Storm Troopers" hidden="false" targetId="4406-f18f-b2df-5f01" type="profile"/>
         <infoLink id="597a-ecde-b2cf-2a3e" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="ee61-4ba2-c42e-a127" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="aa86-0282-c675-3f97" name="Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
@@ -16093,6 +16207,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       <infoLinks>
         <infoLink id="37a9-2720-356a-3538" name="Aerial Drop" hidden="false" targetId="0a6c-a8e0-8fd8-b3f0" type="profile"/>
         <infoLink id="ee21-c407-5267-fe68" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="356a-0ea8-8b25-0964" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="25fd-b542-b5bb-9ca2" name="Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
@@ -16463,6 +16578,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       </profiles>
       <infoLinks>
         <infoLink id="7b3d-03eb-bbd6-db44" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="c9c4-00c5-811e-bb74" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="38ac-7398-a889-f82d" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
@@ -17129,7 +17245,7 @@ You can only use this Stratagem once, unless you are playing a Strike Force batt
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="95bf-a6bb-aa87-0baa" name="Whiteshields" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="95bf-a6bb-aa87-0baa" name="Whiteshields" hidden="true" collective="false" import="true" type="upgrade">
       <modifiers>
         <modifier type="set" field="hidden" value="true"/>
         <modifier type="set" field="2d3b-b544-ad49-fb75" value="-2.0">
@@ -17236,6 +17352,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
       </profiles>
       <infoLinks>
         <infoLink id="919a-3d34-6cf4-5ab2" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="971c-3357-9772-aee1" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8fed-d0c2-1ecd-e848" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
@@ -17266,6 +17383,10 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
           </characteristics>
         </profile>
       </profiles>
+      <infoLinks>
+        <infoLink id="11de-824e-78c7-d2c2" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
+        <infoLink id="2d66-f185-fdc4-f95f" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+      </infoLinks>
       <categoryLinks>
         <categoryLink id="431c-3750-bbb6-8db1" name="Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
         <categoryLink id="1a58-7c34-dbe7-8ff7" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
@@ -17725,6 +17846,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         <infoLink id="b05c-b12f-7578-9579" name="Heavy stubber" hidden="false" targetId="0031-0314-5b36-a220" type="profile"/>
         <infoLink id="61dd-e723-bd4c-d490" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
         <infoLink id="1b46-128c-efaf-0bd7" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="55ec-5430-7482-ddc9" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8363-d9d5-78fd-6eb6" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
@@ -18073,6 +18195,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         <infoLink id="f2d5-3b56-da4b-3008" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
         <infoLink id="6977-79dd-7ced-b4ce" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
         <infoLink id="0cd3-5fe3-c424-0949" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="2cae-3e22-4c93-b1ba" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="9dcd-5f81-46ac-f1da" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
@@ -18146,6 +18269,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         <infoLink id="24ef-c115-0701-4727" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
         <infoLink id="fc80-8d72-7fd2-8d0c" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
         <infoLink id="c026-d9ae-b06d-9973" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="ba70-ddf1-7ebe-3ef4" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="837c-d9b6-12a5-71c0" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
@@ -18235,6 +18359,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         <infoLink id="4319-e6eb-77b0-770e" name="Refractor Field" hidden="false" targetId="783d-d067-2d7f-d2a1" type="profile"/>
         <infoLink id="e441-ce12-485c-e230" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
         <infoLink id="8b40-6f09-4d8f-5c3c" name="Senior Officer" hidden="false" targetId="f34c8090-4e32-bd27-df37-1b714a4288d2" type="profile"/>
+        <infoLink id="cf5e-f47b-28ec-5259" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8bab-32f2-e257-5cf2" name="Officer" hidden="false" targetId="dd6e-7055-ca6b-b711" primary="false"/>
@@ -18555,7 +18680,8 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
       </profiles>
       <infoLinks>
         <infoLink id="8654-9afa-0409-880a" name="Senior Officer (Aura)" hidden="false" targetId="f34c8090-4e32-bd27-df37-1b714a4288d2" type="profile"/>
-        <infoLink id="6ab5-ced6-74f9-3026" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="6ab5-ced6-74f9-3026" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
+        <infoLink id="09a5-dad4-a7d7-d077" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="acbe-6971-042d-8483" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
@@ -18689,6 +18815,7 @@ Note that this ability only affects the original target of that Order, and not a
         <infoLink id="e7c5-056e-5543-9bd7" name="Refractor Field" hidden="false" targetId="783d-d067-2d7f-d2a1" type="profile"/>
         <infoLink id="33c4-225b-4ba8-d3af" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
         <infoLink id="8b75-6ac7-50da-19c1" name="Senior Officer (Aura)" hidden="false" targetId="f34c8090-4e32-bd27-df37-1b714a4288d2" type="profile"/>
+        <infoLink id="040c-7e98-ef9b-17fd" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="a721-fb44-4a74-198a" name="New CategoryLink" hidden="false" targetId="b332-b046-7171-5059" primary="false"/>
@@ -18810,6 +18937,7 @@ Note that this ability only affects the original target of that Order, and not a
         <infoLink id="55cf-21ff-20fe-719c" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
         <infoLink id="780a-ef23-2ed4-2ea4" name="Death Korps" hidden="false" targetId="d87e-6f7f-5d78-6485" type="profile"/>
         <infoLink id="953f-d716-d8a3-6937" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="ed65-6166-7c8d-acb7" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="fc7c-d5ee-a61a-9611" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
@@ -19281,6 +19409,7 @@ Note that this ability only affects the original target of that Order, and not a
       </profiles>
       <infoLinks>
         <infoLink id="9ace-53cf-81e7-82cc" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="edd1-6439-c356-cd78" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1cec-9e59-a0d5-ac6b" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
@@ -19479,6 +19608,7 @@ Note that this ability only affects the original target of that Order, and not a
         <infoLink id="68ac-6b6a-1d9c-ce8d" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
         <infoLink id="8a91-a2b7-e059-15de" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
         <infoLink id="186e-a91b-9e21-c59a" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="a9e6-6e78-c271-2986" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="6331-ebf1-884b-3302" name="Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
@@ -19721,6 +19851,7 @@ Note that this ability only affects the original target of that Order, and not a
         <infoLink id="56ce-41fe-fa90-cfae" name="Hellhound" hidden="false" targetId="bd48e6cb-2610-1525-abcc-200af38774a2" type="profile"/>
         <infoLink id="c706-a180-90b0-1b64" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
         <infoLink id="fa24-b91f-4bff-bcb4" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="2004-b6ba-5ede-3ed7" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="ba20-375d-4b12-5783" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
@@ -19751,6 +19882,11 @@ Note that this ability only affects the original target of that Order, and not a
                   </characteristics>
                 </profile>
               </profiles>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="3317-9bc1-154e-2051" name="Melta Cannon" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
@@ -19765,6 +19901,11 @@ Note that this ability only affects the original target of that Order, and not a
                   </characteristics>
                 </profile>
               </profiles>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
             <selectionEntry id="0364-b7ce-1ede-7aec" name="Inferno Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
               <profiles>
@@ -19849,16 +19990,6 @@ Note that this ability only affects the original target of that Order, and not a
             <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model can never be your WARLORD.</characteristic>
           </characteristics>
         </profile>
-        <profile id="4dca-f960-fa13-f42a" name="Ripper Pistol" publicationId="e831-8627-fbc7-5b35" page="93" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">12&quot;</characteristic>
-            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Pistol 3</characteristic>
-            <characteristic name="S" typeId="59b1-319e-ec13-d466">5</characteristic>
-            <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
-            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Each time you select a target for this weapon, you can ignore the Look Out, Sir rule. Each time an attack is made with this weapon, an unmodified wound roll of 6 inflicts 1 mortal wound on the target in addition to any normal damage.</characteristic>
-          </characteristics>
-        </profile>
         <profile id="cb76-2512-9970-93da" name="Hidden Ambush" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">During deployment, you can set up this model in ambush instead of setting it up on the battlefield. If you do so, then in the Reinforcements step of one of your Movement phases, you can set up this unit anywhere on the battlefield that is more than 9&quot; away from any enemy models. Until the end of that turn, you can re-roll charge rolls made for this model.</characteristic>
@@ -19869,19 +20000,10 @@ Note that this ability only affects the original target of that Order, and not a
             <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Once per battle, at the end of the Fight phase, you can remove this unit from the battlefield. If you do so, in the Reinforcements step of your next Movement phase, set this model back up anywhere on the battlefield that is more than 9&quot; away from any enemy models. If the battle ends and this model is not on the Battlefield, it is destroyed.</characteristic>
           </characteristics>
         </profile>
-        <profile id="5941-5646-0871-382c" name="Envenomed blade" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">Melee</characteristic>
-            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Melee</characteristic>
-            <characteristic name="S" typeId="59b1-319e-ec13-d466">+2</characteristic>
-            <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
-            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Each time an attack made with this weapon is allocated to a non-VEHICLE model, that attack has a Damage characteristic of 2.</characteristic>
-          </characteristics>
-        </profile>
       </profiles>
       <infoLinks>
         <infoLink id="16e2-3dcd-189e-0915" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="0696-7cad-d493-5a45" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="14f8-a9a6-e927-6a64" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
@@ -19894,6 +20016,58 @@ Note that this ability only affects the original target of that Order, and not a
         <categoryLink id="4787-a888-4b71-d6b3" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
         <categoryLink id="d8ea-2b29-fe65-fe6a" name="Sly Marbo" hidden="false" targetId="9ef3-50ee-426d-597b" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="4c59-e7b6-cb2b-dcc7" name="Envenomed Blade" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8991-4c9c-de47-c9e4" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="28e3-1659-aac6-2b5f" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="b7a4-96fc-281c-4c54" name="Envenomed blade" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">Melee</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Melee</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">+2</characteristic>
+                <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Each time an attack made with this weapon is allocated to a non-VEHICLE model, that attack has a Damage characteristic of 2.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="0b6d-a88e-2b1c-f1ce" name="Ripper Pistol" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="97c6-c6e3-428e-c74f" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="614d-5811-0ee1-0fbf" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="6ed8-239d-0502-ea9f" name="Ripper Pistol" publicationId="e831-8627-fbc7-5b35" page="93" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">12&quot;</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Pistol 3</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">5</characteristic>
+                <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Each time you select a target for this weapon, you can ignore the Look Out, Sir rule. Each time an attack is made with this weapon, an unmodified wound roll of 6 inflicts 1 mortal wound on the target in addition to any normal damage.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="0732-30f4-0052-5ca4" name="Character Stratagems (Named)" hidden="false" collective="false" import="true" targetId="ed7a-3deb-4d62-b2a9" type="selectionEntryGroup"/>
+        <entryLink id="c316-b755-f832-56c0" name="Frag grenades" hidden="false" collective="false" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9452-b270-7451-7649" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ae2-8522-b343-934a" type="min"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="50.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="3.0"/>
@@ -19923,16 +20097,6 @@ Note that this ability only affects the original target of that Order, and not a
             <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Before deployment, you can select one CATACHAN JUNGLE FIGHTERS unit from your army. Until the end of the battle, each time a model in that unit makes an attack, re-roll a hit roll of 1.</characteristic>
           </characteristics>
         </profile>
-        <profile id="2c6a-24bb-22de-1c9c" name="Payback" publicationId="e831-8627-fbc7-5b35" page="95" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-          <characteristics>
-            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">36&quot;</characteristic>
-            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault 3</characteristic>
-            <characteristic name="S" typeId="59b1-319e-ec13-d466">5</characteristic>
-            <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
-            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"></characteristic>
-          </characteristics>
-        </profile>
         <profile id="0e1b-1f30-ce98-ff4e" name="Catachan Sergeant" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">This model can never be your WARLORD.</characteristic>
@@ -19951,6 +20115,7 @@ Note that this ability only affects the original target of that Order, and not a
       </profiles>
       <infoLinks>
         <infoLink id="2192-1459-27e5-d725" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="82d8-88cc-ed92-f61d" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8e11-aeea-9af9-dab3" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
@@ -19962,9 +20127,327 @@ Note that this ability only affects the original target of that Order, and not a
         <categoryLink id="ab19-2702-51ce-3c85" name="Officer" hidden="false" targetId="dd6e-7055-ca6b-b711" primary="false"/>
         <categoryLink id="2cb1-d9e0-c30e-fbf2" name="Sergeant Harker" hidden="false" targetId="2aa8-ef0c-eae7-21bc" primary="false"/>
       </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="1681-3d8f-0ef4-fb7f" name="Payback" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b990-f49b-2afd-36ed" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ab7-b241-0de5-7f48" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="e528-0ce4-7e4f-a438" name="Payback" publicationId="e831-8627-fbc7-5b35" page="95" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">36&quot;</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault 3</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">5</characteristic>
+                <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"/>
+              </characteristics>
+            </profile>
+          </profiles>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="cb65-a39f-e061-bb42" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f1c8-ad4a-3931-8002" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2ce-2e4b-8505-5eb1" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="40.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="2.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="83b0-3cc2-15cc-6d3a" name="Cadian Shock Troops" publicationId="e831-8627-fbc7-5b35" page="91" hidden="false" collective="false" import="true" type="unit">
+      <profiles>
+        <profile id="698f-ba09-9209-bd71" name="Shock Troops" publicationId="e831-8627-fbc7-5b35" page="91" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time a model in this unit makes a ranged attack with a lasgun or laspistol, an unmodified hit roll of 6 scores 1 additional hit.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <infoLinks>
+        <infoLink id="4128-8c85-a2ab-e364" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="d60f-e643-e017-d024" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
+      </infoLinks>
+      <categoryLinks>
+        <categoryLink id="b912-eba0-d591-df19" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
+        <categoryLink id="0503-1fb6-e1c6-6239" name="Infantry Squad" hidden="false" targetId="9e19-4e60-2e53-8758" primary="false"/>
+        <categoryLink id="2a00-303e-5340-2a5a" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+        <categoryLink id="0b71-3773-4317-d3f2" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="6e50-2687-3534-607b" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+        <categoryLink id="9da2-8dd6-5a7d-af18" name="Faction: Cadian" hidden="false" targetId="b332-b046-7171-5059" primary="false"/>
+        <categoryLink id="35f5-f53d-e7dc-8f98" name="Core" hidden="false" targetId="08f1-d244-eb44-7e01" primary="false"/>
+        <categoryLink id="048f-cf20-d3b1-f5a8" name="Platoon" hidden="false" targetId="717a-8f8b-caee-189d" primary="false"/>
+        <categoryLink id="9dd0-6534-6753-d025" name="Shock Troops" hidden="false" targetId="22a1-8895-f588-fc52" primary="false"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="dc70-f97e-5534-0b87" name="Shock Trooper Sergeant" page="0" hidden="false" collective="false" import="true" type="model">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b3c7-cfb2-48ce-54ac" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="77a0-b1f3-3050-500f" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="5274-b9d0-19fc-120a" name="Shock Trooper Sergeant" publicationId="e831-8627-fbc7-5b35" page="91" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+              <characteristics>
+                <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
+                <characteristic name="BS" typeId="381b-eb28-74c3-df5f">4+</characteristic>
+                <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
+                <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
+                <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">2</characteristic>
+                <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
+                <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">5+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <infoLinks>
+            <infoLink id="3153-75e8-8392-1bd3" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
+          </infoLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="f6cf-aae0-00f6-3a98" name="Chainsword &amp; Laspistol" hidden="false" collective="false" import="true" defaultSelectionEntryId="860d-f285-ed03-2194">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eb21-e4d1-9548-52c9" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f3b4-647b-91a9-49dd" type="min"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="860d-f285-ed03-2194" name="Chainsword &amp; Laspistol" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="47a5-1cfa-4131-f5f2" type="max"/>
+                  </constraints>
+                  <selectionEntryGroups>
+                    <selectionEntryGroup id="ac17-eba1-8ae6-6b2a" name="Laspistol" hidden="false" collective="false" import="true" defaultSelectionEntryId="0347-c126-d7fa-4749">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0073-e6c1-2616-8c8c" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30e5-46ec-1d1e-9079" type="min"/>
+                      </constraints>
+                      <entryLinks>
+                        <entryLink id="1396-19c1-1a54-c8b1" name="Bolt pistol" hidden="false" collective="false" import="true" targetId="0334-f487-8229-0c1a" type="selectionEntry">
+                          <modifiers>
+                            <modifier type="set" field="points" value="0.0"/>
+                          </modifiers>
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90e3-8ab8-6ab4-d12d" type="max"/>
+                          </constraints>
+                        </entryLink>
+                        <entryLink id="0347-c126-d7fa-4749" name="Laspistol" hidden="false" collective="false" import="true" targetId="c10b-e1a4-c913-ae15" type="selectionEntry">
+                          <constraints>
+                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="31ad-5bdd-6822-5102" type="max"/>
+                          </constraints>
+                        </entryLink>
+                      </entryLinks>
+                    </selectionEntryGroup>
+                  </selectionEntryGroups>
+                  <entryLinks>
+                    <entryLink id="962e-f1af-babd-650c" name="Chainsword" hidden="false" collective="false" import="true" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3134-7e65-c854-ba00" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c40e-2e85-4a83-df3d" type="min"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntry>
+                <selectionEntry id="39b1-b162-5ee9-2776" name="Drum-Fed Autogun" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3552-ae88-bce7-f400" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="2b4b-e66b-2500-fa8e" name="Drum-Fed Autogun" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                      <characteristics>
+                        <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+                        <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Rapid Fire 2</characteristic>
+                        <characteristic name="S" typeId="59b1-319e-ec13-d466">3</characteristic>
+                        <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
+                        <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+                        <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <costs>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="fb18-7957-8c74-82c8" name="Shock Troopers" hidden="false" collective="false" import="true" defaultSelectionEntryId="a5eb-6b7a-7faa-bbd6">
+          <constraints>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="c46f-0115-a4eb-dbe9" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="64f6-2f19-e9c9-3b01" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="4539-acfc-13d1-1a0d" name="Shock Trooper w/ Vox-caster" page="0" hidden="false" collective="false" import="true" type="unit">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b491-af63-44eb-b0e3" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="8c06-3046-55c5-ab81" name="Shock Trooper" publicationId="e831-8627-fbc7-5b35" page="91" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+                  <characteristics>
+                    <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                    <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
+                    <characteristic name="BS" typeId="381b-eb28-74c3-df5f">4+</characteristic>
+                    <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                    <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
+                    <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
+                    <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">1</characteristic>
+                    <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">6</characteristic>
+                    <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">5+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="536b-a3a1-4670-d24d" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
+              </infoLinks>
+              <entryLinks>
+                <entryLink id="08b4-3715-52c4-fb77" name="Lasgun" hidden="false" collective="false" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c6fa-2e0b-712a-f02e" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52b5-78cb-2f9e-2212" type="min"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="b3da-abfd-25f7-cd52" name="Vox-caster" hidden="false" collective="false" import="true" targetId="9ce2-5815-93dd-2918" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="points" value="0.0"/>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b77f-7b13-5c3b-a101" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8842-8ebd-f94b-e6b8" type="max"/>
+                  </constraints>
+                  <categoryLinks>
+                    <categoryLink id="d2c2-10e8-d595-42cf" name="Vox-Caster" hidden="false" targetId="086d-e3ba-a17b-01bd" primary="false"/>
+                  </categoryLinks>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a5eb-6b7a-7faa-bbd6" name="Shock Trooper" page="0" hidden="false" collective="false" import="true" type="unit">
+              <constraints>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="42bc-98cc-7614-34cf" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="bddc-78af-940c-a7c1" name="Shock Trooper" publicationId="e831-8627-fbc7-5b35" page="91" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+                  <characteristics>
+                    <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                    <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
+                    <characteristic name="BS" typeId="381b-eb28-74c3-df5f">4+</characteristic>
+                    <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                    <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
+                    <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
+                    <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">1</characteristic>
+                    <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">6</characteristic>
+                    <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">5+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="de5f-85d5-dc7d-2de6" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
+              </infoLinks>
+              <entryLinks>
+                <entryLink id="914d-f4be-6c31-0d19" name="Lasgun" hidden="false" collective="false" import="true" targetId="7236-b28a-2b6e-ded7" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="efe8-6c64-ccd4-7db8" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6560-f2a1-da76-e4f0" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b273-fb2a-b999-32cc" name="Shock Trooper w/ Special Weapon" page="0" hidden="false" collective="false" import="true" type="unit">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6966-5ef7-5cbf-ea4d" type="max"/>
+              </constraints>
+              <profiles>
+                <profile id="120e-6b9f-fcd2-d584" name="Shock Trooper" publicationId="e831-8627-fbc7-5b35" page="91" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+                  <characteristics>
+                    <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                    <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
+                    <characteristic name="BS" typeId="381b-eb28-74c3-df5f">4+</characteristic>
+                    <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                    <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
+                    <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
+                    <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">1</characteristic>
+                    <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">6</characteristic>
+                    <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">5+</characteristic>
+                  </characteristics>
+                </profile>
+              </profiles>
+              <infoLinks>
+                <infoLink id="992b-8784-b05f-5d05" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
+              </infoLinks>
+              <entryLinks>
+                <entryLink id="0e94-5a67-138c-936b" name="Cadian Shock Troops Special Weapons" hidden="false" collective="false" import="true" targetId="b03b-b25b-69de-66e4" type="selectionEntryGroup">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe93-4f43-7a26-56e3" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fa40-7503-31e4-d6ac" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="3.0"/>
+        <cost name="pts" typeId="points" value="65.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="2f89-1409-f584-dc03" name="Stat Damage (Banehammer)" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c609-09d7-6d2a-9091" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c63-66d8-d09e-b27e" type="min"/>
+      </constraints>
+      <profiles>
+        <profile id="43c6-0285-fcec-c977" name="Banehammer 1" hidden="false" typeId="e6d5-85c5-7b01-a3c4" typeName="Stat Damage - M/BS/A">
+          <characteristics>
+            <characteristic name="Remaining W" typeId="233c-fa78-4641-68d9">15-28+</characteristic>
+            <characteristic name="Movement" typeId="fc73-9b3f-5e4b-86b9">10&quot;</characteristic>
+            <characteristic name="BS" typeId="8010-b879-355a-c137">4+</characteristic>
+            <characteristic name="Attacks" typeId="2e64-2e5c-f4d1-52d3">9</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="8c46-b022-ec1b-3cab" name="Banehammer 2" hidden="false" typeId="e6d5-85c5-7b01-a3c4" typeName="Stat Damage - M/BS/A">
+          <characteristics>
+            <characteristic name="Remaining W" typeId="233c-fa78-4641-68d9">8-14</characteristic>
+            <characteristic name="Movement" typeId="fc73-9b3f-5e4b-86b9">8&quot;</characteristic>
+            <characteristic name="BS" typeId="8010-b879-355a-c137">5+</characteristic>
+            <characteristic name="Attacks" typeId="2e64-2e5c-f4d1-52d3">6</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="3cc2-e0da-d0e9-211c" name="Banehammer 3" hidden="false" typeId="e6d5-85c5-7b01-a3c4" typeName="Stat Damage - M/BS/A">
+          <characteristics>
+            <characteristic name="Remaining W" typeId="233c-fa78-4641-68d9">1-7</characteristic>
+            <characteristic name="Movement" typeId="fc73-9b3f-5e4b-86b9">6&quot;</characteristic>
+            <characteristic name="BS" typeId="8010-b879-355a-c137">6+</characteristic>
+            <characteristic name="Attacks" typeId="2e64-2e5c-f4d1-52d3">3</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -20194,31 +20677,62 @@ Note that this ability only affects the original target of that Order, and not a
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
-    <selectionEntryGroup id="be51-49ae-9966-cfc5" name="Baneblade Sponsons" hidden="false" collective="false" import="true">
+    <selectionEntryGroup id="be51-49ae-9966-cfc5" name="Baneblade Sponsons" hidden="false" collective="false" import="true" defaultSelectionEntryId="5915-dee0-5a61-66f8">
       <constraints>
-        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f693-fac8-25eb-cb65" type="max"/>
-        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b972-7a3a-62db-eb4f" type="min"/>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f693-fac8-25eb-cb65" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b972-7a3a-62db-eb4f" type="min"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="5915-dee0-5a61-66f8" name="Lascannon &amp; Twin Heavy Bolter Sponson" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="5915-dee0-5a61-66f8" name="Lascannon &amp; Twin Heavy Flamer Sponsons" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85b9-d3fb-09e5-4ab8" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85b9-d3fb-09e5-4ab8" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c76f-5327-95f4-4336" type="max"/>
           </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="9dc8-197c-1f2e-4820" name="Twin Heavy Flamers" hidden="false" collective="false" import="true" defaultSelectionEntryId="ff2b-6ec3-e5a1-0ee5">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="178a-e5a2-4581-58c6" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ad1-95e4-b1ca-ab2d" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="7e8e-83d9-2740-fd56" name="Twin Heavy Bolters" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02d1-a87e-9dc1-71dc" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="ef3a-01fc-3bc9-438d" name="Twin heavy bolter" hidden="false" collective="false" import="true" targetId="09d8-7790-ed3f-4d6d" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2137-122c-44ea-4c56" type="min"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3133-1ab9-5208-fd45" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntry>
+                <selectionEntry id="ff2b-6ec3-e5a1-0ee5" name="Twin Heavy Flamers" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7262-3eaf-553d-5a4c" type="max"/>
+                  </constraints>
+                  <entryLinks>
+                    <entryLink id="3e00-ccf0-ebc9-c207" name="Twin heavy flamer" hidden="false" collective="false" import="true" targetId="8d70-a6af-cbad-f08c" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b387-aa70-a7d9-8f9f" type="min"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ba7-ad62-4a58-f256" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <entryLinks>
             <entryLink id="ee5f-74b0-fc23-d2b7" name="Lascannon" hidden="false" collective="false" import="true" targetId="a908-4664-11cd-f8b2" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7cd-c1cc-4073-0725" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b594-597f-f4de-db7d" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7cd-c1cc-4073-0725" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b594-597f-f4de-db7d" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="30.0"/>
+                <cost name="pts" typeId="points" value="20.0"/>
               </costs>
-            </entryLink>
-            <entryLink id="9ce0-390d-5845-70fc" name="Twin heavy bolter" hidden="false" collective="false" import="true" targetId="09d8-7790-ed3f-4d6d" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0588-7825-93a9-8f52" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa98-ae5a-349b-69aa" type="max"/>
-              </constraints>
             </entryLink>
           </entryLinks>
           <costs>
@@ -20227,25 +20741,49 @@ Note that this ability only affects the original target of that Order, and not a
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="c351-8eac-e60e-f8c5" name="Lascannon &amp; Twin Heavy Flamer Sponson" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="c351-8eac-e60e-f8c5" name="Additional Lascannons &amp; Twin Heavy Flamer Sponsons" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a4e-f36d-b21f-8b60" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a4e-f36d-b21f-8b60" type="max"/>
           </constraints>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="2e88-d069-95d4-0e27" name="Twin Heavy Flamers" hidden="false" collective="false" import="true" defaultSelectionEntryId="b028-a1d4-9e1d-9d68">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1d7c-9d29-6cb0-96d5" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d1f3-ceb2-21b7-fbb8" type="min"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="b028-a1d4-9e1d-9d68" name="Twin Heavy Flamers" hidden="false" collective="false" import="true" type="upgrade">
+                  <entryLinks>
+                    <entryLink id="7bdf-2073-6ed8-06f1" name="Twin heavy flamer" hidden="false" collective="false" import="true" targetId="8d70-a6af-cbad-f08c" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1de0-da8c-2850-f24e" type="min"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e3b6-7c59-5507-da8e" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntry>
+                <selectionEntry id="a565-ff78-8f0e-12bc" name="Twin Heavy Bolters" hidden="false" collective="false" import="true" type="upgrade">
+                  <entryLinks>
+                    <entryLink id="304c-b9f8-5743-b010" name="Twin heavy bolter" hidden="false" collective="false" import="true" targetId="09d8-7790-ed3f-4d6d" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cca6-d48d-ffd1-3220" type="min"/>
+                        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ab0-7824-ba1e-035a" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
           <entryLinks>
             <entryLink id="2e9a-f40a-fe1f-9ee7" name="Lascannon" hidden="false" collective="false" import="true" targetId="a908-4664-11cd-f8b2" type="selectionEntry">
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea15-a134-989c-8ded" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="909b-5ec0-0fbd-425d" type="max"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ea15-a134-989c-8ded" type="min"/>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="909b-5ec0-0fbd-425d" type="max"/>
               </constraints>
               <costs>
-                <cost name="pts" typeId="points" value="30.0"/>
+                <cost name="pts" typeId="points" value="20.0"/>
               </costs>
-            </entryLink>
-            <entryLink id="04df-335a-9078-6ca4" name="Twin heavy flamer" hidden="false" collective="false" import="true" targetId="8d70-a6af-cbad-f08c" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffa7-8cdb-0659-cc0f" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d4bf-9598-bf0b-b9c4" type="max"/>
-              </constraints>
             </entryLink>
           </entryLinks>
           <costs>
@@ -22769,6 +23307,62 @@ receive the benefits of cover against that attack.&quot;</characteristic>
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
+    <selectionEntryGroup id="b03b-b25b-69de-66e4" name="Cadian Shock Troops Special Weapons" hidden="false" collective="false" import="true" defaultSelectionEntryId="2d65-a63b-7ba2-0cfc">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9a8-d0cd-ab25-b985" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="2d65-a63b-7ba2-0cfc" name="Grenade launcher" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="166b-fa5a-95aa-18d3" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="6c32-f58e-4bf2-2132" name="Grenade launcher (Frag)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault D6</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">3</characteristic>
+                <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast.</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="f5a5-17ea-45c6-28c6" name="Grenade launcher (Krak)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault 1</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">6</characteristic>
+                <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"/>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <entryLinks>
+        <entryLink id="d795-ceba-6f6c-dcb9" name="Plasma gun" hidden="false" collective="false" import="true" targetId="8c14-22cc-93ce-b85a" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="591d-aa78-a602-146a" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="ce03-ddfd-6d63-76aa" name="Meltagun" hidden="false" collective="false" import="true" targetId="efc8-c51d-5b02-a3a2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="104b-2b00-8406-24bb" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="b19f-b7ed-4629-cab8" name="Flamer" hidden="false" collective="false" import="true" targetId="fd22-6743-2d4c-dd62" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96d4-a6e9-00a6-32e6" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="75fd-ec16-c371-a3e7" name="Acts of Faith" publicationId="53e9d88f--pubN88319" page="99" hidden="false">
@@ -22821,11 +23415,17 @@ Spirit of the Martyr: One model in the unit recovers D3 lost wounds, or you can 
     <rule id="7f63-7184-02bb-aaed" name="Wall of Muscle" hidden="false">
       <description>Each time an attack is allocated to a model in this unit, subtract 1 from teh Damage characteristic of that attack (to a minimum of 1)</description>
     </rule>
+    <rule id="89ad-69f4-02bf-74b6" name="Regimental Tactics" publicationId="e831-8627-fbc7-5b35" page="75" hidden="false">
+      <description>If every model from your army (excluding AGENT OF THE IMPERIUM and UNALIGNED models) has the ASTRA MILITARUM keyword:
+
+• Each time an OFFICER from your army issues a Regimental or Prefectus Order to a unit with this ability, you can select one or more other friendly PLATOON units within 6&quot; of that unit; those PLATOON units are also affected by that Order. 
+• Each time an OFFICER from your army issues a Mechanised Order to a unit with this ability, you can select one or more other friendly SQUADRON units within 6&quot; of that unit; those SQUADRON units are also affected by that Order.</description>
+    </rule>
   </sharedRules>
   <sharedProfiles>
     <profile id="9981-5fb9-57f6-7930" name="Firing Deck" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Up to 10 models being transported by a Banehammer can shoot in their Shooting phase, measuring and drawing line of sight from any point on the vehicle.  Units that shoot in this manner count as having moved if they or the Banehammer moved in the preceding Movement phase.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">In your Shooting phase, one unit embarked within this TRANSPORT model can be selected to shoot; when doing so, measure distances and draw line of sight from any point on this TRANSPORT model. If this TRANSPORT model made a Normal Move, Advanced or Fell Back this turn, embarked units are considered to have done the same. While this TRANSPORT model is within Engagement Range of any enemy units, embarked units cannot shoot, except with Pistols.</characteristic>
       </characteristics>
     </profile>
     <profile id="783d-d067-2d7f-d2a1" name="Refractor Field" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -23185,11 +23785,9 @@ Spirit of the Martyr: One model in the unit recovers D3 lost wounds, or you can 
         <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Turret Weapon (pg 75)</characteristic>
       </characteristics>
     </profile>
-    <profile id="175c-fee4-4229-5628" name="Regimental Tactics" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+    <profile id="175c-fee4-4229-5628" name="Regimental Tactics" publicationId="e831-8627-fbc7-5b35" page="75" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If every model from your army (excluding AGENT OF THE IMPERIUM and UNALIGNED models) has the ASTRA MILITARUM keyword:
-• Each time an OFFICER from your army issues a Regimental or Prefectus Order to a unit with this ability, you can select one or more other friendly PLATOON units within 6&quot; of that unit; those PLATOON units are also affected by that Order. 
-• Each time an OFFICER from your army issues a Mechanised Order to a unit with this ability, you can select one or more other friendly SQUADRON units within 6&quot; of that unit; those SQUADRON units are also affected by that Order.</characteristic>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">See Codex Astra Militarum (9th Ed.) pg 75 or Selection Rules</characteristic>
       </characteristics>
     </profile>
     <profile id="eb4d-1660-544a-18db" name="Regimental Standard (Aura)" publicationId="e831-8627-fbc7-5b35" page="84" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">


### PR DESCRIPTION
Added Cadian Shock Troops
Added Frag and Krak Grenades to Sgt. Harker
Added Frag Grenades to Sly Marbo
Put in the appropriate Selection Entries for Weapons on Harker and Marbo Addded in Regimental Tactics to Kasrkin
Included Chain of Command and Detachment Abilities in Force Rules

Updated
Updated Baneblade Chassis Sponson weapons setup (1 set  included, 1 additional set) Updated all Codex Super Heavies
Updated Infantry Squad
Unhid Sly Marbo and Sergeant Harker from the Non-Library Data File Shortened Regimental Tactics and included a Force Rule

Hid(Removed) Hammer of the Emperor
Removed Steel Behemoth from Super Heavies