### PR TITLE
0.3.1-Regimental-Doctrines-Update

### DIFF
--- a/Imperial_Guard_9th_Ed.cat
+++ b/Imperial_Guard_9th_Ed.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="53e9d88f-7463-8c27-fe67-e1a0d1ed0287" name="Imperium - Imperial Guard 9th Ed" revision="324" battleScribeVersion="2.03" authorName="3Komnenos3 &amp; TheHalfinstream" authorContact="" authorUrl="" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="53e9d88f-7463-8c27-fe67-e1a0d1ed0287" name="Imperium - Imperial Guard 9th Ed" revision="325" battleScribeVersion="2.03" authorName="3Komnenos3 &amp; TheHalfinstream" authorContact="" authorUrl="" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <readme>The BSData team is not responsible for these 9th edition updates and should not be contacted for support. Find us on the Mordian Glory Discord.
 
 This is a heavily modified version of the BSData team&apos;s Astra Militarum 8th Edition battlescribe files, and all credit goes to them for the creation of the 8th edition version which laid the foundation to our project to bring over the 9th edition codex, and an additional thanks for answering some of our questions on the BSData discord, as well as allowing us to go forward with this project.</readme>
@@ -1278,11 +1278,11 @@ Use this Act of Faith at the start of the Morale phase. If successful, the selec
     </selectionEntry>
     <selectionEntry id="73fc-bc45-dbdd-417d" name="Regimental Doctrine" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f6d-f02b-517e-0537" type="max"/>
-        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="629f-f418-774e-01f9" type="min"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4f6d-f02b-517e-0537" type="max"/>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="629f-f418-774e-01f9" type="min"/>
       </constraints>
       <entryLinks>
-        <entryLink id="bca9-103d-9ff7-e000" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="1f55-4ee0-5c0e-5b35" type="selectionEntryGroup"/>
+        <entryLink id="bca9-103d-9ff7-e000" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="98f4-2191-c2da-8c7b" type="selectionEntryGroup"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>

--- a/Imperium_-_Imperial_Guard_9th_Ed_Library.cat
+++ b/Imperium_-_Imperial_Guard_9th_Ed_Library.cat
@@ -1,6 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a2d9-e3b7-13cc-6f15" name="Imperium - Imperial Guard - 9th Ed - Library" revision="120" battleScribeVersion="2.03" authorName="3Komnenos3, TheHalfinStream" authorContact="" authorUrl="" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
-  <readme>The BSData team is not responsible for these 9th edition updates and should not be contacted for support. Find us on the Mordian Glory Discord.</readme>
+<catalogue id="a2d9-e3b7-13cc-6f15" name="Imperium - Imperial Guard - 9th Ed - Library" revision="121" battleScribeVersion="2.03" authorName="3Komnenos3, TheHalfinStream" authorContact="" authorUrl="" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+  <readme>The BSData team is not responsible for these 9th edition updates and should not be contacted for support. Find us on the Mordian Glory Discord.
+
+
+This is a heavily modified version of the BSData team&apos;s Astra Militarum 8th Edition battlescribe files, and all credit goes to them for the creation of the 8th edition version which laid the foundation to our project to bring over the 9th edition codex, and an additional thanks for answering some of our questions on the BSData discord, as well as allowing us to go forward with this project.</readme>
   <publications>
     <publication id="53e9d88f--pubN88319" name="Codex: Astra Militarum"/>
     <publication id="53e9d88f--pubN183884" name="GW Datasheet"/>
@@ -235,7 +238,7 @@
     <categoryEntry id="086d-e3ba-a17b-01bd" name="Vox-Caster" hidden="false"/>
     <categoryEntry id="f89d-fb99-97ed-bc39" name="Medic" hidden="false"/>
     <categoryEntry id="c6c7-5322-42d3-0d07" name="Lord Solar Leontus" publicationId="e831-8627-fbc7-5b35" page="79" hidden="false"/>
-    <categoryEntry id="5513-00e9-c0ea-15c7" name="Born Soldiers" publicationId="e831-8627-fbc7-5b35" page="59" hidden="false"/>
+    <categoryEntry id="5513-00e9-c0ea-15c7" name="BORN SOLDIERS" publicationId="e831-8627-fbc7-5b35" page="59" hidden="false"/>
     <categoryEntry id="fbe2-c251-4b6b-133a" name="Sentinel" hidden="false"/>
     <categoryEntry id="356d-5e5f-3f62-cd4d" name="Abhuman" hidden="false"/>
     <categoryEntry id="dfea-863e-a4a3-95f7" name="Bodyguard" hidden="false"/>
@@ -248,6 +251,13 @@
     <categoryEntry id="2aa8-ef0c-eae7-21bc" name="Sergeant Harker" hidden="false"/>
     <categoryEntry id="22a1-8895-f588-fc52" name="Shock Troops" hidden="false"/>
     <categoryEntry id="ab99-87a7-c0d6-b038" name="Super-Heavy" hidden="false"/>
+    <categoryEntry id="f3d8-6c41-428b-e0fe" name="MECHANISED" hidden="false"/>
+    <categoryEntry id="82a1-e03f-9566-a668" name="ARMOURED SUPERIORITY" hidden="false"/>
+    <categoryEntry id="c09f-e300-1535-0c25" name="EXPERT BOMBARDIERS" hidden="false"/>
+    <categoryEntry id="e029-6691-46a5-a1b6" name="GRIM DEMEANOR" hidden="false"/>
+    <categoryEntry id="2748-cc6c-dbf0-f6ac" name="VETERAN GUERRILLAS" hidden="false"/>
+    <categoryEntry id="8411-aa89-a9b8-d1fb" name="ELITE SHARPSHOOTERS" hidden="false"/>
+    <categoryEntry id="745c-e46a-3c6b-cb64" name="CULT OF SACRIFICE" hidden="false"/>
   </categoryEntries>
   <rules>
     <rule id="1508-5f0f-cede-970a" name="Hammer of the Emperor" publicationId="2fd5-ca70-3d14-d58c" page="2" hidden="false">
@@ -865,6 +875,61 @@ An ASTRA MILITARUM Detachment is one that only includes models with the ASTRA MI
       </costs>
     </selectionEntry>
     <selectionEntry id="da34-52b0-53cc-1128" name="Tank Commander" publicationId="e831-8627-fbc7-5b35" page="82" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="21fe-eae7-7c55-6d35" name="Tank Commander" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -895,6 +960,19 @@ An ASTRA MILITARUM Detachment is one that only includes models with the ASTRA MI
         <infoLink id="d845-46c0-d9b2-9570" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
         <infoLink id="bbad-18ae-3c2f-4586" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
         <infoLink id="4223-5f27-3a85-2879" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
+        <infoLink id="cf3d-69fc-5c04-2c3c" name="Born Soldiers (Aura)" hidden="false" targetId="ea70-4965-e2ad-a96f" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="lessThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </infoLink>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="1e26-f803-4a0f-08e2" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
@@ -934,6 +1012,7 @@ An ASTRA MILITARUM Detachment is one that only includes models with the ASTRA MI
         </entryLink>
         <entryLink id="7104-5113-0e01-e42f" name="Character Stratagems" hidden="false" collective="false" import="true" targetId="2527-4b0c-1e18-38b3" type="selectionEntryGroup"/>
         <entryLink id="11e9-e65b-a6d0-3502" name="Display Mechanised Orders" hidden="false" collective="false" import="true" targetId="61ed-ee78-e2e8-556c" type="selectionEntry"/>
+        <entryLink id="192f-9233-97b8-d47b" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="10.0"/>
@@ -942,6 +1021,61 @@ An ASTRA MILITARUM Detachment is one that only includes models with the ASTRA MI
       </costs>
     </selectionEntry>
     <selectionEntry id="3a4e-81fe-1325-ac27" name="Stormsword" page="0" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="dde3-fd12-f3be-aa23" name="Stormsword" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -1029,6 +1163,7 @@ An ASTRA MILITARUM Detachment is one that only includes models with the ASTRA MI
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a925-2961-0b80-99a0" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="5fac-e034-cbb5-8b10" name="Unit Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="420.0"/>
@@ -1056,6 +1191,61 @@ An ASTRA MILITARUM Detachment is one that only includes models with the ASTRA MI
       </costs>
     </selectionEntry>
     <selectionEntry id="8194-93bb-950a-d88b" name="Shadowsword" page="0" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="b58a-ab7d-03cc-8656" name="Shadowsword" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -1143,6 +1333,7 @@ An ASTRA MILITARUM Detachment is one that only includes models with the ASTRA MI
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="60cb-7b73-93ee-679b" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="7638-233c-515d-cc11" name="Unit Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="450.0"/>
@@ -1215,6 +1406,7 @@ An ASTRA MILITARUM Detachment is one that only includes models with the ASTRA MI
         </entryLink>
         <entryLink id="0977-0307-a1a5-8a8c" name="Basilisk Hull Weapon" hidden="false" collective="false" import="true" targetId="809c-35f5-e84b-7065" type="selectionEntryGroup"/>
         <entryLink id="1075-13f1-cceb-e1b7" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
+        <entryLink id="fa48-bcb3-7156-5c7f" name="Unit Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="140.0"/>
@@ -1361,6 +1553,7 @@ An ASTRA MILITARUM Detachment is one that only includes models with the ASTRA MI
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5776-7865-48ea-b1a5" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="3038-87e5-3e7f-1e1a" name="Unit Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="430.0"/>
@@ -3162,6 +3355,61 @@ An ASTRA MILITARUM Detachment is one that only includes models with the ASTRA MI
       </costs>
     </selectionEntry>
     <selectionEntry id="dd1b-faed-2f1c-c9ba" name="Stormblade" page="0" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="4776-67fc-81b5-da32" name="Stormblade [1] (14-26+ wounds remaining)" publicationId="7573-8d1b-acdf-2de8" page="76" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -5839,8 +6087,8 @@ If this unit scores 5 or more hits against that enemy unit, then until the end o
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3263-4233-4344-6228" type="notInstanceOf"/>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd6e-7055-ca6b-b711" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3263-4233-4344-6228" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd6e-7055-ca6b-b711" type="notInstanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -5923,7 +6171,7 @@ This WARLORD knows those Orders in addition to any others it knows.</characteris
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3263-4233-4344-6228" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3263-4233-4344-6228" type="notInstanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6118,7 +6366,7 @@ This WARLORD knows those Orders in addition to any others it knows.</characteris
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="d7be-7049-0cc9-dcf3" name="Imperial Commander&apos;s Armoury" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="d7be-7049-0cc9-dcf3" name="Stratagem: Imperial Commander&apos;s Armoury" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="12c4-7182-af91-c83d" type="max"/>
       </constraints>
@@ -6242,7 +6490,7 @@ This WARLORD knows those Orders in addition to any others it knows.</characteris
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3984-854b-4603-be64" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3984-854b-4603-be64" type="notInstanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6597,7 +6845,7 @@ Refractor Field Generator (Aura): While a friendly MILITARUM TEMPESTUS INFANTRY 
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3984-854b-4603-be64" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3984-854b-4603-be64" type="notInstanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6680,7 +6928,7 @@ Refractor Field Generator (Aura): While a friendly MILITARUM TEMPESTUS INFANTRY 
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3984-854b-4603-be64" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3984-854b-4603-be64" type="notInstanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -6746,7 +6994,7 @@ Refractor Field Generator (Aura): While a friendly MILITARUM TEMPESTUS INFANTRY 
             <characteristic name="S" typeId="59b1-319e-ec13-d466">8</characteristic>
             <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
             <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
-            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"></characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"/>
           </characteristics>
         </profile>
         <profile id="25fc-d604-2121-afd4" name="The Emperor&apos;s Fury" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
@@ -7091,8 +7339,8 @@ Relic of Lost Cadia (Aura): While a friendly CADIAN INFANTRY unit is within 6&qu
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3263-4233-4344-6228" type="notInstanceOf"/>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd6e-7055-ca6b-b711" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3263-4233-4344-6228" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd6e-7055-ca6b-b711" type="notInstanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -7122,8 +7370,8 @@ Old Grudges (Aura): While a friendly PLATOON or BATTLE TANK SQUADRON unit is wit
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3263-4233-4344-6228" type="notInstanceOf"/>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd6e-7055-ca6b-b711" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3263-4233-4344-6228" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd6e-7055-ca6b-b711" type="notInstanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -7152,8 +7400,8 @@ Old Grudges (Aura): While a friendly PLATOON or BATTLE TANK SQUADRON unit is wit
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3263-4233-4344-6228" type="notInstanceOf"/>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd6e-7055-ca6b-b711" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3263-4233-4344-6228" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd6e-7055-ca6b-b711" type="notInstanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -7182,8 +7430,8 @@ Old Grudges (Aura): While a friendly PLATOON or BATTLE TANK SQUADRON unit is wit
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3263-4233-4344-6228" type="notInstanceOf"/>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd6e-7055-ca6b-b711" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd6e-7055-ca6b-b711" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3263-4233-4344-6228" type="notInstanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -7212,8 +7460,8 @@ Old Grudges (Aura): While a friendly PLATOON or BATTLE TANK SQUADRON unit is wit
           <conditionGroups>
             <conditionGroup type="or">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3263-4233-4344-6228" type="notInstanceOf"/>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd6e-7055-ca6b-b711" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3263-4233-4344-6228" type="notInstanceOf"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd6e-7055-ca6b-b711" type="notInstanceOf"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
@@ -7754,7 +8002,13 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
               </constraints>
             </entryLink>
             <entryLink id="604e-da14-d07a-dd5a" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-            <entryLink id="8afc-811e-6f72-c4fa" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+            <entryLink id="8afc-811e-6f72-c4fa" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+            <entryLink id="a5f8-2c1b-7d26-7a81" name="Unit Regimental Doctrines" hidden="false" collective="true" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1d7e-e21e-f918-0822" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b126-7dab-0f4c-2b57" type="max"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="45.0"/>
@@ -8034,6 +8288,7 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dd0a-3345-1418-23c8" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="cf2a-a9e6-ca2e-109e" name="Unit Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="400.0"/>
@@ -8121,6 +8376,7 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
         <entryLink id="d1e1-e6b6-5c6c-f55b" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
         <entryLink id="f8b4-bee6-b52f-753c" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
         <entryLink id="6fb2-f0e1-dfff-d7d2" name="Super Heavy Aces" hidden="false" collective="false" import="true" targetId="f14f-06c3-76c0-2c4a" type="selectionEntryGroup"/>
+        <entryLink id="2fe7-506b-a417-f494" name="Unit Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="390.0"/>
@@ -8624,6 +8880,61 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
           </conditionGroups>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="9f9d-00a0-5084-7079" name="Transport: Chimera" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
           <modifiers>
@@ -8857,6 +9168,7 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
         <entryLink id="2294-2bcf-6b58-50ea" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
         <entryLink id="91a8-d59c-ee46-939c" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
         <entryLink id="3216-7e35-6ee4-72bd" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="6273-60b3-54f4-9aa4" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="85.0"/>
@@ -8865,6 +9177,61 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
       </costs>
     </selectionEntry>
     <selectionEntry id="3b7d-927b-8856-e8b7" name="Platoon Command Squad" publicationId="e831-8627-fbc7-5b35" page="83" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="7813-a2a2-93be-9b77" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
         <infoLink id="59a2-c7e2-c45e-385a" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
@@ -8916,6 +9283,19 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
           </profiles>
           <infoLinks>
             <infoLink id="a2c2-be50-168c-9922" name="Refractor Field" hidden="false" targetId="783d-d067-2d7f-d2a1" type="profile"/>
+            <infoLink id="5e8a-046d-2c9a-8f58" name="Born Soldiers (Aura)" hidden="false" targetId="ea70-4965-e2ad-a96f" type="profile">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="lessThan"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </infoLink>
           </infoLinks>
           <categoryLinks>
             <categoryLink id="200b-dfef-704e-8c65" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
@@ -9539,6 +9919,7 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="3451-5278-97f0-3b6b" name="Attaché" hidden="false" collective="false" import="true" targetId="698f-df58-b9ae-9ece" type="selectionEntryGroup"/>
+        <entryLink id="63ed-f1c0-0f17-758c" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
@@ -9750,6 +10131,61 @@ While a unit is suppressed, each time a model in that unit makes an attack, subt
           </conditionGroups>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="80da-0c59-ea83-1578" name="Senior Officer (Aura)" hidden="false" targetId="f34c8090-4e32-bd27-df37-1b714a4288d2" type="profile"/>
         <infoLink id="ee2f-c036-f1c6-03e0" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
@@ -9789,6 +10225,19 @@ While a unit is suppressed, each time a model in that unit makes an attack, subt
           </profiles>
           <infoLinks>
             <infoLink id="31d4-17bd-8337-fc6c" name="Refractor Field" hidden="false" targetId="783d-d067-2d7f-d2a1" type="profile"/>
+            <infoLink id="defe-5acc-6b6e-29aa" name="Born Soldiers (Aura)" hidden="false" targetId="ea70-4965-e2ad-a96f" type="profile">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="lessThan"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+            </infoLink>
           </infoLinks>
           <categoryLinks>
             <categoryLink id="f81a-df1d-0604-28f3" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
@@ -9880,6 +10329,7 @@ While a unit is suppressed, each time a model in that unit makes an attack, subt
             <entryLink id="f45a-2a15-740d-b989" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
             <entryLink id="fb61-7f36-cb56-3a99" name="Heirlooms of Conquest" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup"/>
             <entryLink id="0d62-0913-dee3-6601" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
+            <entryLink id="3b5a-a749-3233-32dd" name="Character Stratagems" hidden="false" collective="false" import="true" targetId="2527-4b0c-1e18-38b3" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
@@ -10281,6 +10731,7 @@ While a unit is suppressed, each time a model in that unit makes an attack, subt
         <entryLink id="41ab-5dd7-0797-8a12" name="Display Regimental Orders" hidden="false" collective="false" import="true" targetId="af30-711d-1707-fcdc" type="selectionEntry"/>
         <entryLink id="7f61-bf6d-a6c0-d7d3" name="Attaché" hidden="false" collective="false" import="true" targetId="698f-df58-b9ae-9ece" type="selectionEntryGroup"/>
         <entryLink id="7e90-dbdb-23c3-48ad" name="Bodyguard" hidden="false" collective="false" import="true" targetId="3cd9-53fc-5ffb-5f60" type="selectionEntryGroup"/>
+        <entryLink id="5c08-9bca-7077-89a5" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="75.0"/>
@@ -10544,6 +10995,61 @@ While a unit is suppressed, each time a model in that unit makes an attack, subt
       </costs>
     </selectionEntry>
     <selectionEntry id="2255-9de3-c6f8-838b" name="Deathstrike" publicationId="53e9d88f--pubN88319" page="53" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="7ca6-37c0-23e6-7ccd" name="Deathstrike" publicationId="53e9d88f--pubN88319" page="53" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -10624,7 +11130,13 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         <entryLink id="6891-6aa3-c888-5fd1" name="Hull Weapon" hidden="false" collective="false" import="true" targetId="846f-095f-3967-92af" type="selectionEntryGroup"/>
         <entryLink id="f0ff-12f3-b18f-09ca" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
         <entryLink id="efc0-8c6d-2152-f932" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="33f4-f274-554a-dc2e" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="33f4-f274-554a-dc2e" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="edc6-ba5e-7e76-8662" name="Unit Regimental Doctrines" hidden="false" collective="true" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="54da-597a-6017-dab6" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6bdb-6225-81ad-c933" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="160.0"/>
@@ -10782,6 +11294,61 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       </costs>
     </selectionEntry>
     <selectionEntry id="36c4-e49f-cb7a-a22e" name="Doomhammer" page="0" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="91fd-c3ab-639d-7d04" name="Transport: Doomhammer" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
           <characteristics>
@@ -10874,6 +11441,12 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d70a-ad6a-4acf-9101" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c5fb-ebe5-6d78-0186" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="71ce-7adb-ae44-fc04" name="Unit Regimental Doctrines" hidden="false" collective="true" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b3fb-9d44-69f6-0949" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a964-8dad-ea86-384d" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
@@ -11230,6 +11803,61 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       </costs>
     </selectionEntry>
     <selectionEntry id="b796-7e12-3616-52e6" name="Heavy Weapons Squad" publicationId="e831-8627-fbc7-5b35" page="104" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="839d-8321-d166-9586" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
         <infoLink id="3ee4-362e-20c0-ab10" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
@@ -11275,6 +11903,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       <entryLinks>
         <entryLink id="c3b3-d4f2-1af5-f37f" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
         <entryLink id="21fd-14a9-fc62-fd93" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="bebf-8db3-6a2e-5328" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="3.0"/>
@@ -11283,6 +11912,61 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       </costs>
     </selectionEntry>
     <selectionEntry id="f6ce-eff4-32ac-51dc" name="Hellhammer" page="0" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="e959-e4a3-05f3-6390" name="Hellhammer" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -11418,6 +12102,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a569-eb6d-7a04-da58" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="3384-4ee1-baf2-26b8" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="450.0"/>
@@ -11565,6 +12250,61 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
           </conditionGroups>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="670b-0164-7936-4247" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
         <infoLink id="bdb0-bb73-5a8e-19bc" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
@@ -11603,7 +12343,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
             <infoLink id="3f30-8405-3a82-3762" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
           </infoLinks>
           <selectionEntryGroups>
-            <selectionEntryGroup id="03a5-6df4-65c7-221b" name="Chainsword" hidden="false" collective="false" import="true">
+            <selectionEntryGroup id="03a5-6df4-65c7-221b" name="Chainsword" hidden="false" collective="false" import="true" defaultSelectionEntryId="2d66-a855-6696-ac2f">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d15a-52e4-9083-5629" type="max"/>
               </constraints>
@@ -11661,6 +12401,13 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="e99b-dd1c-d6bc-833e" name="Stratagem: Battlefield Bequest" hidden="false" collective="false" import="true" targetId="1ac8-f654-2dc9-4613" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b4d3-a940-c14f-a57d" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
@@ -11723,7 +12470,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d15f-15e9-8e88-637d" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="7fb0-164b-8f3b-9ac9" name="New InfoLink" hidden="false" targetId="3635-257d-26f1-26e8" type="profile"/>
+                <infoLink id="7fb0-164b-8f3b-9ac9" name="Guardsman" hidden="false" targetId="3635-257d-26f1-26e8" type="profile"/>
                 <infoLink id="a8ff-59cd-7e2d-7f9f" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
               </infoLinks>
               <entryLinks>
@@ -11793,11 +12540,66 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       </selectionEntryGroups>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="3.0"/>
-        <cost name="pts" typeId="points" value="60.0"/>
+        <cost name="pts" typeId="points" value="65.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
     <selectionEntry id="af7a-3b6b-099c-c23b" name="Leman Russ Battle Tanks" publicationId="e831-8627-fbc7-5b35" page="105" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <categoryLinks>
         <categoryLink id="bc43-a148-1176-e457" name="Leman Russ Battle Tank" hidden="false" targetId="dccb-7194-05d6-9725" primary="false"/>
         <categoryLink id="5b15-40dc-e36c-4728" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
@@ -11809,28 +12611,16 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         <categoryLink id="88b4-3cf3-afb1-4cc8" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
-        <selectionEntryGroup id="cab8-09fb-4f01-e432" name="Leman Russ" hidden="false" collective="false" import="true">
+        <selectionEntryGroup id="cab8-09fb-4f01-e432" name="Leman Russ" hidden="false" collective="false" import="true" defaultSelectionEntryId="1942-754b-39c5-cd09">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="be88-9664-949b-cd7f" type="min"/>
             <constraint field="selections" scope="parent" value="3.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f954-1d7f-49ef-1b9f" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="1942-754b-39c5-cd09" name="Leman Russ Battle Tank" publicationId="e831-8627-fbc7-5b35" page="105" hidden="false" collective="false" import="true" type="model">
-              <modifiers>
-                <modifier type="append" field="name" value="[Legends]">
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition field="selections" scope="1942-754b-39c5-cd09" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac67-32a6-44a4-8dff" type="greaterThan"/>
-                        <condition field="selections" scope="1942-754b-39c5-cd09" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7b19-bc3c-4a64-2f3f" type="greaterThan"/>
-                        <condition field="selections" scope="1942-754b-39c5-cd09" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9211-39f2-d24b-0fcf" type="greaterThan"/>
-                        <condition field="selections" scope="1942-754b-39c5-cd09" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0569-31b8-8524-2a78" type="greaterThan"/>
-                        <condition field="selections" scope="1942-754b-39c5-cd09" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0569-31b8-8524-2a78" type="greaterThan"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8247-9a3f-818a-1b38" type="min"/>
+              </constraints>
               <infoLinks>
                 <infoLink id="9c1a-50da-9849-e7c2" name="Leman Russ" hidden="false" targetId="59561fd3-8437-5e2e-1080-fe4d29ae4a60" type="profile"/>
                 <infoLink id="b51c-4e8c-a5d6-1aa0" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
@@ -11842,127 +12632,6 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
               <categoryLinks>
                 <categoryLink id="9084-bff1-9911-3b16" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
               </categoryLinks>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="481f-21ea-5260-e733" name="Battle Cannon" hidden="false" collective="false" import="true" defaultSelectionEntryId="6013-cdd7-7009-fb33">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8460-f3c9-727f-642d" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bc39-5500-556a-3fa1" type="max"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="6013-cdd7-7009-fb33" name="Battle Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="61f4-d9ef-d04e-df7e" type="max"/>
-                      </constraints>
-                      <profiles>
-                        <profile id="34a2-4410-3fac-a57e" name="Leman Russ Battle Cannon" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-                          <characteristics>
-                            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">72&quot;</characteristic>
-                            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy D6+3</characteristic>
-                            <characteristic name="S" typeId="59b1-319e-ec13-d466">8</characteristic>
-                            <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
-                            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">3</characteristic>
-                            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast, Turret Weapon (pg 75).</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <costs>
-                        <cost name="pts" typeId="points" value="5.0"/>
-                        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="ac67-32a6-44a4-8dff" name="Battle Cannon &amp; Storm Bolter [Legends]" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="eef2-8b74-d079-13e7" type="max"/>
-                      </constraints>
-                      <entryLinks>
-                        <entryLink id="d71c-94f3-6a00-ba63" name="Battle Cannon" hidden="false" collective="false" import="true" targetId="6013-cdd7-7009-fb33" type="selectionEntry">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="039f-1181-1aff-fbbb" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d5f0-6911-8ff9-9e7c" type="max"/>
-                          </constraints>
-                        </entryLink>
-                        <entryLink id="27f9-cb2c-5fc5-8b34" name="Storm bolter" hidden="false" collective="false" import="true" targetId="2b03-8d64-3711-f300" type="selectionEntry">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5b47-7cc2-1039-2e32" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="bff6-e8ab-cd4b-610d" type="max"/>
-                          </constraints>
-                          <costs>
-                            <cost name="pts" typeId="points" value="5.0"/>
-                          </costs>
-                        </entryLink>
-                      </entryLinks>
-                      <costs>
-                        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                        <cost name="pts" typeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="9211-39f2-d24b-0fcf" name="Battle Cannon &amp; Heavy Stubber [Legends]" page="0" hidden="false" collective="false" import="true" type="upgrade">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6ddb-2a31-9115-2c88" type="max"/>
-                      </constraints>
-                      <entryLinks>
-                        <entryLink id="077b-acc5-006d-d9ac" name="Battle Cannon" hidden="false" collective="false" import="true" targetId="6013-cdd7-7009-fb33" type="selectionEntry">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="56d5-b365-82d9-f61b" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f5d4-0b1c-c5ad-bd8e" type="max"/>
-                          </constraints>
-                        </entryLink>
-                        <entryLink id="d830-db87-b956-2b3d" name="Heavy stubber" hidden="false" collective="false" import="true" targetId="cfa3-5fcd-af10-5520" type="selectionEntry">
-                          <constraints>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9308-7a54-35e3-1e6a" type="min"/>
-                            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7293-cd07-9c04-0d73" type="max"/>
-                          </constraints>
-                          <costs>
-                            <cost name="pts" typeId="points" value="5.0"/>
-                          </costs>
-                        </entryLink>
-                      </entryLinks>
-                      <costs>
-                        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                        <cost name="pts" typeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="7b19-bc3c-4a64-2f3f" name="Stygies Vanquisher Battle Cannon [Legends]" page="" hidden="false" collective="false" import="true" type="upgrade">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0a13-2441-0023-4508" type="max"/>
-                      </constraints>
-                      <profiles>
-                        <profile id="b9a5-ecf2-a1c6-4930" name="Stygies Vanquisher Battle Cannon" publicationId="b652-8bab-1453-da20" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-                          <characteristics>
-                            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">72&quot;</characteristic>
-                            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Heavy 1</characteristic>
-                            <characteristic name="S" typeId="59b1-319e-ec13-d466">8</characteristic>
-                            <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
-                            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3+3</characteristic>
-                            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <costs>
-                        <cost name="pts" typeId="points" value="10.0"/>
-                        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                    <selectionEntry id="0569-31b8-8524-2a78" name="Twin lascannon [Legends]" page="" hidden="false" collective="false" import="true" type="upgrade">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="10db-beec-cc7c-246f" type="max"/>
-                      </constraints>
-                      <infoLinks>
-                        <infoLink id="305d-5604-ea6c-c07f" name="Twin lascannon" hidden="false" targetId="1662-54b9-46da-fefc" type="profile"/>
-                      </infoLinks>
-                      <costs>
-                        <cost name="pts" typeId="points" value="25.0"/>
-                        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
               <entryLinks>
                 <entryLink id="d49b-8437-b9c6-5053" name="Russ Hull Weapon" hidden="false" collective="false" import="true" targetId="5bed-1f36-dd00-bd20" type="selectionEntryGroup"/>
                 <entryLink id="5c9b-6070-f427-6b3c" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
@@ -11972,229 +12641,15 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13c6-b43b-f112-9988" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="9234-32ed-62d3-c89b" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
+                <entryLink id="9234-32ed-62d3-c89b" name="Russ Equipment List" hidden="false" collective="false" import="true" targetId="8788-8deb-650b-be6a" type="selectionEntryGroup"/>
                 <entryLink id="1526-b899-be3f-3b14" name="Tank Aces (Battle Tank)" hidden="false" collective="false" import="true" targetId="d8ad-1ab9-059c-9325" type="selectionEntryGroup"/>
                 <entryLink id="f0b8-2bc3-b6ab-81bd" name="Sponson Weapons" hidden="false" collective="false" import="true" targetId="3ba3-a817-04f2-0282" type="selectionEntryGroup"/>
+                <entryLink id="3bf1-691f-f787-a558" name="Turret Cannon" hidden="false" collective="false" import="true" targetId="033c-c12e-bdf2-bc9e" type="selectionEntryGroup"/>
+                <entryLink id="6b36-b2ae-7321-b270" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="150.0"/>
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="9.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="fe7f-2ffa-6b35-cb9f" name="Leman Russ Eradicator" publicationId="53e9d88f--pubN88319" page="47" hidden="false" collective="false" import="true" type="model">
-              <infoLinks>
-                <infoLink id="a22d-1e58-6d29-6e46" name="Leman Russ" hidden="false" targetId="59561fd3-8437-5e2e-1080-fe4d29ae4a60" type="profile"/>
-                <infoLink id="ccf0-a7a6-f2d3-071f" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
-                <infoLink id="0884-cc6d-2bd2-1c1d" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
-                <infoLink id="42f1-c630-5158-7c3c" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
-                <infoLink id="72c1-90ee-9ad1-f876" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
-                <infoLink id="0e9e-7cc5-413b-513c" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
-              </infoLinks>
-              <categoryLinks>
-                <categoryLink id="7c73-1ab7-cafe-52de" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
-              </categoryLinks>
-              <entryLinks>
-                <entryLink id="8476-2c4c-3983-9c5d" name="Turret-mounted Eradicator Nova Cannon" hidden="false" collective="false" import="true" targetId="f342-97f0-feb4-882c" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="49cf-2d2a-c7d6-dfa9" type="min"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="3786-5498-5d26-fdd6" name="Russ Hull Weapon" hidden="false" collective="false" import="true" targetId="5bed-1f36-dd00-bd20" type="selectionEntryGroup"/>
-                <entryLink id="5cd6-35b5-a757-c1a2" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
-                <entryLink id="7690-21be-dc42-b637" name="Sponson Weapons" hidden="false" collective="false" import="true" targetId="3ba3-a817-04f2-0282" type="selectionEntryGroup"/>
-                <entryLink id="202d-e7fa-de1d-74bc" name="Stat Damage (Leman Russ)" hidden="false" collective="false" import="true" targetId="aff3-db41-0dc2-49ce" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cb7a-48c6-d342-8799" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2937-c427-b721-a9a5" type="max"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="b795-1dff-530d-961b" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
-                <entryLink id="bf09-6043-9e6a-934a" name="Tank Aces (Battle Tank)" hidden="false" collective="false" import="true" targetId="d8ad-1ab9-059c-9325" type="selectionEntryGroup"/>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="130.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="10.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="10e8-3f53-f686-d0a9" name="Leman Russ Exterminator" publicationId="53e9d88f--pubN88319" page="46" hidden="false" collective="false" import="true" type="model">
-              <infoLinks>
-                <infoLink id="eff0-5319-6b70-00ac" name="Leman Russ" hidden="false" targetId="59561fd3-8437-5e2e-1080-fe4d29ae4a60" type="profile"/>
-                <infoLink id="c3ae-d145-4b23-c911" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
-                <infoLink id="faba-e220-35c9-07ed" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
-                <infoLink id="332e-63f3-1706-7c18" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
-                <infoLink id="232b-0cb2-b6a3-82a4" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
-                <infoLink id="b7f4-f988-ed62-6b3e" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
-              </infoLinks>
-              <categoryLinks>
-                <categoryLink id="b543-4f7c-7117-44ee" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
-              </categoryLinks>
-              <entryLinks>
-                <entryLink id="e598-b58c-7a89-6a45" name="Turret-mounted Exterminator Autocannon" hidden="false" collective="false" import="true" targetId="7bb3-24e8-431d-6bca" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4ebc-186f-7b51-ec1c" type="min"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="c6ca-816d-ecf2-3026" name="Russ Hull Weapon" hidden="false" collective="false" import="true" targetId="5bed-1f36-dd00-bd20" type="selectionEntryGroup"/>
-                <entryLink id="b526-3ca8-e048-68eb" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
-                <entryLink id="1318-87d1-7da1-a024" name="Sponson Weapons" hidden="false" collective="false" import="true" targetId="3ba3-a817-04f2-0282" type="selectionEntryGroup"/>
-                <entryLink id="8577-2b04-e57a-ceb5" name="Stat Damage (Leman Russ)" hidden="false" collective="false" import="true" targetId="aff3-db41-0dc2-49ce" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="50b8-4248-2acb-206b" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="40af-fb60-aebe-3800" type="max"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="706a-ead8-38c1-cbec" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
-                <entryLink id="ff9b-e0e1-7931-ed74" name="Tank Aces (Battle Tank)" hidden="false" collective="false" import="true" targetId="d8ad-1ab9-059c-9325" type="selectionEntryGroup"/>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="130.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="10.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="e7a1-ec8c-78a0-94a8" name="Leman Russ Vanquisher" publicationId="53e9d88f--pubN88319" page="47" hidden="false" collective="false" import="true" type="model">
-              <infoLinks>
-                <infoLink id="2550-ef33-ce56-f484" name="Leman Russ" hidden="false" targetId="59561fd3-8437-5e2e-1080-fe4d29ae4a60" type="profile"/>
-                <infoLink id="0824-166c-fe9e-845b" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
-                <infoLink id="780c-c171-0175-bd13" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
-                <infoLink id="d08f-302c-bbfe-9e87" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
-                <infoLink id="1247-2439-7ef4-4cc3" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
-                <infoLink id="78be-c0a7-c3dc-764a" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
-              </infoLinks>
-              <categoryLinks>
-                <categoryLink id="12fb-c09f-7b39-0be4" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
-              </categoryLinks>
-              <entryLinks>
-                <entryLink id="8c06-3431-44b3-3e7f" name="Turret-mounted Vanquisher Battle Cannon" hidden="false" collective="false" import="true" targetId="5901-34d7-fb83-0e4a" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="21db-ca5d-23ae-6fcc" type="min"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="61aa-6d50-0ef9-c281" name="Russ Hull Weapon" hidden="false" collective="false" import="true" targetId="5bed-1f36-dd00-bd20" type="selectionEntryGroup"/>
-                <entryLink id="d964-61e9-5ccd-0276" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
-                <entryLink id="bc7f-acc3-f859-0c9e" name="Sponson Weapons" hidden="false" collective="false" import="true" targetId="3ba3-a817-04f2-0282" type="selectionEntryGroup"/>
-                <entryLink id="1006-7346-4b08-9017" name="Stat Damage (Leman Russ)" hidden="false" collective="false" import="true" targetId="aff3-db41-0dc2-49ce" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8760-8e34-6311-b4ad" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a872-c057-fa75-1550" type="max"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="c2d2-f506-bf9b-0387" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
-                <entryLink id="dcd4-3cc8-e77c-c2b6" name="Tank Aces (Battle Tank)" hidden="false" collective="false" import="true" targetId="d8ad-1ab9-059c-9325" type="selectionEntryGroup"/>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="130.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="10.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="70d3-335c-e94b-9a8d" name="Leman Russ Executioner" publicationId="53e9d88f--pubN88319" page="47" hidden="false" collective="false" import="true" type="model">
-              <infoLinks>
-                <infoLink id="cf4a-2766-d886-7eb9" name="Leman Russ" hidden="false" targetId="59561fd3-8437-5e2e-1080-fe4d29ae4a60" type="profile"/>
-                <infoLink id="3d6f-e9e7-3506-015d" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
-                <infoLink id="2ad2-0d2b-cbb8-a8d9" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
-                <infoLink id="5b65-66a0-84e5-f1e2" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
-                <infoLink id="8d3e-59d6-c722-9208" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
-                <infoLink id="c93a-3a05-5645-e252" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
-              </infoLinks>
-              <categoryLinks>
-                <categoryLink id="4d06-97f3-b5e6-267c" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
-              </categoryLinks>
-              <entryLinks>
-                <entryLink id="0643-8461-4953-c990" name="Turret-mounted Executioner Plasma Cannon" hidden="false" collective="false" import="true" targetId="3a4b-c307-894e-3e63" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7419-67bd-ad5f-0e27" type="min"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="c47f-6523-de69-2786" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
-                <entryLink id="b69a-7624-5939-1afb" name="Russ Hull Weapon" hidden="false" collective="false" import="true" targetId="5bed-1f36-dd00-bd20" type="selectionEntryGroup"/>
-                <entryLink id="dc04-7bba-6259-4f06" name="Sponson Weapons" hidden="false" collective="false" import="true" targetId="3ba3-a817-04f2-0282" type="selectionEntryGroup"/>
-                <entryLink id="519f-d0ce-03ed-9374" name="Stat Damage (Leman Russ)" hidden="false" collective="false" import="true" targetId="aff3-db41-0dc2-49ce" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f90a-cb60-c660-65b5" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a758-cafa-5d41-ffef" type="max"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="4d6c-fb66-8be8-d6f9" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
-                <entryLink id="34d6-26e2-3096-0347" name="Tank Aces (Battle Tank)" hidden="false" collective="false" import="true" targetId="d8ad-1ab9-059c-9325" type="selectionEntryGroup"/>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="130.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="10.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="4f56-3c2b-01f6-55dc" name="Leman Russ Demolisher" publicationId="53e9d88f--pubN88319" page="47" hidden="false" collective="false" import="true" type="model">
-              <infoLinks>
-                <infoLink id="b1b5-484d-2d36-ab94" name="Leman Russ" hidden="false" targetId="59561fd3-8437-5e2e-1080-fe4d29ae4a60" type="profile"/>
-                <infoLink id="727d-e34f-c3dd-4281" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
-                <infoLink id="4af0-cef5-1509-77af" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
-                <infoLink id="68a8-622a-54c5-abad" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
-                <infoLink id="1e91-fa98-8130-a14a" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
-                <infoLink id="2fd0-6539-f4da-a88e" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
-              </infoLinks>
-              <categoryLinks>
-                <categoryLink id="088a-d4d4-e27e-ed59" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
-              </categoryLinks>
-              <entryLinks>
-                <entryLink id="d18f-2e19-beb5-fdf8" name="Turret-mounted Demolisher Siege Cannon" hidden="false" collective="false" import="true" targetId="7def-3d84-3d31-afba" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6ad6-9401-7e8c-4d0a" type="min"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="6555-27a9-234e-643b" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
-                <entryLink id="7137-c0d7-eee0-e7b6" name="Russ Hull Weapon" hidden="false" collective="false" import="true" targetId="5bed-1f36-dd00-bd20" type="selectionEntryGroup"/>
-                <entryLink id="bdb6-2d10-8744-b8d7" name="Sponson Weapons" hidden="false" collective="false" import="true" targetId="3ba3-a817-04f2-0282" type="selectionEntryGroup"/>
-                <entryLink id="ebea-ac66-2130-99c0" name="Stat Damage (Leman Russ)" hidden="false" collective="false" import="true" targetId="aff3-db41-0dc2-49ce" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66d3-22be-9ce2-aec5" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65df-6f98-81ed-4be0" type="max"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="a281-a303-ddd6-4e74" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
-                <entryLink id="884e-5118-8a4e-3672" name="Tank Aces (Battle Tank)" hidden="false" collective="false" import="true" targetId="d8ad-1ab9-059c-9325" type="selectionEntryGroup"/>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="130.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="10.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="6f35-a7b5-a2aa-583a" name="Leman Russ Punisher" publicationId="53e9d88f--pubN88319" page="47" hidden="false" collective="false" import="true" type="model">
-              <infoLinks>
-                <infoLink id="f311-898c-9180-e208" name="Leman Russ" hidden="false" targetId="59561fd3-8437-5e2e-1080-fe4d29ae4a60" type="profile"/>
-                <infoLink id="518a-46b0-3edb-4725" name="Explodes (6+/6&quot;/D3)" hidden="false" targetId="9bde-7aa6-8e9a-0792" type="profile"/>
-                <infoLink id="7fa4-9c60-07b7-15cb" name="Vehicle Squadron" hidden="false" targetId="ed79-bdf5-75ca-f019" type="profile"/>
-                <infoLink id="f5e8-0c2c-ae7f-b103" name="Armour of Contempt" hidden="false" targetId="ab12-fdad-19bf-29d7" type="rule"/>
-                <infoLink id="aee4-9be1-6a28-65f9" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
-                <infoLink id="5a3c-5ee5-827d-4eaa" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
-              </infoLinks>
-              <categoryLinks>
-                <categoryLink id="5c48-35f3-e5c9-78db" name="Leman Russ" hidden="false" targetId="2fcb-22c9-d86a-96e3" primary="false"/>
-              </categoryLinks>
-              <entryLinks>
-                <entryLink id="5b5c-5366-7cb3-fffc" name="Turret-mounted Punisher Gatling Cannon" hidden="false" collective="false" import="true" targetId="7205-1c2b-23e2-5c6b" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2079-ad82-a768-c7cc" type="min"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="c7d4-a89a-8077-672b" name="Pintle Mount" hidden="false" collective="false" import="true" targetId="ebb9-dadc-c98d-9b62" type="selectionEntryGroup"/>
-                <entryLink id="97ca-3c8c-25ec-5840" name="Russ Hull Weapon" hidden="false" collective="false" import="true" targetId="5bed-1f36-dd00-bd20" type="selectionEntryGroup"/>
-                <entryLink id="9158-9a56-019c-294f" name="Sponson Weapons" hidden="false" collective="false" import="true" targetId="3ba3-a817-04f2-0282" type="selectionEntryGroup"/>
-                <entryLink id="a719-1897-1914-a5e1" name="Stat Damage (Leman Russ)" hidden="false" collective="false" import="true" targetId="aff3-db41-0dc2-49ce" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d21a-83bd-a527-2bd9" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dea5-28b2-d03d-b416" type="max"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="7b9c-b690-7fc4-71e3" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
-                <entryLink id="c6e8-0a3f-5463-96f8" name="Tank Aces (Battle Tank)" hidden="false" collective="false" import="true" targetId="d8ad-1ab9-059c-9325" type="selectionEntryGroup"/>
-              </entryLinks>
-              <costs>
-                <cost name="pts" typeId="points" value="130.0"/>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="10.0"/>
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
@@ -12335,6 +12790,61 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       </costs>
     </selectionEntry>
     <selectionEntry id="3e24-04de-c5d1-ac51" name="Manticore" publicationId="53e9d88f--pubN88319" page="52" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="173a-99c5-6ac8-1008" name="Manticore" publicationId="53e9d88f--pubN88319" page="52" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -12433,6 +12943,12 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         <entryLink id="d84f-a45c-36b1-a44b" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
         <entryLink id="8d76-562a-17ec-8f8b" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
         <entryLink id="61fd-d9b5-f43a-14cf" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="9967-e68b-7db3-7948" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f395-3c2b-be91-219b" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="08ee-7c5a-ae5c-0800" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="140.0"/>
@@ -13964,6 +14480,11 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                   </characteristics>
                 </profile>
               </profiles>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
             </selectionEntry>
           </selectionEntries>
           <selectionEntryGroups>
@@ -13993,6 +14514,11 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="612d-1572-fba3-06c5" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fca3-f7bc-4257-95dc" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="af3e-b58b-889d-fb76" name="Stratagem: Battlefield Bequest" hidden="false" collective="false" import="true" targetId="1ac8-f654-2dc9-4613" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1ce0-0ee4-e684-84ef" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
@@ -14126,6 +14652,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       <entryLinks>
         <entryLink id="a950-817d-b849-23d4" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
         <entryLink id="d93c-23e0-dc29-12b4" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="7448-106a-0470-e9f9" name="Unit Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
@@ -14371,6 +14898,61 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       </costs>
     </selectionEntry>
     <selectionEntry id="5d31-5e21-5ec2-7f79" name="Scout Sentinels" publicationId="e831-8627-fbc7-5b35" page="100" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <categoryLinks>
         <categoryLink id="4473-9f76-088a-64bd" name="Scout Sentinels" hidden="false" targetId="91ce-fd28-b4de-0951" primary="false"/>
         <categoryLink id="9e64-ee4f-06d8-ed28" name="Vehicle" hidden="false" targetId="c8fd-783f-3230-493e" primary="false"/>
@@ -14430,7 +15012,8 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
             </entryLink>
             <entryLink id="dcf7-92a8-70e6-3c81" name="Sentinel Weapon" hidden="false" collective="false" import="true" targetId="17a8-0cf1-0bbc-23b3" type="selectionEntryGroup"/>
             <entryLink id="583a-005e-504e-5938" name="Unit has battle honors?" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-            <entryLink id="e7e6-df3e-0655-c8e2" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+            <entryLink id="e7e6-df3e-0655-c8e2" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+            <entryLink id="e395-4cb6-51f2-fd66" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="40.0"/>
@@ -14556,12 +15139,10 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         </profile>
       </profiles>
       <categoryLinks>
-        <categoryLink id="9f05-6e07-3156-b7ed" name="Faction: &lt;FORGEWORLD&gt;" hidden="false" targetId="107e-7049-a707-a021" primary="false"/>
-        <categoryLink id="a92f-208d-af86-9142" name="Faction: Adeptus Mechanicus" hidden="false" targetId="a794-f43a-87e6-1693" primary="false"/>
         <categoryLink id="b86f-1b09-0f5b-a8d0" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
-        <categoryLink id="cae9-2383-b1f8-53a3" name="Infantry Squad" hidden="false" targetId="9e19-4e60-2e53-8758" primary="false"/>
         <categoryLink id="dd1a-2554-1968-70e4" name="Servitors" hidden="false" targetId="d3aa-1901-9278-2e3d" primary="false"/>
         <categoryLink id="b80c-383b-989c-c0d9" name="Faction: Astra Militarum" hidden="false" targetId="3263-4233-4344-6228" primary="false"/>
+        <categoryLink id="6401-e4be-16cf-41e8" name="Militarum Auxilla" hidden="false" targetId="fabd-67cb-befb-8f75" primary="false"/>
       </categoryLinks>
       <selectionEntryGroups>
         <selectionEntryGroup id="5cdd-ffaf-cab9-a0ec" name="Servitors" hidden="false" collective="false" import="true" defaultSelectionEntryId="3d37-1bc0-21d0-7076">
@@ -14808,6 +15389,61 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       </costs>
     </selectionEntry>
     <selectionEntry id="8e95-af10-b229-cd6d" name="Stormlord" page="0" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="7ccf-c1b1-9a42-7ec9" name="Transport: Stormlord" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
           <characteristics>
@@ -14908,6 +15544,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e172-a496-a167-aebf" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="9efa-8ab8-1d77-4bad" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="430.0"/>
@@ -14916,6 +15553,61 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       </costs>
     </selectionEntry>
     <selectionEntry id="f8ad-8cb3-9d8d-0ce5" name="Taurox" publicationId="e831-8627-fbc7-5b35" page="112" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="b49b-5726-0305-df5c" name="Transport: Taurox" publicationId="e831-8627-fbc7-5b35" page="112" hidden="false" typeId="b3a8-0452-7436-44d1" typeName="Transport">
           <characteristics>
@@ -15016,6 +15708,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4433-6ace-17af-7875" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="656a-7a04-3b37-b496" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="70.0"/>
@@ -15092,7 +15785,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="2.0"/>
-        <cost name="pts" typeId="points" value="35.0"/>
+        <cost name="pts" typeId="points" value="40.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -17129,11 +17822,15 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f713-54b4-15f7-ea9b" type="max"/>
               </constraints>
             </entryLink>
-            <entryLink id="0af6-c830-9c88-4e7c" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
-            <entryLink id="0fda-a252-2e2b-82c7" name="Warlord Traits (Named)" hidden="false" collective="false" import="true" targetId="6871-2805-7938-980c" type="selectionEntryGroup"/>
-            <entryLink id="3dde-7906-5236-4abf" name="Character Stratagems (Named)" hidden="false" collective="false" import="true" targetId="ed7a-3deb-4d62-b2a9" type="selectionEntryGroup"/>
             <entryLink id="0be7-6f69-1bbd-be40" name="Display Prefectus Orders" hidden="false" collective="false" import="true" targetId="18d0-904b-dff4-a149" type="selectionEntry"/>
             <entryLink id="5e65-9f99-fe29-1f63" name="Display Regimental Orders" hidden="false" collective="false" import="true" targetId="af30-711d-1707-fcdc" type="selectionEntry"/>
+            <entryLink id="4daf-70de-3473-a5c6" name="Warlord Traits (Named)" hidden="false" collective="false" import="true" targetId="6871-2805-7938-980c" type="selectionEntryGroup"/>
+            <entryLink id="d5f3-db7e-4b0b-d7a4" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="a860-567a-2539-61bd" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="7283-f7fc-97b0-f930" name="Character Stratagems (Named)" hidden="false" collective="false" import="true" targetId="ed7a-3deb-4d62-b2a9" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
@@ -17467,6 +18164,61 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
       </costs>
     </selectionEntry>
     <selectionEntry id="0fcd-d6ee-231e-920e" name="Lord Solar Leontus" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0428-37ce-a41a-d05c" type="max"/>
       </constraints>
@@ -17535,6 +18287,19 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
       <infoLinks>
         <infoLink id="919a-3d34-6cf4-5ab2" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
         <infoLink id="971c-3357-9772-aee1" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
+        <infoLink id="b986-79e6-d45e-f5df" name="Born Soldiers (Aura)" hidden="false" targetId="ea70-4965-e2ad-a96f" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="lessThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </infoLink>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8fed-d0c2-1ecd-e848" name="Faction: Imperium" hidden="false" targetId="84e2-9fa9-ebe6-1d18" primary="false"/>
@@ -17547,9 +18312,9 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         <categoryLink id="6f9c-f04a-08d0-8499" name="Lord Solar Leontus" hidden="false" targetId="c6c7-5322-42d3-0d07" primary="false"/>
       </categoryLinks>
       <entryLinks>
-        <entryLink id="764b-6320-991f-62b1" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
         <entryLink id="6711-2876-2277-c45c" name="Warlord Traits (Named)" hidden="false" collective="false" import="true" targetId="6871-2805-7938-980c" type="selectionEntryGroup"/>
         <entryLink id="36f1-de1f-d97e-d294" name="Character Stratagems (Named)" hidden="false" collective="false" import="true" targetId="ed7a-3deb-4d62-b2a9" type="selectionEntryGroup"/>
+        <entryLink id="e8be-dc1f-05f7-fb61" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="9.0"/>
@@ -17558,6 +18323,90 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
       </costs>
     </selectionEntry>
     <selectionEntry id="0609-08fb-cd8a-8b1e" name="Kasrkin" page="0" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="0609-08fb-cd8a-8b1e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a38c-0ce5-01c4-b9e4" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+                    <condition field="selections" scope="0609-08fb-cd8a-8b1e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7656-d592-d765-e9df" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d0f0-20ea-a122-ec20" type="greaterThan"/>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+                    <condition field="selections" scope="0609-08fb-cd8a-8b1e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1010-778c-012b-60c5" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="815d-e33e-b434-d4d2" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe31-ff7b-a6f6-584a" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="0609-08fb-cd8a-8b1e" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9c07-c27a-1e44-b6bc" type="greaterThan"/>
+                    <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="1786-9def-1400-548b" name="Warrior Elites" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -17662,6 +18511,11 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0090-43b4-679b-4bc1" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ebe-1d47-0e33-209f" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="5fa2-6cc6-186b-05e7" name="Stratagem: Battlefield Bequest" hidden="false" collective="false" import="true" targetId="1ac8-f654-2dc9-4613" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9c86-81e3-78d9-87ed" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
@@ -17965,15 +18819,299 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
             </selectionEntry>
           </selectionEntries>
         </selectionEntryGroup>
+        <selectionEntryGroup id="6f8b-c1d9-4156-2b54" name="Warrior Elites: Regimental Doctrines" hidden="false" collective="false" import="true" defaultSelectionEntryId="9c07-c27a-1e44-b6bc">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="484b-fd07-b10e-dbdd" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9317-d1a2-762a-cdc8" type="max"/>
+          </constraints>
+          <selectionEntries>
+            <selectionEntry id="7656-d592-d765-e9df" name="Armoured Superiority" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5591-b636-73c3-e3ed" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d50a-fbb9-f913-b014" name="Doctrine: Armoured Superiority" hidden="false" targetId="b2fd-4733-bddc-4233" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="72bb-a94b-ff4a-200b" name="Blitz Division" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="39e5-4c5b-7c0a-5ecd" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d988-a398-9a6b-61fb" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="5d28-0f50-c9bc-2bc9" name="Doctrine: Blitz Division" hidden="false" targetId="37a7-97cb-9112-c56b" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="b03b-0dd4-eda9-e7ac" name="Brutal Strength" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5efd-3e35-4dc2-1c26" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9257-c5d9-417b-1ca1" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="d867-b8d5-26ec-4f46" name="Doctrine: Brutal Strength" hidden="false" targetId="5438-3a38-60d0-d189" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="d0f0-20ea-a122-ec20" name="Cult of Sacrifice" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e072-e377-b519-e4f0" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="dd84-1142-de84-3b80" name="Doctrine: Cult of Sacrifice" hidden="false" targetId="0017-0c4f-66b5-690f" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9c07-c27a-1e44-b6bc" name="Elite Sharpshooters" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="243c-579c-5b38-fe7b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="7c3e-8b17-c989-6c81" name="Doctrine: Elite Sharpshooters" hidden="false" targetId="e2e9-e670-c5f5-0618" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="815d-e33e-b434-d4d2" name="Expert Bombardiers" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d41f-8a8b-8c88-92e9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="40e6-4d23-2921-4eb4" name="Doctrine: Expert Bombardiers" hidden="false" targetId="1b1a-e9c8-6fe5-d3e5" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="fe31-ff7b-a6f6-584a" name="Grim Demeanor" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdbf-2115-dad2-35b8" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="89e5-4f83-f2fc-410b" name="Doctrine: Grim Demeanor" hidden="false" targetId="a3d2-2bad-44ee-c917" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="0a51-b324-2fa6-0773" name="Heirloom Weapons" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1a1b-4222-ea2a-ddea" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d20f-804d-754a-889e" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c876-4874-03c8-f7d6" name="Doctrine: Heirloom Weapons" hidden="false" targetId="32d3-9063-2029-d45b" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="9fc9-910e-2416-bb67" name="Industrial Efficiency" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="821d-f32b-3d0a-eda5" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c445-376b-30d8-00d3" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c75d-6e3b-b07f-9506" name="Doctrine: Industrial Efficiency" hidden="false" targetId="1b8b-bd08-8f89-0848" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="a38c-0ce5-01c4-b9e4" name="Mechanised Infantry" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff1e-bed6-59f9-55d9" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b673-bb08-07a6-316d" name="Doctrine: Mechanised Infantry" hidden="false" targetId="ea1c-06da-438a-cf51" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="8a56-b7ae-57c1-91c7" name="Parade Drill" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="dd63-58f1-da0f-0888" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53a4-0bc6-68b8-a09b" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="b49c-7665-3081-f18a" name="Doctrine: Parade Drill" hidden="false" targetId="a9f4-2ae1-1447-0d82" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="f060-fa7c-12a7-7da7" name="Recon Operators" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c24f-1506-78c9-7407" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8447-231c-6c99-7f1a" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="e362-e92a-51e3-43ad" name="Doctrine: Recon Operators" hidden="false" targetId="3594-f562-2ecf-c607" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="7ccd-3d1d-6bc7-dceb" name="Swift as the Wind" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2f76-2c8d-131e-2c7e" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="176f-df3c-2fb1-4280" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="c447-03e0-cb13-371a" name="Doctrine: Swift as the Wind" hidden="false" targetId="32fd-39a5-3099-65ea" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+            <selectionEntry id="1010-778c-012b-60c5" name="Veteran Guerrillas" hidden="false" collective="false" import="true" type="upgrade">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2f76-2c8d-131e-2c7e" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d15e-26b4-a3f1-ef60" type="max"/>
+              </constraints>
+              <infoLinks>
+                <infoLink id="0718-7487-8889-6da2" name="Doctrine: Veteran Guerrillas" hidden="false" targetId="73e1-d2e0-cbc7-e405" type="profile"/>
+              </infoLinks>
+              <costs>
+                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                <cost name="pts" typeId="points" value="0.0"/>
+              </costs>
+            </selectionEntry>
+          </selectionEntries>
+        </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="d0e7-885c-11eb-2915" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
         <entryLink id="122e-100c-50b8-d509" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
-        <entryLink id="9d90-5612-6969-7740" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="1f55-4ee0-5c0e-5b35" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="68b3-fcaa-2f3f-a9f5" value="3.0"/>
-          </modifiers>
-        </entryLink>
+        <entryLink id="160e-b4ee-2c30-996b" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
@@ -17982,6 +19120,61 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
       </costs>
     </selectionEntry>
     <selectionEntry id="95b5-ba43-04f7-91fa" name="Rogal Dorn Battle Tank" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="e828-bc4d-2b30-0a9d" name="Rogal Dorn Battle Tank [1] (9+ wounds remaining)" publicationId="e831-8627-fbc7-5b35" page="103" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -18199,6 +19392,12 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         <entryLink id="f020-98eb-67cd-c92e" name="Rogal Dorn Sponson Weapons" hidden="false" collective="false" import="true" targetId="2358-1348-7c6b-bb88" type="selectionEntryGroup"/>
         <entryLink id="7008-1b81-5929-6b70" name="Rogal Dorn Equipment List" hidden="false" collective="false" import="true" targetId="e5ea-94cb-40bf-722b" type="selectionEntryGroup"/>
         <entryLink id="ff72-8116-51d8-4a23" name="Tank Aces (Battle Tank)" hidden="false" collective="false" import="true" targetId="d8ad-1ab9-059c-9325" type="selectionEntryGroup"/>
+        <entryLink id="9ef7-bdd1-032b-5bb7" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0fde-f4eb-f306-d015" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2a05-6586-00a9-09d6" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="250.0"/>
@@ -18207,6 +19406,61 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
       </costs>
     </selectionEntry>
     <selectionEntry id="7e79-96d0-b25b-e3ed" name="Field Ordnance Battery" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="a2b0-ca78-a533-76c2" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
       </infoLinks>
@@ -18351,6 +19605,9 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="1a32-ddb9-b689-edc1" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
+      </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
         <cost name="pts" typeId="points" value="130.0"/>
@@ -18358,6 +19615,61 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
       </costs>
     </selectionEntry>
     <selectionEntry id="411a-f57a-9f2b-b9df" name="Hydra" page="0" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="27fa-1133-a681-859c" name="Hydra" publicationId="53e9d88f--pubN88319" page="49" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -18423,7 +19735,8 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         </entryLink>
         <entryLink id="4ccb-ebdb-7e74-100a" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
         <entryLink id="d160-e37d-9a00-43ac" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
-        <entryLink id="f0a1-8d98-eea1-f4b6" name="Battle Honors" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="f0a1-8d98-eea1-f4b6" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
+        <entryLink id="1841-47f7-26f2-2855" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="110.0"/>
@@ -18432,6 +19745,61 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
       </costs>
     </selectionEntry>
     <selectionEntry id="aa0e-0155-aed7-0679" name="Wyvern" page="0" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="59e3-66c1-a79c-7118" name="Wyvern" publicationId="53e9d88f--pubN88319" page="51" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -18496,6 +19864,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1abf-763d-a017-6636" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="5207-df28-4d9b-4729" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="120.0"/>
@@ -18516,6 +19885,61 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
           </conditionGroups>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="a29c-5dd7-afeb-92a3" name="Cadian Castellan" publicationId="28ec-711c-pubN76527" page="81" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
           <characteristics>
@@ -18541,6 +19965,19 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         <infoLink id="e441-ce12-485c-e230" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
         <infoLink id="8b40-6f09-4d8f-5c3c" name="Senior Officer (Aura)" hidden="false" targetId="f34c8090-4e32-bd27-df37-1b714a4288d2" type="profile"/>
         <infoLink id="cf5e-f47b-28ec-5259" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
+        <infoLink id="b8b1-d4a7-71f5-8225" name="Born Soldiers (Aura)" hidden="false" targetId="ea70-4965-e2ad-a96f" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="lessThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </infoLink>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8bab-32f2-e257-5cf2" name="Officer" hidden="false" targetId="dd6e-7055-ca6b-b711" primary="false"/>
@@ -18628,19 +20065,20 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="a45a-6f6c-2d94-861b" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
+        <entryLink id="a45a-6f6c-2d94-861b" name="Frag grenades" hidden="false" collective="true" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7b18-e50c-0b34-e4c9" type="max"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c637-79e7-0015-0ce4" type="min"/>
           </constraints>
         </entryLink>
-        <entryLink id="3351-85cc-2cbb-08db" name="Display Astra Militarum Orders" hidden="false" collective="false" import="true" targetId="af30-711d-1707-fcdc" type="selectionEntry"/>
+        <entryLink id="3351-85cc-2cbb-08db" name="Display Regimental Orders" hidden="false" collective="false" import="true" targetId="af30-711d-1707-fcdc" type="selectionEntry"/>
         <entryLink id="ddcb-270f-43ad-c225" name="Heirlooms of Conquest" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup"/>
         <entryLink id="afe6-a9ac-8833-646c" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
         <entryLink id="7910-af97-02fc-8a0d" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
         <entryLink id="fc25-d4fc-9720-9c0a" name="Field Commander" hidden="false" collective="false" import="true" targetId="c7d5-e7b4-87d5-c29a" type="selectionEntry"/>
         <entryLink id="b550-7ce0-7d28-fce1" name="Character Stratagems" hidden="false" collective="false" import="true" targetId="2527-4b0c-1e18-38b3" type="selectionEntryGroup"/>
         <entryLink id="7e50-65ef-d113-fd64" name="Bodyguard" hidden="false" collective="false" import="true" targetId="3cd9-53fc-5ffb-5f60" type="selectionEntryGroup"/>
+        <entryLink id="49bf-7f0e-bdcc-4430" name="Regimental Doctrines" hidden="false" collective="true" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="50.0"/>
@@ -18863,6 +20301,19 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         <infoLink id="8654-9afa-0409-880a" name="Senior Officer (Aura)" hidden="false" targetId="f34c8090-4e32-bd27-df37-1b714a4288d2" type="profile"/>
         <infoLink id="6ab5-ced6-74f9-3026" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
         <infoLink id="09a5-dad4-a7d7-d077" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
+        <infoLink id="e2c2-1a2f-bc4b-6847" name="Born Soldiers (Aura)" hidden="false" targetId="ea70-4965-e2ad-a96f" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="lessThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </infoLink>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="acbe-6971-042d-8483" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
@@ -18943,6 +20394,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         <entryLink id="2a3a-142e-760f-f4fd" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
         <entryLink id="c1e0-780f-1a19-71c5" name="Character Stratagems (Named)" hidden="false" collective="false" import="true" targetId="ed7a-3deb-4d62-b2a9" type="selectionEntryGroup"/>
         <entryLink id="e9c0-7d37-4265-5ba8" name="Warlord Traits (Named)" hidden="false" collective="false" import="true" targetId="6871-2805-7938-980c" type="selectionEntryGroup"/>
+        <entryLink id="0e50-0fcf-640c-4e26" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="75.0"/>
@@ -18958,6 +20410,61 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
       </costs>
     </selectionEntry>
     <selectionEntry id="4530-30c2-e2b2-90a8" name="Ursula Creed" publicationId="e831-8627-fbc7-5b35" page="5680" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="b12e-9d5a-bbe3-cdf5" type="max"/>
       </constraints>
@@ -18997,6 +20504,19 @@ Note that this ability only affects the original target of that Order, and not a
         <infoLink id="33c4-225b-4ba8-d3af" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
         <infoLink id="8b75-6ac7-50da-19c1" name="Senior Officer (Aura)" hidden="false" targetId="f34c8090-4e32-bd27-df37-1b714a4288d2" type="profile"/>
         <infoLink id="040c-7e98-ef9b-17fd" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
+        <infoLink id="8f6d-f84e-d663-d8ef" name="Born Soldiers (Aura)" hidden="false" targetId="ea70-4965-e2ad-a96f" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="lessThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </infoLink>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="a721-fb44-4a74-198a" name="New CategoryLink" hidden="false" targetId="b332-b046-7171-5059" primary="false"/>
@@ -19048,6 +20568,7 @@ Note that this ability only affects the original target of that Order, and not a
         <entryLink id="060d-83fa-fb63-6226" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
         <entryLink id="61d9-5f7e-8d4a-79b2" name="Character Stratagems (Named)" hidden="false" collective="false" import="true" targetId="ed7a-3deb-4d62-b2a9" type="selectionEntryGroup"/>
         <entryLink id="9826-2c99-59aa-27af" name="Warlord Traits (Named)" hidden="false" collective="false" import="true" targetId="6871-2805-7938-980c" type="selectionEntryGroup"/>
+        <entryLink id="842c-f0da-109c-7f5b" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="80.0"/>
@@ -19114,6 +20635,61 @@ Note that this ability only affects the original target of that Order, and not a
           </conditionGroups>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <infoLinks>
         <infoLink id="55cf-21ff-20fe-719c" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
         <infoLink id="780a-ef23-2ed4-2ea4" name="Death Korps" hidden="false" targetId="d87e-6f7f-5d78-6485" type="profile"/>
@@ -19133,8 +20709,8 @@ Note that this ability only affects the original target of that Order, and not a
       <selectionEntries>
         <selectionEntry id="9be9-51c0-3d7c-7e43" name="Death Korps Watchmaster" page="0" hidden="false" collective="false" import="true" type="model">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="773f-cef3-c2e5-0315" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6592-c550-a61a-1882" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d0ef-94af-cde6-9082" type="min"/>
           </constraints>
           <profiles>
             <profile id="2e88-e8da-301e-e10e" name="Death Korps Watchmaster" publicationId="53e9d88f--pubN88319" page="36" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -19240,6 +20816,11 @@ Note that this ability only affects the original target of that Order, and not a
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f6ac-953e-f84c-91df" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ce84-3f64-81ac-80a3" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="2685-38aa-7a92-6f49" name="Stratagem: Battlefield Bequest" hidden="false" collective="false" import="true" targetId="1ac8-f654-2dc9-4613" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="39be-ca32-90cc-3da5" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
@@ -19455,7 +21036,12 @@ Note that this ability only affects the original target of that Order, and not a
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4c97-3188-5552-66f8" type="max"/>
                       </constraints>
                     </entryLink>
-                    <entryLink id="e20c-a32b-73a2-d03e" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry"/>
+                    <entryLink id="2780-c312-a55a-9f92" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2085-4002-618e-2145" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ae8-e27a-cceb-69e2" type="min"/>
+                      </constraints>
+                    </entryLink>
                   </entryLinks>
                   <costs>
                     <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
@@ -19562,6 +21148,9 @@ Note that this ability only affects the original target of that Order, and not a
           </selectionEntryGroups>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="e280-7561-c1d6-48f1" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
+      </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
         <cost name="pts" typeId="points" value="75.0"/>
@@ -19581,6 +21170,61 @@ Note that this ability only affects the original target of that Order, and not a
           </conditionGroups>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="ff64-852f-cd4b-92f9" name="Jungle Fighters" publicationId="e831-8627-fbc7-5b35" page="93" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -19635,6 +21279,11 @@ Note that this ability only affects the original target of that Order, and not a
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="59d2-df87-be43-3e6e" type="min"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="905a-47a7-2020-628d" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="247e-a65f-9e89-b9d6" name="Stratagem: Battlefield Bequest" hidden="false" collective="false" import="true" targetId="1ac8-f654-2dc9-4613" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0ead-baed-3f76-9f40" type="max"/>
               </constraints>
             </entryLink>
           </entryLinks>
@@ -19742,6 +21391,9 @@ Note that this ability only affects the original target of that Order, and not a
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="7083-9634-660b-90c6" name="Unit Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
+      </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="3.0"/>
         <cost name="pts" typeId="points" value="70.0"/>
@@ -20021,6 +21673,61 @@ Note that this ability only affects the original target of that Order, and not a
           </conditions>
         </modifier>
       </modifiers>
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="3f51-086a-2b37-7c4d" name="Explodes (5+/6&quot;/D3)" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -20141,6 +21848,7 @@ Note that this ability only affects the original target of that Order, and not a
           </constraints>
         </entryLink>
         <entryLink id="0f20-239f-d82b-4f36" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
+        <entryLink id="9bce-2f38-6e9d-d873" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="110.0"/>
@@ -20149,6 +21857,61 @@ Note that this ability only affects the original target of that Order, and not a
       </costs>
     </selectionEntry>
     <selectionEntry id="17d2-e653-5b72-59bf" name="Sly Marbo" publicationId="e831-8627-fbc7-5b35" page="93" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="1b06-9eaf-0965-5e83" type="max"/>
       </constraints>
@@ -20253,6 +22016,7 @@ Note that this ability only affects the original target of that Order, and not a
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8ae2-8522-b343-934a" type="min"/>
           </constraints>
         </entryLink>
+        <entryLink id="fe51-81c1-d86a-289d" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="50.0"/>
@@ -20261,6 +22025,61 @@ Note that this ability only affects the original target of that Order, and not a
       </costs>
     </selectionEntry>
     <selectionEntry id="0705-6f49-57b2-7288" name="Sergeant Harker" publicationId="e831-8627-fbc7-5b35" page="95" hidden="false" collective="false" import="true" type="model">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="0e29-6b31-fdee-920c" type="max"/>
       </constraints>
@@ -20302,6 +22121,19 @@ Note that this ability only affects the original target of that Order, and not a
       <infoLinks>
         <infoLink id="2192-1459-27e5-d725" name="Regimental Tactics" hidden="false" targetId="175c-fee4-4229-5628" type="profile"/>
         <infoLink id="82d8-88cc-ed92-f61d" name="Regimental Tactics" hidden="false" targetId="89ad-69f4-02bf-74b6" type="rule"/>
+        <infoLink id="74ca-2526-0ee4-e5f3" name="Born Soldiers (Aura)" hidden="false" targetId="ea70-4965-e2ad-a96f" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="lessThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+        </infoLink>
       </infoLinks>
       <categoryLinks>
         <categoryLink id="8e11-aeea-9af9-dab3" name="Character" hidden="false" targetId="ef18-746a-369f-43a4" primary="false"/>
@@ -20345,6 +22177,7 @@ Note that this ability only affects the original target of that Order, and not a
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2ce-2e4b-8505-5eb1" type="max"/>
           </constraints>
         </entryLink>
+        <entryLink id="7062-9b1f-4ade-d95e" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="40.0"/>
@@ -20353,6 +22186,61 @@ Note that this ability only affects the original target of that Order, and not a
       </costs>
     </selectionEntry>
     <selectionEntry id="83b0-3cc2-15cc-6d3a" name="Cadian Shock Troops" publicationId="e831-8627-fbc7-5b35" page="91" hidden="false" collective="false" import="true" type="unit">
+      <modifierGroups>
+        <modifierGroup>
+          <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+          <modifiers>
+            <modifier type="add" field="category" value="f3d8-6c41-428b-e0fe">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="82a1-e03f-9566-a668">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="745c-e46a-3c6b-cb64">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="5513-00e9-c0ea-15c7">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="2748-cc6c-dbf0-f6ac">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="c09f-e300-1535-0c25">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="e029-6691-46a5-a1b6">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="greaterThan"/>
+              </conditions>
+            </modifier>
+            <modifier type="add" field="category" value="8411-aa89-a9b8-d1fb">
+              <comment>This modifier adds Regimental Doctrine-derived keywords</comment>
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="greaterThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
       <profiles>
         <profile id="698f-ba09-9209-bd71" name="Shock Troops" publicationId="e831-8627-fbc7-5b35" page="91" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
@@ -20472,6 +22360,13 @@ Note that this ability only affects the original target of that Order, and not a
               </selectionEntries>
             </selectionEntryGroup>
           </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="956d-1082-b0f8-92af" name="Stratagem: Battlefield Bequest" hidden="false" collective="false" import="true" targetId="1ac8-f654-2dc9-4613" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ec4f-8a6a-aeac-e320" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
           <costs>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
@@ -20609,6 +22504,9 @@ Note that this ability only affects the original target of that Order, and not a
           </selectionEntries>
         </selectionEntryGroup>
       </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="9473-87d2-bc5f-48d7" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
+      </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="3.0"/>
         <cost name="pts" typeId="points" value="65.0"/>
@@ -20650,6 +22548,571 @@ Note that this ability only affects the original target of that Order, and not a
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ba4b-6ae1-ffb8-76aa" name="Stratagem: Officer Cadre" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1f07-a468-bda8-fd3f" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" field="10a5-c34d-f766-eca5" value="3.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fad2-035f-88a7-60c0" type="atLeast"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="10a5-c34d-f766-eca5" value="2.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="09f9-b586-8d63-7635" type="atLeast"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="10a5-c34d-f766-eca5" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd04-f176-7af4-ea73" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="7628-5152-0e9c-756d" name="Officer Cadre" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Use this Stratagem before the battle, when you are mustering your army, if your WARLORD has the ASTRA MILITARUM keyword, select one ASTRA MILITARUN CHARACTER model from your army (excluding named characters) and determine one Warlord Trait for that model (this must be a Warlord Trait they can have); that model is only regarded as your WARLORD for the purposes of that Warlord Trait. Each Warlord Trait in your army must be unique (if randomly generated, re-roll duplicate results), and you cannot use this Stratagem to give a model two Warlord Traits.
+
+You can only use this Stratagem once, unless you are playing a Strike Force battle (in which case you can use this Stratagem twice), or an Onslaught battle (in which case you can use this Stratagem three times).</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <categoryLinks>
+        <categoryLink id="62eb-9bd6-fcd8-1fbd" name="New CategoryLink" hidden="false" targetId="c845-c72c-6afe-3fc2" primary="true"/>
+      </categoryLinks>
+      <selectionEntries>
+        <selectionEntry id="7cb9-7b74-77b8-3349" name="Warlord Trait" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="60c3-2d20-71c6-3303" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="e0c0-8c3e-1feb-7c88" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="c854-3a66-d47f-aa91" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
+          </entryLinks>
+          <costs>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="-1.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1ac8-f654-2dc9-4613" name="Stratagem: Battlefield Bequest" publicationId="e831-8627-fbc7-5b35" page="64" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="c8d9-4af9-f218-0df7" value="2.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="09f9-b586-8d63-7635" type="atLeast"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="c8d9-4af9-f218-0df7" value="3.0">
+          <conditions>
+            <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fad2-035f-88a7-60c0" type="atLeast"/>
+          </conditions>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <conditions>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2f48-9469-77ab-8a36" type="greaterThan"/>
+          </conditions>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c8d9-4af9-f218-0df7" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6d4e-5c3f-7bcb-eaef" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="dc50-4e00-1d7d-751d" name="Battlefield Bequest" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Use this Stratagem before the battle, when you are mustering your army: Select one ASTRA MILITARUM model from your army that has the word Sergeant&apos; or &apos;Watchmaster&apos; in their profile and give them one of the following Heirlooms of Conquest (this must be a Relic they could have): Legacy of Kalladius; Claw of the Desert Tigers The Barbicant&apos;s Key, The Emperor&apos;s Fury; Relic of Lost Cadia. Each Relic in your army must be unique, and you cannot use this Stratagem to give a model two Relics.
+You can only use this Stratagem once, unless you are playing a Strike Force battle (in which case, you can use this Stratagem twice) or an Onslaught battle (in which case, you can use this Stratagem three times).</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="c6cb-010b-0e94-f2a3" name="Relic" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="7244-1451-f13a-33db" type="min"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="fa55-2b99-5451-9835" type="max"/>
+          </constraints>
+        </selectionEntryGroup>
+        <selectionEntryGroup id="d078-fced-18bd-56b3" name="Heirlooms of Conquest" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="8ddd-f056-962d-6893" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="49c6-b16b-27cf-049d" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="72bd-d971-6c1d-2a0b" name="Relic: Claw of the Desert Tigers" hidden="false" collective="false" import="true" targetId="b317-c165-a7d5-0388" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="lessThan"/>
+                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d475-faf3-ef14-5ea5" type="lessThan"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7049-e7b5-a3f5-734b" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="846c-15f9-7c43-88e6" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="572d-4ed9-829e-fbe0" name="Relic: The Barbicant&apos;s Key" hidden="false" collective="false" import="true" targetId="1a31-5371-2f9a-9234" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3d52-fccf-10c0-3fae" type="notInstanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd6e-7055-ca6b-b711" type="notInstanceOf"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="39e1-38d6-b391-0b7b" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="b088-0e00-2604-e9f3" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="7981-12f2-0a35-82b7" name="Relic: The Emperor&apos;s Fury" hidden="false" collective="false" import="true" targetId="0a30-6d27-4709-ca86" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f65e-f53c-96e4-29cb" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="dce3-6c81-9382-77c8" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="f139-a679-50c1-9d40" name="Relic: Relic of Lost Cadia" hidden="false" collective="false" import="true" targetId="0cbc-fba4-2e32-1813" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9239-69be-f460-3c53" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="ea89-ed5c-1e80-f306" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="ae8d-c3b1-5059-9a0a" name="Relic: Legacy of Kalladius" hidden="false" collective="false" import="true" targetId="eb13-2076-18e2-e4e7" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="979a-9829-e5b6-a08e" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="9ccb-5535-8ec7-80eb" type="max"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <costs>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="-1.0"/>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="bf21-4244-aca2-4799" name="Regimental Doctrine: Armoured Superiority" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="1cc3-f8a6-7222-5e7c" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="783f-5dac-6efc-f2ed" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="efc3-3199-634e-8a8c" name="Armoured Superiority" hidden="false" targetId="b2fd-4733-bddc-4233" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="da6e-20f2-61f5-9ac8" name="Regimental Doctrine: Blitz Division" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="e8a9-66c4-6b0d-48e3" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="52d6-93bf-a521-a594" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="a646-5351-5fb9-ded7" name="Blitz Division" hidden="false" targetId="37a7-97cb-9112-c56b" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ae77-4fd2-1624-42c2" name="Regimental Doctrine: Born Soldiers" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="3650-02de-eb83-7e1a" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7979-879c-99fb-f1eb" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="6f71-992c-48a9-8afe" name="Born Soldiers" hidden="false" targetId="7af2-d39f-af65-c235" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="07d8-92d7-aed9-1e29" name="Regimental Doctrine: Brutal Strength" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="1cce-4757-c86e-b75f" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc1a-d5ed-9127-ec35" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="1cc7-d5fd-2907-0f99" name="Brutal Strength" hidden="false" targetId="5438-3a38-60d0-d189" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="52e3-be91-5a44-e115" name="Regimental Doctrine: Cult of Sacrifice" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="3f35-93d9-5cd8-e725" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3493-dce0-e404-3661" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="bdbf-de66-9e99-537f" name="Cult of Sacrifice" hidden="false" targetId="0017-0c4f-66b5-690f" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="1055-d5e3-e818-886c" name="Regimental Doctrine: Elite Sharpshooters" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="3430-dad8-4b2e-a980" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e2f-094e-c6d6-09d9" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="96ef-6174-340a-56dc" name="Doctrine: Elite Sharpshooters" hidden="false" targetId="e2e9-e670-c5f5-0618" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="3805-49d3-9d0d-8f69" name="Regimental Doctrine: Expert Bombardiers" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="55c7-fe71-5d4f-e604" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="13a8-f46f-d4e5-9607" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="3e4b-2cd5-bb32-c622" name="Doctrine: Expert Bombardiers" hidden="false" targetId="1b1a-e9c8-6fe5-d3e5" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="ca5f-086d-29e5-dc5f" name="Regimental Doctrine: Grim Demeanor" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="4a4c-5996-bc57-e817" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2478-9f29-2caa-488c" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="24a4-89c4-40e4-4122" name="Grim Demeanor" hidden="false" targetId="a3d2-2bad-44ee-c917" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="11d9-47b5-aef4-99a6" name="Regimental Doctrine: Heirloom Weapons" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="d75f-3293-f931-72ba" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f29e-57ef-24f7-d430" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="f709-48c5-5428-d4c0" name="Heirloom Weapons" hidden="false" targetId="32d3-9063-2029-d45b" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="553c-39b4-f531-6fc6" name="Regimental Doctrine: Industrial Efficiency" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="d025-13e1-9ef2-94c4" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="29b8-1833-e426-0b7c" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="937b-2ee3-04a7-5a22" name="Industrial Efficiency" hidden="false" targetId="1b8b-bd08-8f89-0848" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fbdb-1695-45c4-d5ce" name="Regimental Doctrine: Parade Drill" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="2f99-4857-47ee-4290" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="608c-6671-6250-e415" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="8a90-7c6d-2215-3d61" name="Parade Drill" hidden="false" targetId="a9f4-2ae1-1447-0d82" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="64a5-29d6-8920-6ce4" name="Regimental Doctrine: Mechanised Infantry" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="b004-f7a2-6e9c-fa23" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="75f0-09c9-9f82-37bf" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="924f-b0d0-ff64-5793" name="Mechanised Infantry" hidden="false" targetId="ea1c-06da-438a-cf51" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="f125-cf90-9697-9c06" name="Regimental Doctrine: Recon Operators" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="7099-a01d-7332-f6bf" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a17-1c2d-16f8-181c" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="8a0c-10c4-547a-be91" name="Recon Operators" hidden="false" targetId="3594-f562-2ecf-c607" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="0561-8ece-dd7b-e104" name="Regimental Doctrine: Swift as the Wind" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="7a37-eaf7-8f14-b8f2" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4544-4828-b860-ca1c" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="abbf-350b-50a4-d9d2" name="Swift as the Wind" hidden="false" targetId="32fd-39a5-3099-65ea" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="fd97-bdfc-d0c0-8ba3" name="Regimental Doctrine: Trophy Hunters" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="344c-17a8-aef7-e816" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1cdc-3f35-f017-be23" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="1f31-39c4-9edd-65f9" name="Trophy Hunters" hidden="false" targetId="17c9-0a0c-c8db-76da" type="profile"/>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5aed-5e69-be20-d805" name="Regimental Doctrine: Veteran Guerrillas" hidden="false" collective="false" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="1ada-7bca-6cd3-d23f" type="max"/>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="07de-b5a9-877a-19dc" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="4f4c-b7a1-895b-7c08" name="Veteran Guerrillas" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">• Units with this doctrine gain the VETERAN GUERRILLAS keyword.
+• Each time an INFANTRY or SENTINEL model with this doctrine makes an attack that targets a unit within 18&quot;, the target does not receive the benefits of cover against that attack.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="71c4-b0c4-a7b5-4f1d" name="Regimental Doctrines" hidden="false" collective="false" import="true" type="upgrade">
+      <comment>Doctrines per unit. Add these to every REGIMENTAL unit</comment>
+      <modifierGroups>
+        <modifierGroup>
+          <conditions>
+            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26db-0ffa-fcee-3555" type="greaterThan"/>
+          </conditions>
+          <modifiers>
+            <modifier type="set" field="a20d-a8fe-cc12-5c6b" value="1.0"/>
+            <modifier type="set" field="753e-35a5-7445-4056" value="1.0"/>
+          </modifiers>
+        </modifierGroup>
+      </modifierGroups>
+      <constraints>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a20d-a8fe-cc12-5c6b" type="min"/>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="753e-35a5-7445-4056" type="max"/>
+      </constraints>
+      <infoLinks>
+        <infoLink id="7f26-4f48-57d9-fd5b" name="Doctrine: Armoured Superiority" hidden="false" targetId="b2fd-4733-bddc-4233" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="64b3-32cc-03e1-773d" type="lessThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="2f0c-ec0e-69ba-3314" name="Doctrine: Blitz Division" hidden="false" targetId="37a7-97cb-9112-c56b" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="39e5-4c5b-7c0a-5ecd" type="lessThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="bda7-d381-eed7-ba0d" name="Doctrine: Born Soldiers" hidden="false" targetId="7af2-d39f-af65-c235" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="true" childId="5c51-6541-57fe-420b" type="lessThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="3b74-1221-32fb-42e5" name="Doctrine: Brutal Strength" hidden="false" targetId="5438-3a38-60d0-d189" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5efd-3e35-4dc2-1c26" type="lessThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="59da-8520-de83-0200" name="Doctrine: Cult of Sacrifice" hidden="false" targetId="0017-0c4f-66b5-690f" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="63b7-057c-2c0e-4d9e" type="lessThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="3223-90c5-3b51-67b4" name="Doctrine: Elite Sharpshooters" hidden="false" targetId="e2e9-e670-c5f5-0618" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fe02-e641-1d10-4624" type="lessThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="1336-acd0-147c-c67e" name="Doctrine: Expert Bombardiers" hidden="false" targetId="1b1a-e9c8-6fe5-d3e5" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="a5ca-802a-7be6-e111" type="lessThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="2291-0378-d658-fffa" name="Doctrine: Grim Demeanor" hidden="false" targetId="a3d2-2bad-44ee-c917" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8f3e-5685-68c7-36c2" type="lessThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8c5c-5e25-76d1-c717" name="Doctrine: Heirloom Weapons" hidden="false" targetId="32d3-9063-2029-d45b" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a1b-4222-ea2a-ddea" type="lessThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="f3c6-8ebd-7d0d-6306" name="Doctrine: Industrial Efficiency" hidden="false" targetId="1b8b-bd08-8f89-0848" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="821d-f32b-3d0a-eda5" type="lessThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="8ead-ee94-c38f-a64b" name="Doctrine: Mechanised Infantry" hidden="false" targetId="ea1c-06da-438a-cf51" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7aaa-cfd0-f1be-9619" type="lessThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="3814-c25c-1533-771b" name="Doctrine: Parade Drill" hidden="false" targetId="a9f4-2ae1-1447-0d82" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="dd63-58f1-da0f-0888" type="lessThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="122b-bd8f-dc80-7d21" name="Doctrine: Recon Operators" hidden="false" targetId="3594-f562-2ecf-c607" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c24f-1506-78c9-7407" type="lessThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="7534-3d5c-d932-6c3b" name="Doctrine: Swift as the Wind" hidden="false" targetId="32fd-39a5-3099-65ea" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2f76-2c8d-131e-2c7e" type="lessThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="b26c-7459-4ab6-c6ee" name="Doctrine: Trophy Hunters" hidden="false" targetId="17c9-0a0c-c8db-76da" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26db-0ffa-fcee-3555" type="lessThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+        <infoLink id="13a6-ca08-931f-9d53" name="Doctrine: Veteran Guerillas" hidden="false" targetId="73e1-d2e0-cbc7-e405" type="profile">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditions>
+                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b353-ee05-82f5-a3f0" type="lessThan"/>
+              </conditions>
+            </modifier>
+          </modifiers>
+        </infoLink>
+      </infoLinks>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -21670,9 +24133,9 @@ Note that this ability only affects the original target of that Order, and not a
             </profile>
           </profiles>
           <costs>
-            <cost name="pts" typeId="points" value="5.0"/>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="5.0"/>
           </costs>
         </selectionEntry>
         <selectionEntry id="943c-8344-a018-1213" name="Armoured Tracks" publicationId="e831-8627-fbc7-5b35" page="82" hidden="false" collective="false" import="true" type="upgrade">
@@ -21792,25 +24255,17 @@ Note that this ability only affects the original target of that Order, and not a
     </selectionEntryGroup>
     <selectionEntryGroup id="d6e2-a400-a8db-d4f2" name="Warlord Traits" hidden="false" collective="false" import="true">
       <modifiers>
-        <modifier type="set" field="bed7-65c6-5ef5-566f" value="0.0">
-          <conditionGroups>
-            <conditionGroup type="and">
-              <conditions>
-                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1f07-a468-bda8-fd3f" type="greaterThan"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
             <conditionGroup type="and">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="871a-0c5d-8d92-cd67" type="equalTo"/>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6771-6ab3-1672-6a39" type="equalTo"/>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ba4b-6ae1-ffb8-76aa" type="notInstanceOf"/>
               </conditions>
               <conditionGroups>
                 <conditionGroup type="or">
                   <conditions>
+                    <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6771-6ab3-1672-6a39" type="lessThan"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6771-6ab3-1672-6a39" type="equalTo"/>
                     <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1f07-a468-bda8-fd3f" type="equalTo"/>
                   </conditions>
                   <conditionGroups>
@@ -21833,7 +24288,7 @@ Note that this ability only affects the original target of that Order, and not a
       <selectionEntryGroups>
         <selectionEntryGroup id="c22c-df46-53a4-6177" name="Warlord Traits" hidden="false" collective="false" import="true">
           <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="27cc-1afc-b3b6-8509" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acf2-a6f4-faa4-80ae" type="max"/>
           </constraints>
           <entryLinks>
             <entryLink id="58e0-805c-f866-99f3" name="WT: Superior Tactical Training" hidden="false" collective="false" import="true" targetId="8d6d-9c06-8025-de58" type="selectionEntry"/>
@@ -21843,6 +24298,9 @@ Note that this ability only affects the original target of that Order, and not a
             <entryLink id="be2b-ae93-c886-91b4" name="WT: Master of Command" hidden="false" collective="false" import="true" targetId="4a25-7a1d-4442-3728" type="selectionEntry"/>
             <entryLink id="729a-9ba0-7448-bfae" name="WT: Master Tactician" hidden="false" collective="false" import="true" targetId="2b95-ca70-0ccd-7118" type="selectionEntry"/>
             <entryLink id="af38-d09b-eda1-57d9" name="WT: Old Grudges" hidden="false" collective="false" import="true" targetId="43d2-fba4-4e96-a8d3" type="selectionEntry"/>
+            <entryLink id="89ef-e07a-f193-5e96" name="WT: Precision Targeting (Aura)" hidden="false" collective="false" import="true" targetId="2d3e-d413-b82d-809b" type="selectionEntry"/>
+            <entryLink id="df85-062c-2d08-a17c" name="WT: Drill Commander (Aura)" hidden="false" collective="false" import="true" targetId="0d9b-e4d2-5ec0-54dc" type="selectionEntry"/>
+            <entryLink id="d1b8-8068-8a92-9ae0" name="WT: Uncompromising Prosecution (Aura)" hidden="false" collective="false" import="true" targetId="ce0c-087c-cdcd-7a32" type="selectionEntry"/>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -21887,338 +24345,6 @@ Note that this ability only affects the original target of that Order, and not a
         <entryLink id="c657-e6a9-1217-f746" name="Turret-mounted Eradicator Nova Cannon" hidden="false" collective="false" import="true" targetId="f342-97f0-feb4-882c" type="selectionEntry"/>
         <entryLink id="1e0e-aae7-3358-a27b" name="Turret-mounted Demolisher Battle Cannon" hidden="false" collective="false" import="true" targetId="7def-3d84-3d31-afba" type="selectionEntry"/>
       </entryLinks>
-    </selectionEntryGroup>
-    <selectionEntryGroup id="1f55-4ee0-5c0e-5b35" name="Regimental Doctrines" hidden="false" collective="false" import="true">
-      <modifiers>
-        <modifier type="decrement" field="68b3-fcaa-2f3f-a9f5" value="1.0">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="502b-5f31-6b85-64b3" type="atLeast"/>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="db28-b04c-1383-e8e4" type="atLeast"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="68b3-fcaa-2f3f-a9f5" type="max"/>
-      </constraints>
-      <selectionEntries>
-        <selectionEntry id="df5b-f9c6-5d13-5273" name="Armoured Superiority" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="a647-a9e2-ab11-63aa" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0bf0-3991-b43c-e500" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="172b-9763-01ea-6231" name="Armoured Superiority" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">⚫ Units with this doctrine gain the ARMOURED SUPERIORITY keyword.
-⚫ SENTINEL models with this doctrine count as 3 models each when determining control of an objective marker.
-⚫ TITANIC models with this doctrine count as 10 models each when determining control of an objective marker.
-⚫ All other VEHICLE models with this doctrine count as 5 models each when determining control of an objective marker.
-
-</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="178f-0359-0b55-dec6" name="Veteran Guerrillas" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="687a-212a-a687-f3b5" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="22b5-196c-6eaa-d0bd" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="a681-c7f2-caf6-8ac8" name="Veteran Guerillas" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">• Units with this doctrine gain the VETERAN GUERRILLAS keyword.
-• Each time an INFANTRY or SENTINEL model with this doctrine makes an attack that targets a unit within 18&quot;, the target does not receive the benefits of cover against that attack.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="35dc-a874-3258-7638" name="Expert Bombardiers" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="b3a9-4be1-29fc-61c1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8453-0e44-cc82-15c5" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="dfd1-78d1-8803-7986" name="Expert Bombardiers" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">⚫ Units with this doctrine gain the EXPERT BOMBARDIERS keyword.
-⚫ Each time an ARTILLERY model with this doctrine makes a ranged attack, if the target of that attack is within 12&quot; of and visible to a friendly VOX-CASTER OF SENTINEL unit, add 1 to that attack&apos;s hit roll.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="6427-d583-c838-08ea" name="Cult of Sacrifice" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="85b4-1d1b-dbff-47c9" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3214-c2c2-3eaa-30cf" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="2c41-e53b-8cb4-ed05" name="Cult of Sacrifice" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">⚫ Units with this doctrine gain the CULT OF SACRIFICE keyword.
-⚫ Each time a model with this doctrine makes an attack, if that model&apos;s unit was below its Starting Strength when it was selected to shoot or fight, add 1 to that attack&apos;s hit roll.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="372c-adf1-38a2-b489" name="Grim Demeanor" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="0c97-1179-d994-5dfa" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f2bd-48b8-6cb9-a1df" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="0926-716a-870c-33cb" name="Grim Demeanor" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">⚫ Units with this doctrine gain the GRIM DEMEANOUR keyword.
-⚫ Each time a Combat Attrition test is taken fora unit with this doctrine, you can ignore any or all modifiers.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="123d-5dc6-fd39-5ace" name="Mechanised Infantry" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="e7f8-bae4-8e6c-4de7" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a6f8-3c90-ec25-0345" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="7d47-b7ed-6ada-c42a" name="Mechanised Infantry" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">• Units with this doctrine gain the MECHANISED keyword.
-• Units with this doctrine can disembark from a TRANSPORT model (excluding AIRCRAFT models) after that model has made a Normal Move, but if they do so, such units cannot be selected to move again this phase (though they still count as having moved) and neither they nor that TRANSPORT model are eligible to declare a charge this turn&quot;</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="75d8-6cbd-5446-791d" name="Parade Drill" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="4e51-efc1-9ef9-317d" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5b6f-b661-00bb-5b5c" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="63a6-8f45-86f2-94b1" name="Parade Drill" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If a unit with this doctrine Remained Stationary in your Movement phase, then until the end of your next Shooting phase, change the Type characteristic of lasguns and hot-shot lasguns models in that unit are equipped with to Heavy 2.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="a291-7ee0-2424-64c3" name="Blitz Division" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="e205-bd55-c126-c964" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="14c1-7208-289c-649c" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="eceb-ecf1-d576-1df2" name="Blitz Division" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">- When placing units with this doctrine into Strategic Reserves, halve their combined Power Ratings when determining the number of Command points you must spend to do so.
-- In the second battle round, each time you set up a VEHICLE unit (excluding SENTINEL units) with this doctrine from Strategic Reserves, it is considered to be the third battle round for the purposes of determining where that unit can be set up.
-
-</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="5ccd-ced3-e777-6174" name="Brutal Strength" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="ee14-0299-54cf-c1e1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9bfb-65f0-cf7d-a67a" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="0512-a13d-1dc6-cec9" name="Brutal Strength" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">• INFANTRY models with this doctrine do not suffer the penalty to hit rolls incurred for firing Heavy weapons in the same turn that their unit
-has moved.
-• Each time an INFANTRY unit with this doctrine fights, if it made a charge move, was charged, or performed a Heroic Intervention this turn, then until that fight is resolved, add 1 to the Strength characteristic of models in that unit.
-
-</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="db28-b04c-1383-e8e4" name="Trophy Hunters" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="0b16-873f-7db7-2cfd" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9090-96cc-2528-5853" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="5be2-7e64-1159-7885" name="Trophy Hunters" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">You cannot select this doctrine if you have selected any other doctrine, and if you select this doctrine you cannot select a second. Each time a model with this doctrine makes an attack against a MONSTER OF VEHICLE unit, add 1 to the Strength characteristic of that attack.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="a5ac-7ce8-a62e-0c59" name="Recon Operators" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="5989-156b-882a-33cc" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1b8c-ed3e-95c5-5595" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="b180-fcb3-e85e-34e6" name="Recon Operators" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the start of the first battle round, before the first turn begins, INFANTRY, CAVALRY and SENTINEL units with this doctrine that start the battle wholly within your deployment zone can make a Normal Move of up to 6&quot;. They cannot end this move within 9&quot; of the enemy deployment zone or any enemy models.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="0f13-960d-ed8c-10ef" name="Heirloom Weapons" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="cd9f-13a6-2729-d51a" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="913c-2440-1639-4333" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="70d0-74bc-780b-fcbf" name="Heirloom Weapons" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">• Add 4&quot; to the Range characteristic of all ranged weapons (excluding Relics) models with this doctrine are equipped with.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="502b-5f31-6b85-64b3" name="Born Soldiers" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="353a-afc6-fe1b-783c" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d12d-916b-229f-9c48" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="fdbc-cdc4-f807-a408" name="Born Soldiers" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">• Models with this doctrine have the BORN SOLDIERS keyword.
-• OFFICERS with this doctrine have the following aura ability: 
-&apos;Born Soldiers (Aura): While a friendly PLATOON unit is within 6&quot; of this model, models in that PLATOON unit can use this OFFICER&apos;s Leadership characteristic instead of their own.&apos;
-• Each time a model with this doctrine makes a ranged attack, an unmodified hit roll of 6 automatically wounds the target.
-
-Note, if an attack automatically wounds the target as a result of this doctrine, then for the purposes of any other rules that are triggered on a particular wound roll, that
-attack is considered to have been made with an unmodified wound roll of 6.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="a875-962d-e0a6-6ba1" name="Elite Sharpshooters" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="47db-9559-8a61-f19f" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90ab-0bbe-00ed-1bb7" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="6fc6-2d96-8e81-a16f" name="Elite Sharpshooters" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">• Units with this doctrine gain the ELITE SHARPSHOOTERS keyword.
-• Each time a unit with this doctrine is selected to shoot, you can re-roll one hit roll when resolving that unit&apos;s attacks.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="3770-f746-7e12-027a" name="Industrial Efficiency" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="91f7-d214-966e-2ab1" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d236-e695-bcce-d736" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="c772-505e-4004-4f41" name="Industrial Efficiency" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time an attack with an Armour Penetration characteristic of-1 is allocated to a model with this doctrine, that attack has an Armour Penetration characteristic of 0 instead.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="3348-5914-c869-1ce2" name="Swift as the Wind" hidden="false" collective="false" import="true" type="upgrade">
-          <constraints>
-            <constraint field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="e25c-6df7-2ae9-7929" type="max"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c60-8a5d-61b0-8edf" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="539f-f7ee-22e6-6cdb" name="Swift as the Wind" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-              <characteristics>
-                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">• Add 1&quot; to the Move characteristic of INFANTRY and ARTILLERY models with this doctrine, and add 2&quot; to the Move characteristic of all other models with this doctrine.
-• Add 1 to charge rolls made for units with this doctrine.</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
     </selectionEntryGroup>
     <selectionEntryGroup id="d8ad-1ab9-059c-9325" name="Tank Aces (Battle Tank)" hidden="false" collective="false" import="true">
       <modifiers>
@@ -22547,12 +24673,17 @@ receive the benefits of cover against that attack.&quot;</characteristic>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="5d24-89b0-592a-2abb" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="fbb7-d75f-7ef1-6c7f" name="Relic: The Blade of Conquest" hidden="false" collective="false" import="true" targetId="b317-c165-a7d5-0388" type="selectionEntry">
+        <entryLink id="fbb7-d75f-7ef1-6c7f" name="Relic: Claw of the Desert Tigers" hidden="false" collective="false" import="true" targetId="b317-c165-a7d5-0388" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="lessThan"/>
-              </conditions>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="lessThan"/>
+                    <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d475-faf3-ef14-5ea5" type="lessThan"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
           <constraints>
@@ -22587,12 +24718,12 @@ receive the benefits of cover against that attack.&quot;</characteristic>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="1b5a-414e-881d-69aa" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="339f-06cf-f0ba-dcb2" name="Relic (Catachan): Mamorth Tuskblade" hidden="false" collective="false" import="true" targetId="da66-a94e-d518-7f77" type="selectionEntry">
+        <entryLink id="339f-06cf-f0ba-dcb2" name="Relic (Catachan): Mamorth Tuskblade" hidden="true" collective="false" import="true" targetId="da66-a94e-d518-7f77" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1f27-e55b-f555-fa3f" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="d3d4-410e-a378-0f0a" name="Relic (Valhallan): Pietrov&apos;s Mk 45 " hidden="false" collective="false" import="true" targetId="d7d8-3d43-2cbd-5051" type="selectionEntry">
+        <entryLink id="d3d4-410e-a378-0f0a" name="Relic (Valhallan): Pietrov&apos;s Mk 45 " hidden="true" collective="false" import="true" targetId="d7d8-3d43-2cbd-5051" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1046-24ff-22eb-b0a2" type="max"/>
           </constraints>
@@ -22643,7 +24774,7 @@ receive the benefits of cover against that attack.&quot;</characteristic>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3e0e-9309-3fe7-ddb9" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="97cc-82e7-e4eb-8915" name="Relic (Mordian): Order of the Iron Star of Mordian" hidden="false" collective="false" import="true" targetId="316a-1dbd-2185-a82f" type="selectionEntry">
+        <entryLink id="97cc-82e7-e4eb-8915" name="Relic (Mordian): Order of the Iron Star of Mordian" hidden="true" collective="false" import="true" targetId="316a-1dbd-2185-a82f" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f91b-1134-2d02-c7bf" type="max"/>
           </constraints>
@@ -22671,7 +24802,7 @@ receive the benefits of cover against that attack.&quot;</characteristic>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="4e6b-c54e-f74b-4920" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="8bc7-5b5f-4c1a-26ad" name="Relic (Armageddon): Skull Mask of Acheron" hidden="false" collective="false" import="true" targetId="0bb8-8323-a997-109a" type="selectionEntry">
+        <entryLink id="8bc7-5b5f-4c1a-26ad" name="Relic (Armageddon): Skull Mask of Acheron" hidden="true" collective="false" import="true" targetId="0bb8-8323-a997-109a" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a349-c47d-2957-ba63" type="max"/>
           </constraints>
@@ -22689,12 +24820,12 @@ receive the benefits of cover against that attack.&quot;</characteristic>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="8169-cb6e-eafc-20e3" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="9a43-9116-e6ee-a657" name="Relic (54th Psian Jackals): The Hounds Teeth" hidden="false" collective="false" import="true" targetId="ea97-24cc-f581-8f62" type="selectionEntry">
+        <entryLink id="9a43-9116-e6ee-a657" name="Relic: Psy-Sigil of Sanction" hidden="false" collective="false" import="true" targetId="ea97-24cc-f581-8f62" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01bb-454c-38ed-52e1" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="32e6-f08c-313b-0be2" name="Relic (55th Kappic Eagles): Distraction Charges" hidden="false" collective="false" import="true" targetId="7024-0bc8-1395-0ce7" type="selectionEntry">
+        <entryLink id="32e6-f08c-313b-0be2" name="Relic: Clarion Proclamatus" hidden="false" collective="false" import="true" targetId="7024-0bc8-1395-0ce7" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08f0-9558-b6bd-d985" type="max"/>
           </constraints>
@@ -22709,17 +24840,17 @@ receive the benefits of cover against that attack.&quot;</characteristic>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b0ba-9c96-9aeb-179e" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="c16a-935a-7eff-7e8c" name="Relic (133rd Lambdan Lions): Refractor Field Generator" hidden="false" collective="false" import="true" targetId="00cb-7dec-59f8-acfc" type="selectionEntry">
+        <entryLink id="c16a-935a-7eff-7e8c" name="Relic: Refractor Field Generator" hidden="false" collective="false" import="true" targetId="00cb-7dec-59f8-acfc" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5903-4a5d-d4f5-9c52" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="0488-54a7-52c4-c7c9" name="Relic (43rd Iotan Dragons): Emperor&apos;s Fury" hidden="false" collective="false" import="true" targetId="eb13-2076-18e2-e4e7" type="selectionEntry">
+        <entryLink id="0488-54a7-52c4-c7c9" name="Relic: Legacy of Kalladius" hidden="false" collective="false" import="true" targetId="eb13-2076-18e2-e4e7" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4b9-90b6-eaec-383a" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="2e6e-fcb6-7c0c-afe0" name="Relic (Cadia): Dekker&apos;s Auto-Vox Servo Skull" hidden="false" collective="false" import="true" targetId="1a76-a46f-bbdb-d14e" type="selectionEntry">
+        <entryLink id="2e6e-fcb6-7c0c-afe0" name="Relic (Cadia): Dekker&apos;s Auto-Vox Servo Skull" hidden="true" collective="false" import="true" targetId="1a76-a46f-bbdb-d14e" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
@@ -22736,7 +24867,7 @@ receive the benefits of cover against that attack.&quot;</characteristic>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c1a-aa7d-1069-ce17" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="b867-f02a-6ea1-7e63" name="Relic (Cadia): Bastonne&apos;s Sword" hidden="false" collective="false" import="true" targetId="a4e1-e30f-95f1-34bd" type="selectionEntry">
+        <entryLink id="b867-f02a-6ea1-7e63" name="Relic (Cadia): Bastonne&apos;s Sword" hidden="true" collective="false" import="true" targetId="a4e1-e30f-95f1-34bd" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -22748,7 +24879,7 @@ receive the benefits of cover against that attack.&quot;</characteristic>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d98-663e-f841-7ac3" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="9c22-313b-591d-de0e" name="Relic (Cadia): Tactica Pax Cadia" hidden="false" collective="false" import="true" targetId="9ce5-10ed-7d52-9857" type="selectionEntry">
+        <entryLink id="9c22-313b-591d-de0e" name="Relic (Cadia): Tactica Pax Cadia" hidden="true" collective="false" import="true" targetId="9ce5-10ed-7d52-9857" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
@@ -22760,7 +24891,7 @@ receive the benefits of cover against that attack.&quot;</characteristic>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6e08-10b6-4f86-dd1b" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="d428-6dc8-639e-726f" name="Relic (Cadia): Gatekeeper" hidden="false" collective="false" import="true" targetId="c723-aa80-a8e0-6a8d" type="selectionEntry">
+        <entryLink id="d428-6dc8-639e-726f" name="Relic: Gatekeeper" hidden="false" collective="false" import="true" targetId="c723-aa80-a8e0-6a8d" type="selectionEntry">
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
@@ -22793,14 +24924,6 @@ receive the benefits of cover against that attack.&quot;</characteristic>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="860a-607f-b8d3-edc3" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="86ef-62f7-7a05-7193" type="max"/>
           </constraints>
-          <entryLinks>
-            <entryLink id="e1fe-cb80-3b1c-e33c" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="1f55-4ee0-5c0e-5b35" type="selectionEntryGroup">
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="32ca-4a74-403f-5d89" type="min"/>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2044-7512-88da-cb96" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
           <costs>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
             <cost name="pts" typeId="points" value="0.0"/>
@@ -22823,8 +24946,8 @@ receive the benefits of cover against that attack.&quot;</characteristic>
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ae09-117e-a6fa-316b" type="greaterThan"/>
                     <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ae09-117e-a6fa-316b" type="greaterThan"/>
                   </conditions>
                 </conditionGroup>
               </conditionGroups>
@@ -22835,7 +24958,7 @@ receive the benefits of cover against that attack.&quot;</characteristic>
       <entryLinks>
         <entryLink id="3f13-48f6-efc1-cf44" name="Stratagem: Relic" hidden="false" collective="false" import="true" targetId="c470-54ac-0863-8848" type="selectionEntry"/>
         <entryLink id="d0d7-60a5-28b0-678a" name="Stratagem: Warlord Trait" hidden="false" collective="false" import="true" targetId="6771-6ab3-1672-6a39" type="selectionEntry"/>
-        <entryLink id="b260-a1b0-e411-e14d" name="Stratagem: Progeny of Conflict" hidden="false" collective="false" import="true" targetId="871a-0c5d-8d92-cd67" type="selectionEntry"/>
+        <entryLink id="b260-a1b0-e411-e14d" name="Stratagem: Officer Cadre" hidden="false" collective="false" import="true" targetId="ba4b-6ae1-ffb8-76aa" type="selectionEntry"/>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="ed7a-3deb-4d62-b2a9" name="Character Stratagems (Named)" hidden="false" collective="false" import="true">
@@ -22870,9 +24993,10 @@ receive the benefits of cover against that attack.&quot;</characteristic>
                   <conditionGroups>
                     <conditionGroup type="or">
                       <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="078d-3b57-a663-33c8" type="instanceOf"/>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="092e-5104-6d53-e1e1" type="instanceOf"/>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="24d2-da10-88cf-0c73" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9145-1d3b-9057-7a17" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="152f-4a16-468d-f82b" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="24bb-92d3-d923-00af" type="instanceOf"/>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c6c7-5322-42d3-0d07" type="instanceOf"/>
                       </conditions>
                     </conditionGroup>
                   </conditionGroups>
@@ -22971,9 +25095,6 @@ receive the benefits of cover against that attack.&quot;</characteristic>
             <modifier type="set" field="hidden" value="true">
               <conditionGroups>
                 <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="152f-4a16-468d-f82b" type="notInstanceOf"/>
-                  </conditions>
                   <conditionGroups>
                     <conditionGroup type="and">
                       <conditions>
@@ -22995,6 +25116,11 @@ receive the benefits of cover against that attack.&quot;</characteristic>
                           </conditionGroups>
                         </conditionGroup>
                       </conditionGroups>
+                    </conditionGroup>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="152f-4a16-468d-f82b" type="notInstanceOf"/>
+                      </conditions>
                     </conditionGroup>
                   </conditionGroups>
                 </conditionGroup>
@@ -23067,7 +25193,6 @@ receive the benefits of cover against that attack.&quot;</characteristic>
                 <conditionGroup type="or">
                   <conditions>
                     <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8a48-22fc-3bf4-43d4" type="notInstanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="3bb8-2f9a-48de-c16f" type="notInstanceOf"/>
                   </conditions>
                   <conditionGroups>
                     <conditionGroup type="and">
@@ -23584,6 +25709,248 @@ receive the benefits of cover against that attack.&quot;</characteristic>
         </entryLink>
       </entryLinks>
     </selectionEntryGroup>
+    <selectionEntryGroup id="8788-8deb-650b-be6a" name="Russ Equipment List" publicationId="e831-8627-fbc7-5b35" page="114929" hidden="false" collective="false" import="true">
+      <constraints>
+        <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c84-0de3-3c28-5f2e" type="min"/>
+        <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2108-6602-ba23-1170" type="max"/>
+      </constraints>
+      <selectionEntries>
+        <selectionEntry id="6492-67a3-1b2a-178d" name="Dozer blade" publicationId="e831-8627-fbc7-5b35" page="82" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="add" field="category" value="15e6-b4e1-a0a6-1098"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5622-252c-d7c3-6ffb" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="f7d3-9ef4-b010-a307" name="Dozer blade" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+              <characteristics>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">The bearer gains the DOZER BLADE keyword, and can ignore any or all modifiers to its Move characteristic, Advance rolls, and Charge rolls.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="5.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="389c-a090-7862-2211" name="Armoured Tracks" publicationId="e831-8627-fbc7-5b35" page="82" hidden="false" collective="false" import="true" type="upgrade">
+          <modifiers>
+            <modifier type="add" field="category" value="9401-e2e7-bd2c-b3cf"/>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a3e-104b-87da-23f2" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="3198-4f29-c691-e159" name="Armoured Tracks" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+              <characteristics>
+                <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">The bearer gains the ARMOURED keyword, and each time a ranged attack with a Damage characteristic of 1 is allocated to the bearer, add 1 to the armour saving throw made against that attack.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="1cfe-4ca7-9938-5de6" name="Hunter-Killer Missile" publicationId="53e9d88f--pubN189241" page="129" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="acda-5014-44c1-ba3e" type="max"/>
+          </constraints>
+          <infoLinks>
+            <infoLink id="e161-b690-1962-87be" name="Hunter-killer missile" hidden="false" targetId="e2a9-e8fc-3a6b-2eec" type="profile"/>
+          </infoLinks>
+          <costs>
+            <cost name="pts" typeId="points" value="5.0"/>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+          </costs>
+        </selectionEntry>
+      </selectionEntries>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="4bce-d87b-0323-cd39" name="Warlord Traits (Militarum Tempestus)" hidden="false" collective="false" import="true">
+      <modifiers>
+        <modifier type="set" field="bd33-ae6f-088b-105e" value="0.0">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1f07-a468-bda8-fd3f" type="greaterThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="871a-0c5d-8d92-cd67" type="equalTo"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6771-6ab3-1672-6a39" type="equalTo"/>
+              </conditions>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1f07-a468-bda8-fd3f" type="equalTo"/>
+                  </conditions>
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1f07-a468-bda8-fd3f" type="greaterThan"/>
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                      </conditions>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="bd33-ae6f-088b-105e" type="max"/>
+      </constraints>
+      <selectionEntryGroups>
+        <selectionEntryGroup id="1355-e7a7-33d9-23ea" name="Warlord Traits" hidden="false" collective="false" import="true">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="107f-c311-9fe6-072b" type="max"/>
+          </constraints>
+          <entryLinks>
+            <entryLink id="1142-255c-3d6c-a42b" name="WT: Superior Tactical Training" hidden="false" collective="false" import="true" targetId="8d6d-9c06-8025-de58" type="selectionEntry"/>
+            <entryLink id="3cf5-0444-aba7-3419" name="WT: Front-Line Combatant" hidden="false" collective="false" import="true" targetId="1fff-d44f-98e9-609c" type="selectionEntry"/>
+            <entryLink id="ae1e-3d25-6726-6dc1" name="WT: Grand Strategist" hidden="false" collective="false" import="true" targetId="9f7a-4c34-8d0c-e3c7" type="selectionEntry"/>
+            <entryLink id="65ef-7830-dff6-7cbd" name="WT: Lead By Example" hidden="false" collective="false" import="true" targetId="75b8-5f2d-9f0c-fbb5" type="selectionEntry"/>
+            <entryLink id="073d-d149-2b7e-e12a" name="WT: Master of Command" hidden="false" collective="false" import="true" targetId="4a25-7a1d-4442-3728" type="selectionEntry"/>
+            <entryLink id="8337-cdff-de58-2382" name="WT: Master Tactician" hidden="false" collective="false" import="true" targetId="2b95-ca70-0ccd-7118" type="selectionEntry"/>
+            <entryLink id="76a1-0217-f3ea-3605" name="WT: Old Grudges" hidden="false" collective="false" import="true" targetId="43d2-fba4-4e96-a8d3" type="selectionEntry"/>
+          </entryLinks>
+        </selectionEntryGroup>
+      </selectionEntryGroups>
+      <entryLinks>
+        <entryLink id="3790-1380-d45b-180c" name="Warlord Traits (BRB)" hidden="false" collective="false" import="true" targetId="d442-1f03-d9da-e77f" type="selectionEntryGroup"/>
+      </entryLinks>
+    </selectionEntryGroup>
+    <selectionEntryGroup id="98f4-2191-c2da-8c7b" name="Regimental Doctrines" hidden="false" collective="false" import="true" defaultSelectionEntryId="5c51-6541-57fe-420b">
+      <comment>Armywide selection</comment>
+      <modifiers>
+        <modifier type="set" field="aa56-80c8-12d8-ab7a" value="2.0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26db-0ffa-fcee-3555" type="lessThan"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="lessThan"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" field="d0f0-8830-7d00-d677" value="1.0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="atLeast"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26db-0ffa-fcee-3555" type="atLeast"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="set" field="aa56-80c8-12d8-ab7a" value="1.0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26db-0ffa-fcee-3555" type="atLeast"/>
+                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5c51-6541-57fe-420b" type="atLeast"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aa56-80c8-12d8-ab7a" type="min"/>
+        <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d0f0-8830-7d00-d677" type="max"/>
+      </constraints>
+      <entryLinks>
+        <entryLink id="64b3-32cc-03e1-773d" name="Regimental Doctrine: Armoured Superiority" hidden="false" collective="false" import="true" targetId="bf21-4244-aca2-4799" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2028-5864-3494-4f91" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="5c51-6541-57fe-420b" name="Regimental Doctrine: Born Soldiers" hidden="false" collective="false" import="true" targetId="ae77-4fd2-1624-42c2" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b2ca-3b58-26c4-bd48" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="39e5-4c5b-7c0a-5ecd" name="Regimental Doctrine: Blitz Division" hidden="false" collective="false" import="true" targetId="da6e-20f2-61f5-9ac8" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fcae-3f13-0960-4963" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="5efd-3e35-4dc2-1c26" name="Regimental Doctrine: Brutal Strength" hidden="false" collective="false" import="true" targetId="07d8-92d7-aed9-1e29" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bc72-f79e-9a32-0a86" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="63b7-057c-2c0e-4d9e" name="Regimental Doctrine: Cult of Sacrifice" hidden="false" collective="false" import="true" targetId="52e3-be91-5a44-e115" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9c08-40a2-888e-944c" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="fe02-e641-1d10-4624" name="Regimental Doctrine: Elite Sharpshooters" hidden="false" collective="false" import="true" targetId="1055-d5e3-e818-886c" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2fcc-7af0-b507-6921" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="a5ca-802a-7be6-e111" name="Regimental Doctrine: Expert Bombardiers" hidden="false" collective="false" import="true" targetId="3805-49d3-9d0d-8f69" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db89-6d87-6651-55d5" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="8f3e-5685-68c7-36c2" name="Regimental Doctrine: Grim Demeanor" hidden="false" collective="false" import="true" targetId="ca5f-086d-29e5-dc5f" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="45af-3e92-cb5d-c9b7" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="1a1b-4222-ea2a-ddea" name="Regimental Doctrine: Heirloom Weapons" hidden="false" collective="false" import="true" targetId="11d9-47b5-aef4-99a6" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="06c2-fbc0-48bf-62fe" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="821d-f32b-3d0a-eda5" name="Regimental Doctrine: Industrial Efficiency" hidden="false" collective="false" import="true" targetId="553c-39b4-f531-6fc6" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f7d9-c25f-9f3b-37c5" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="7aaa-cfd0-f1be-9619" name="Regimental Doctrine: Mechanised Infantry" hidden="false" collective="false" import="true" targetId="64a5-29d6-8920-6ce4" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48d6-b704-82be-5c5f" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="dd63-58f1-da0f-0888" name="Regimental Doctrine: Parade Drill" hidden="false" collective="false" import="true" targetId="fbdb-1695-45c4-d5ce" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4259-0ae9-eae9-5d56" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="c24f-1506-78c9-7407" name="Regimental Doctrine: Recon Operators" hidden="false" collective="false" import="true" targetId="f125-cf90-9697-9c06" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7ec3-e3aa-00a4-30eb" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="2f76-2c8d-131e-2c7e" name="Regimental Doctrine: Swift as the Wind" hidden="false" collective="false" import="true" targetId="0561-8ece-dd7b-e104" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d2f5-0598-933e-5938" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="26db-0ffa-fcee-3555" name="Regimental Doctrine: Trophy Hunters" hidden="false" collective="false" import="true" targetId="fd97-bdfc-d0c0-8ba3" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d163-2357-fbaf-0fc8" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="b353-ee05-82f5-a3f0" name="Regimental Doctrine: Veteran Guerrillas" hidden="false" collective="false" import="true" targetId="5aed-5e69-be20-d805" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2a54-0395-1200-d54d" type="max"/>
+          </constraints>
+        </entryLink>
+      </entryLinks>
+    </selectionEntryGroup>
   </sharedSelectionEntryGroups>
   <sharedRules>
     <rule id="75fd-ec16-c371-a3e7" name="Acts of Faith" publicationId="53e9d88f--pubN88319" page="99" hidden="false">
@@ -24038,14 +26405,10 @@ Spirit of the Martyr: One model in the unit recovers D3 lost wounds, or you can 
         <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time a model in this unit makes an attack, an unmodified hit roll of 6 scores 1 additional hit.</characteristic>
       </characteristics>
     </profile>
-    <profile id="7af2-d39f-af65-c235" name="Born Soldiers" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+    <profile id="7af2-d39f-af65-c235" name="Doctrine: Born Soldiers" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
       <characteristics>
-        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">- Models with this doctrine have the BORN SOLDIERS keyword.
-- OFFICERS with this doctrine have the following aura ability: 
-&apos;Born Soldiers (Aura): While a friendly PLATOON unit is within 6&quot; of this model, models in that PLATOON unit can use this OFFICER&apos;s Leadership characteristic instead of their own.&apos;
-- Each time a model with this doctrine makes a ranged attack, an unmodified hit roll of 6 automatically wounds the target.
-
-Note, if an attack automatically wounds the target as a result of this doctrine, then for the purposes of any other rules that are triggered on a particular wound roll, that
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time a model with this doctrine makes a ranged attack, an unmodified hit roll of 6 automatically wounds the target.
+NOTE: if an attack automatically wounds the target as a result of this doctrine, then for the purposes of any other rules that are triggered on a particular wound roll, that
 attack is considered to have been made with an unmodified wound roll of 6.</characteristic>
       </characteristics>
     </profile>
@@ -24108,6 +26471,101 @@ attack is considered to have been made with an unmodified wound roll of 6.</char
         <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
         <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
         <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="b2fd-4733-bddc-4233" name="Doctrine: Armoured Superiority" publicationId="e831-8627-fbc7-5b35" page="60" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">• Units with this doctrine gain the ARMOURED SUPERIORITY keyword.
+• SENTINEL models with this doctrine count as 3 models each when determining control of an objective marker.
+• TITANIC models with this doctrine count as 10 models each when determining control of an objective marker.
+• All other VEHICLE models with this doctrine count as 5 models each when determining control of an objective marker.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="37a7-97cb-9112-c56b" name="Doctrine: Blitz Division" publicationId="e831-8627-fbc7-5b35" page="60" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">• When placing units with this doctrine into Strategic Reserves, halve their combined Power Ratings when determining the number of Command points you must spend to do so.
+• In the second battle round, each time you set up a VEHICLE unit (excluding SENTINEL units) with this doctrine from Strategic Reserves, it is considered to be the third battle round for the purposes of determining where that unit can be set up.
+
+</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="5438-3a38-60d0-d189" name="Doctrine: Brutal Strength" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">• INFANTRY models with this doctrine do not suffer the penalty to hit rolls incurred for firing Heavy weapons in the same turn that their unit
+has moved.
+• Each time an INFANTRY unit with this doctrine fights, if it made a charge move, was charged, or performed a Heroic Intervention this turn, then until that fight is resolved, add 1 to the Strength characteristic of models in that unit.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="0017-0c4f-66b5-690f" name="Doctrine: Cult of Sacrifice" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">• Units with this doctrine gain the CULT OF SACRIFICE keyword.
+• Each time a model with this doctrine makes an attack, if that model&apos;s unit was below its Starting Strength when it was selected to shoot or fight, add 1 to that attack&apos;s hit roll.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="e2e9-e670-c5f5-0618" name="Doctrine: Elite Sharpshooters" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">• Units with this doctrine gain the ELITE SHARPSHOOTERS keyword.
+• Each time a unit with this doctrine is selected to shoot, you can re-roll one hit roll when resolving that unit&apos;s attacks.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="1b1a-e9c8-6fe5-d3e5" name="Doctrine: Expert Bombardiers" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">• Units with this doctrine gain the EXPERT BOMBARDIERS keyword.
+• Each time an ARTILLERY model with this doctrine makes a ranged attack, if the target of that attack is within 12&quot; of and visible to a friendly VOX-CASTER OF SENTINEL unit, add 1 to that attack&apos;s hit roll.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="a3d2-2bad-44ee-c917" name="Doctrine: Grim Demeanor" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">• Units with this doctrine gain the GRIM DEMEANOUR keyword.
+• Each time a Combat Attrition test is taken fora unit with this doctrine, you can ignore any or all modifiers.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="32d3-9063-2029-d45b" name="Doctrine: Heirloom Weapons" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Add 4&quot; to the Range characteristic of all ranged weapons (excluding Relics) models with this doctrine are equipped with.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="1b8b-bd08-8f89-0848" name="Doctrine: Industrial Efficiency" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">Each time an attack with an Armour Penetration characteristic of-1 is allocated to a model with this doctrine, that attack has an Armour Penetration characteristic of 0 instead.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="ea1c-06da-438a-cf51" name="Doctrine: Mechanised Infantry" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">• Units with this doctrine gain the MECHANISED keyword.
+• Units with this doctrine can disembark from a TRANSPORT model (excluding AIRCRAFT models) after that model has made a Normal Move, but if they do so, such units cannot be selected to move again this phase (though they still count as having moved) and neither they nor that TRANSPORT model are eligible to declare a charge this turn&quot;</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="a9f4-2ae1-1447-0d82" name="Doctrine: Parade Drill" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">If a unit with this doctrine Remained Stationary in your Movement phase, then until the end of your next Shooting phase, change the Type characteristic of lasguns and hot-shot lasguns models in that unit are equipped with to Heavy 2.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="3594-f562-2ecf-c607" name="Doctrine: Recon Operators" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">At the start of the first battle round, before the first turn begins, INFANTRY, CAVALRY and SENTINEL units with this doctrine that start the battle wholly within your deployment zone can make a Normal Move of up to 6&quot;. They cannot end this move within 9&quot; of the enemy deployment zone or any enemy models.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="32fd-39a5-3099-65ea" name="Doctrine: Swift as the Wind" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">• Add 1&quot; to the Move characteristic of INFANTRY and ARTILLERY models with this doctrine, and add 2&quot; to the Move characteristic of all other models with this doctrine.
+• Add 1 to charge rolls made for units with this doctrine.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="17c9-0a0c-c8db-76da" name="Doctrine: Trophy Hunters" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">You cannot select this doctrine if you have selected any other doctrine, and if you select this doctrine you cannot select a second. Each time a model with this doctrine makes an attack against a MONSTER OF VEHICLE unit, add 1 to the Strength characteristic of that attack.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="73e1-d2e0-cbc7-e405" name="Doctrine: Veteran Guerrillas" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">• Units with this doctrine gain the VETERAN GUERRILLAS keyword.
+• Each time an INFANTRY or SENTINEL model with this doctrine makes an attack that targets a unit within 18&quot;, the target does not receive the benefits of cover against that attack.</characteristic>
+      </characteristics>
+    </profile>
+    <profile id="ea70-4965-e2ad-a96f" name="Born Soldiers (Aura)" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+      <characteristics>
+        <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">While a friendly PLATOON unit is within 6&quot; of this model, models in that PLATOON unit can use this OFFICER&apos;s Leadership characteristic instead of their own.</characteristic>
       </characteristics>
     </profile>
   </sharedProfiles>


### PR DESCRIPTION
Fixed Gaunt's Ghosts Warlord Trait selection
Fixed Munitorum Servitors Keywords
Fixed Infantry Squad points cost


Added shared Miltiarum Tempestus Warlord Traits list Added Officer Cadre to all non named characters
Added Battlefield Bequest to Sergeant, Shock Trooper Sergeant, Death Korps Watchmaster,rough rider sergeant and Kasrkin Sergeant (Cannot have had heirlooms before or Imp commanders armoury) 
Added Limits to Officer Cadre/Battlefield Bequest/Imperial Commander's Armoury of 1 (Standard), 2 (Strike Force battle) and 3 (Onslaught Battle)

Updated Regimental Doctrines functionality, including per-unit keywords and ability listings 
Updated Kasrkin Warrior Elites Functionality for new Regimental Doctrines