### PR TITLE
0.6.2-Imperial Commander's Armoury Fixes

### DIFF
--- a/Imperium_-_Imperial_Guard_9th_Ed_Library.cat
+++ b/Imperium_-_Imperial_Guard_9th_Ed_Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a2d9-e3b7-13cc-6f15" name="Imperium - Imperial Guard - 9th Ed - Library" revision="133" battleScribeVersion="2.03" authorName="3Komnenos3, TheHalfinStream, Nerdylicious (reference servitor) , based on files originally developed by Jon K, Joe B, Wil" authorContact="" authorUrl="" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a2d9-e3b7-13cc-6f15" name="Imperium - Imperial Guard - 9th Ed - Library" revision="134" battleScribeVersion="2.03" authorName="3Komnenos3, TheHalfinStream, Nerdylicious (reference servitor) , based on files originally developed by Jon K, Joe B, Wil" authorContact="" authorUrl="" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <readme>The BSData team is not responsible for these 9th edition updates and should not be contacted for support. Find us on the Mordian Glory Discord.
 
 
@@ -997,15 +997,7 @@ An ASTRA MILITARUM Detachment is one that only includes models with the ASTRA MI
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" id="c218-f41e-58b7-a50d" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="2f48-9469-77ab-8a36" name="Heirlooms of Conquest" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f2ee-41e3-618f-08db" type="greaterThan"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-        </entryLink>
+        <entryLink id="2f48-9469-77ab-8a36" name="Heirlooms of Conquest" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup"/>
         <entryLink id="9ebd-26ba-bcdd-6e38" name="Vehicle Equipment List" hidden="false" collective="false" import="true" targetId="d9f1-0505-984e-c749" type="selectionEntryGroup"/>
         <entryLink id="68ce-2664-95dd-95ad" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
         <entryLink id="3920-c977-20c1-9169" name="Tank Aces" hidden="false" collective="false" import="true" targetId="998b-b53a-603f-6c5b" type="selectionEntryGroup">
@@ -1016,6 +1008,7 @@ An ASTRA MILITARUM Detachment is one that only includes models with the ASTRA MI
         <entryLink id="7104-5113-0e01-e42f" name="Character Stratagems" hidden="false" collective="false" import="true" targetId="2527-4b0c-1e18-38b3" type="selectionEntryGroup"/>
         <entryLink id="11e9-e65b-a6d0-3502" name="Display Mechanised Orders" hidden="false" collective="false" import="true" targetId="61ed-ee78-e2e8-556c" type="selectionEntry"/>
         <entryLink id="192f-9233-97b8-d47b" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
+        <entryLink id="8a21-8396-3260-7076" name="Stratagem: Imperial Commander&apos;s Armoury" hidden="false" collective="false" import="true" targetId="d7be-7049-0cc9-dcf3" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="10.0"/>
@@ -1566,7 +1559,7 @@ An ASTRA MILITARUM Detachment is one that only includes models with the ASTRA MI
     </selectionEntry>
     <selectionEntry id="7236-b28a-2b6e-ded7" name="Lasgun" hidden="false" collective="true" import="true" type="upgrade">
       <infoLinks>
-        <infoLink id="5afb-7ec1-de74-ff33" name="New InfoLink" hidden="false" targetId="d174-eb55-aaa6-d032" type="profile"/>
+        <infoLink id="5afb-7ec1-de74-ff33" name="Lasgun" hidden="false" targetId="d174-eb55-aaa6-d032" type="profile"/>
       </infoLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
@@ -5939,8 +5932,6 @@ If this unit scores 5 or more hits against that enemy unit, then until the end o
               <conditions>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="54fa-3b28-008a-74c1" type="instanceOf"/>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cf83-4163-2d65-cb4f" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bff2-9ebc-0912-a1b3" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6ea3-ca90-2382-3846" type="instanceOf"/>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7746-0a7f-e844-2e37" type="instanceOf"/>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d55-4c9d-ac32-8437" type="instanceOf"/>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9be9-51c0-3d7c-7e43" type="instanceOf"/>
@@ -6401,255 +6392,6 @@ Alternatively, you can use this Stratagem to give one COMMAND SQUAD model from y
           </characteristics>
         </profile>
       </profiles>
-      <selectionEntries>
-        <selectionEntry id="8d07-99e2-03ab-062d" name="Clarion Proclamatus" hidden="true" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="hidden" value="false">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="39ec-1afb-b31d-83d3" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f6ef-fcd4-7c88-e3e1" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7d52-314d-5403-d56f" type="instanceOf"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1bf-a746-cbe5-29d7" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="86a3-7205-736d-5a4a" type="max"/>
-          </constraints>
-          <categoryLinks>
-            <categoryLink id="7cc3-28b9-a52c-e3c4" name="New CategoryLink" hidden="false" targetId="ff36a6f3-19bf-4f48-8956-adacfd28fe74" primary="false"/>
-          </categoryLinks>
-          <entryLinks>
-            <entryLink id="30db-62e5-82d7-79b4" name="Relic: Clarion Proclamatus" hidden="false" collective="false" import="true" targetId="7024-0bc8-1395-0ce7" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="32c5-4ea9-d665-3c47" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="be53-242a-6201-1d59" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e78b-af48-1d48-54dc" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="6ea0-66d8-6d80-3d86" name="Relic: Clarion Proclamatus" hidden="false" targetId="58c4-4b91-7cd9-c8c3" type="profile"/>
-              </infoLinks>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="-1.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="ed2f-1b65-e898-073b" name="Finial of the Nemrodesh 1st" hidden="true" collective="false" import="true" type="upgrade">
-          <modifiers>
-            <modifier type="set" field="hidden" value="false">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="abd0-52a2-c2f2-306f" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="7a14-c953-72c9-5b46" type="instanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="a7b7-b474-c07a-101f" type="instanceOf"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a09-30ac-f5ce-c35a" type="max"/>
-            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="ec45-80f8-59c5-3f11" type="max"/>
-          </constraints>
-          <categoryLinks>
-            <categoryLink id="dad7-2c7f-8949-71f4" name="New CategoryLink" hidden="false" targetId="ff36a6f3-19bf-4f48-8956-adacfd28fe74" primary="false"/>
-          </categoryLinks>
-          <entryLinks>
-            <entryLink id="1b32-9641-860e-cefb" name="Relic: Finial of the Nemrodesh 1st" hidden="false" collective="false" import="true" targetId="bed3-70b2-ff0b-8788" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="e35e-63f4-9779-fada" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf49-bae5-fd79-0be8" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e4bc-be21-9093-9d12" type="max"/>
-              </constraints>
-              <infoLinks>
-                <infoLink id="dc6e-3b9e-03a1-a5ed" name="Relic: Finial of the Nemrodesh 1st" hidden="false" targetId="f6fb-0a03-530f-c251" type="profile"/>
-              </infoLinks>
-            </entryLink>
-          </entryLinks>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-          </costs>
-        </selectionEntry>
-      </selectionEntries>
-      <selectionEntryGroups>
-        <selectionEntryGroup id="9790-7628-dfef-3ea7" name="Heirlooms of Conquest" hidden="false" collective="false" import="true">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6ea3-ca90-2382-3846" type="notInstanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9af0-2061-d963-dc8d" type="notInstanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="20d1-d4c6-1dea-fe19" type="notInstanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bff2-9ebc-0912-a1b3" type="notInstanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7746-0a7f-e844-2e37" type="notInstanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e3f-b42f-0740-448e" type="notInstanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="da34-52b0-53cc-1128" type="notInstanceOf"/>
-              </conditions>
-            </modifier>
-          </modifiers>
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1abd-9089-1745-333f" type="max"/>
-          </constraints>
-          <entryLinks>
-            <entryLink id="85cb-f706-ef88-9836" name="Relic: Kurov&apos;s Aquila" hidden="false" collective="false" import="true" targetId="4068-03ef-f2e9-1d58" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd6e-7055-ca6b-b711" type="notInstanceOf"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7921-45fe-365a-246d" type="max"/>
-                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="280f-e2c9-9a05-a16c" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="2153-7df8-1116-0bf6" name="Relic: Legacy of Kalladius" hidden="false" collective="false" import="true" targetId="eb13-2076-18e2-e4e7" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2ad3-62ae-375f-6942" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="5187-a412-2ebd-b6f7" name="Relic: Order of the Bastium Stellaris" hidden="false" collective="false" import="true" targetId="2698-2602-4337-6408" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="65cf-ce47-b5ae-7d50" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="5138-611d-a4e1-35a3" name="Relic: Psy-Sigil of Sanction" hidden="false" collective="false" import="true" targetId="ea97-24cc-f581-8f62" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9088-4c5e-6081-1924" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="59e3-71b6-92e0-218b" name="Relic: Refractor Field Generator" hidden="false" collective="false" import="true" targetId="00cb-7dec-59f8-acfc" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e133-a7cd-558c-6313" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="b6fe-829a-9f1c-b3aa" name="Relic: Relic of Lost Cadia" hidden="false" collective="false" import="true" targetId="0cbc-fba4-2e32-1813" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3dd4-f790-c003-4a2d" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="a261-de13-136b-9093" name="Relic: The Armour of Graf Toschenko" hidden="false" collective="false" import="true" targetId="02d1-fdc2-288b-6781" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="00bf-ef1c-f2cb-7110" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="70a8-b736-dff6-86fb" name="Relic: The Barbicant&apos;s Key" hidden="false" collective="false" import="true" targetId="1a31-5371-2f9a-9234" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3d52-fccf-10c0-3fae" type="notInstanceOf"/>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd6e-7055-ca6b-b711" type="notInstanceOf"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7817-7560-a9c6-9c72" type="max"/>
-                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="eb1c-fcef-bff3-fc36" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="f5fb-d209-b2c4-4f98" name="Relic: The Deathmask of Ollanius" hidden="false" collective="false" import="true" targetId="8802-85b0-d3d3-6158" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3d52-fccf-10c0-3fae" type="notInstanceOf"/>
-                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="ef18-746a-369f-43a4" type="notInstanceOf"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0705-2410-f7f0-e961" type="max"/>
-                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="7d69-59e0-ff07-9c27" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="8494-44e3-a9a0-1b5c" name="Relic: The Emperor&apos;s Benediction" hidden="false" collective="false" import="true" targetId="25d0-9bd6-7b74-98f4" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0334-f487-8229-0c1a" type="lessThan"/>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa52-8fb7-1c87-80e6" type="notInstanceOf"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="d624-045d-a647-ade8" type="max"/>
-                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="61b9-3df9-855d-debd" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="1802-bdcc-b4aa-4679" name="Relic: The Emperor&apos;s Fury" hidden="false" collective="false" import="true" targetId="0a30-6d27-4709-ca86" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="778a-4b27-b5d0-6068" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="8c8b-9a93-b52b-3016" name="Relic: The Laurels of Command" hidden="true" collective="false" import="true" targetId="ac59-27a4-14ff-220f" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="false">
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="dd6e-7055-ca6b-b711" type="instanceOf"/>
-                        <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="da34-52b0-53cc-1128" type="instanceOf"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="0b29-a4f3-3e6e-d27a" type="max"/>
-                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="1bc5-498a-ca4e-a9cf" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="9537-49ef-a9c5-d4a3" name="Relic: The Tactical Auto-Reliquary of Tyberius" hidden="false" collective="false" import="true" targetId="5ae2-c4d2-05bc-a16f" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="578f-4460-cf29-f2f4" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="7e89-7fcd-ee09-6962" name="Relic: Claw of the Desert Tigers" hidden="true" collective="false" import="true" targetId="b317-c165-a7d5-0388" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="false">
-                  <conditionGroups>
-                    <conditionGroup type="or">
-                      <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="greaterThan"/>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d475-faf3-ef14-5ea5" type="greaterThan"/>
-                      </conditions>
-                    </conditionGroup>
-                  </conditionGroups>
-                </modifier>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="de48-47aa-c5f1-39c3" type="max"/>
-                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="d5c5-018d-716d-5eaa" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="c3e2-ec59-8890-7ccc" name="Relic: Gatekeeper" hidden="false" collective="false" import="true" targetId="c723-aa80-a8e0-6a8d" type="selectionEntry">
-              <modifiers>
-                <modifier type="set" field="hidden" value="false"/>
-              </modifiers>
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b843-744b-e1ca-dd84" type="max"/>
-              </constraints>
-            </entryLink>
-          </entryLinks>
-        </selectionEntryGroup>
-      </selectionEntryGroups>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="pts" typeId="points" value="0.0"/>
@@ -6826,36 +6568,6 @@ Alternatively, you can use this Stratagem to give one COMMAND SQUAD model from y
         <profile id="a9bc-338d-794a-e390" name="Agripinaa-Class Orbital Tracker" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
           <characteristics>
             <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">In your Shooting phase, pick an EMPEROR’S WRATH unit from your army within 6&quot; of the bearer. Until the end of that phase, enemy units do not receive the benefit of cover when targeted by shooting attacks made by that unit.</characteristic>
-          </characteristics>
-        </profile>
-      </profiles>
-      <costs>
-        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-        <cost name="pts" typeId="points" value="0.0"/>
-        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-      </costs>
-    </selectionEntry>
-    <selectionEntry id="69b3-1fc3-ca6d-4512" name="Relic: Null Coat" publicationId="e831-8627-fbc7-5b35" page="73" hidden="false" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="fa52-8fb7-1c87-80e6" type="notInstanceOf"/>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2aba-e4e7-1d91-1a77" type="notInstanceOf"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
-      <constraints>
-        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="bbb4-cb03-3233-2cd6" type="max"/>
-      </constraints>
-      <profiles>
-        <profile id="20ef-0ebb-b2fd-45f3" name="Relic: Null Coat" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
-          <characteristics>
-            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">- In your opponent&apos;s Psychic phase, the bearer can attempt to deny one psychic power as if it were a Psyker.
-- Add 1 to Deny the Witch tests taken for the bearer.</characteristic>
           </characteristics>
         </profile>
       </profiles>
@@ -7169,19 +6881,6 @@ Refractor Field Generator (Aura): While a friendly MILITARUM TEMPESTUS INFANTRY 
       </costs>
     </selectionEntry>
     <selectionEntry id="0a30-6d27-4709-ca86" name="Relic: The Emperor&apos;s Fury" publicationId="e831-8627-fbc7-5b35" page="73" hidden="false" collective="false" import="true" type="upgrade">
-      <modifiers>
-        <modifier type="set" field="hidden" value="true">
-          <conditionGroups>
-            <conditionGroup type="or">
-              <conditions>
-                <condition field="selections" scope="force" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e6d-3f5b-3aac-ac75" type="lessThan"/>
-                <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bc9e-551d-9afb-78d5" type="lessThan"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3e01-e6cf-1353-96f4" type="notInstanceOf"/>
-              </conditions>
-            </conditionGroup>
-          </conditionGroups>
-        </modifier>
-      </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="f36e-d1cd-5b3a-0c24" type="max"/>
       </constraints>
@@ -8199,7 +7898,7 @@ If the mission you are playing uses the Strategic Reserves rules, you can place 
         </profile>
       </profiles>
       <costs>
-        <cost name="pts" typeId="points" value="2.0"/>
+        <cost name="pts" typeId="points" value="5.0"/>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
@@ -9505,6 +9204,168 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94d0-4221-d858-e3fe" type="max"/>
                   </constraints>
                 </entryLink>
+                <entryLink id="cf47-2b0c-d84d-e060" name="Relic: Claw of the Desert Tigers" hidden="true" collective="false" import="true" targetId="b317-c165-a7d5-0388" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3f13-48f6-efc1-cf44" type="equalTo"/>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0bc7-763d-557a-c9e0" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="32e6-f08c-313b-0be2" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                              </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e34-0a27-40d7-4923" type="greaterThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0bc7-763d-557a-c9e0" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="32e6-f08c-313b-0be2" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8ed7-7588-0f06-9b0d" type="lessThan"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a5a-00b2-ab4d-4b99" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
+                <entryLink id="0317-fad1-7a77-e18a" name="Relic: Legacy of Kalladius" hidden="true" collective="false" import="true" targetId="eb13-2076-18e2-e4e7" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3f13-48f6-efc1-cf44" type="equalTo"/>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0bc7-763d-557a-c9e0" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="32e6-f08c-313b-0be2" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                              </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e34-0a27-40d7-4923" type="greaterThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0bc7-763d-557a-c9e0" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e34-0a27-40d7-4923" type="greaterThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="32e6-f08c-313b-0be2" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8ed7-7588-0f06-9b0d" type="lessThan"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7de6-8590-28f7-d324" type="max"/>
+                  </constraints>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="a490-0598-f196-cd41" name="Laspistol" hidden="false" collective="false" import="true" defaultSelectionEntryId="0738-bb71-168d-25c8">
@@ -9536,6 +9397,88 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="eafb-26ca-4d82-3b86" type="max"/>
                   </constraints>
                 </entryLink>
+                <entryLink id="6578-3826-b36f-284b" name="Relic: The Emperor&apos;s Fury" hidden="true" collective="false" import="true" targetId="0a30-6d27-4709-ca86" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3f13-48f6-efc1-cf44" type="equalTo"/>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0bc7-763d-557a-c9e0" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="32e6-f08c-313b-0be2" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                              </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e34-0a27-40d7-4923" type="greaterThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0bc7-763d-557a-c9e0" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="32e6-f08c-313b-0be2" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8ed7-7588-0f06-9b0d" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a21e-1a66-b2ce-6ae0" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -9547,12 +9490,47 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
               </constraints>
             </entryLink>
             <entryLink id="03ae-cf17-a837-cc48" name="Display Regimental Orders" hidden="false" collective="false" import="true" targetId="af30-711d-1707-fcdc" type="selectionEntry"/>
-            <entryLink id="6afa-cd37-b873-8e18" name="Heirlooms of Conquest" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup">
+            <entryLink id="6afa-cd37-b873-8e18" name="Heirlooms of Conquest" hidden="true" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup">
               <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f2ee-41e3-618f-08db" type="greaterThan"/>
-                  </conditions>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e34-0a27-40d7-4923" type="greaterThan"/>
+                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0bc7-763d-557a-c9e0" type="lessThan"/>
+                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="32e6-f08c-313b-0be2" type="lessThan"/>
+                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c470-54ac-0863-8848" type="equalTo"/>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0bc7-763d-557a-c9e0" type="lessThan"/>
+                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="32e6-f08c-313b-0be2" type="lessThan"/>
+                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e34-0a27-40d7-4923" type="equalTo"/>
+                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c470-54ac-0863-8848" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
             </entryLink>
@@ -9562,8 +9540,13 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
               </constraints>
             </entryLink>
             <entryLink id="e178-7a47-be72-0fdc" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
-            <entryLink id="d59d-fb8d-2149-8222" name="Field Commander" hidden="false" collective="false" import="true" targetId="c7d5-e7b4-87d5-c29a" type="selectionEntry"/>
+            <entryLink id="d59d-fb8d-2149-8222" name="Field Commander" hidden="false" collective="false" import="true" targetId="c7d5-e7b4-87d5-c29a" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true"/>
+              </modifiers>
+            </entryLink>
             <entryLink id="c8d8-8980-2418-c301" name="Character Stratagems" hidden="false" collective="false" import="true" targetId="2527-4b0c-1e18-38b3" type="selectionEntryGroup"/>
+            <entryLink id="2af6-2d97-d1d5-ffa5" name="Bodyguard" hidden="false" collective="false" import="true" targetId="3cd9-53fc-5ffb-5f60" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
@@ -9635,17 +9618,6 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dadf-c738-5427-850b" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a890-edc8-a714-fe2e" type="max"/>
                   </constraints>
-                  <infoLinks>
-                    <infoLink id="406b-6a96-f734-1b30" name="Relic: Clarion Proclamatus" hidden="true" targetId="58c4-4b91-7cd9-c8c3" type="profile">
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="false">
-                          <conditions>
-                            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8d07-99e2-03ab-062d" type="greaterThan"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
-                    </infoLink>
-                  </infoLinks>
                 </entryLink>
                 <entryLink id="958e-20fc-acf2-8730" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
                   <constraints>
@@ -9659,7 +9631,122 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e62-6673-1b1b-1525" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="c47e-ec81-6279-7da1" name="Stratagem: Imperial Commander&apos;s Armoury" hidden="false" collective="false" import="true" targetId="d7be-7049-0cc9-dcf3" type="selectionEntry"/>
+                <entryLink id="0118-abdd-1a27-093d" name="Relic: Clarion Proclamatus" hidden="true" collective="false" import="true" targetId="7024-0bc8-1395-0ce7" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                              </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3f13-48f6-efc1-cf44" type="equalTo"/>
+                                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3f13-48f6-efc1-cf44" type="equalTo"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                              </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e34-0a27-40d7-4923" type="greaterThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3f13-48f6-efc1-cf44" type="equalTo"/>
+                                  </conditions>
+                                  <conditionGroups>
+                                    <conditionGroup type="and">
+                                      <conditions>
+                                        <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                        <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                        <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                        <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                        <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                        <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                        <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                        <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                        <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                                        <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                                        <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                                      </conditions>
+                                    </conditionGroup>
+                                  </conditionGroups>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e34-0a27-40d7-4923" type="greaterThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                                <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8ed7-7588-0f06-9b0d" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c30-6015-68d7-3fc6" type="max"/>
+                  </constraints>
+                </entryLink>
               </entryLinks>
               <costs>
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
@@ -9803,16 +9890,125 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
                       </modifiers>
                     </infoLink>
                     <infoLink id="c103-383e-22da-3baf" name="Regimental Standard " hidden="false" targetId="0456-0086-5490-3e04" type="profile"/>
-                    <infoLink id="805f-b6c5-a332-29b1" name="Relic: Finial of the Nemrodesh 1st" hidden="true" targetId="f6fb-0a03-530f-c251" type="profile">
+                  </infoLinks>
+                  <entryLinks>
+                    <entryLink id="c77e-97a8-b5e5-6c4c" name="Relic: Finial of the Nemrodesh 1st" hidden="true" collective="false" import="true" targetId="bed3-70b2-ff0b-8788" type="selectionEntry">
                       <modifiers>
                         <modifier type="set" field="hidden" value="false">
-                          <conditions>
-                            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed2f-1b65-e898-073b" type="greaterThan"/>
-                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="32e6-f08c-313b-0be2" type="lessThan"/>
+                                  </conditions>
+                                  <conditionGroups>
+                                    <conditionGroup type="and">
+                                      <conditions>
+                                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                                        <condition field="selections" scope="3b7d-927b-8856-e8b7" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                                      </conditions>
+                                    </conditionGroup>
+                                  </conditionGroups>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3f13-48f6-efc1-cf44" type="equalTo"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="32e6-f08c-313b-0be2" type="lessThan"/>
+                                  </conditions>
+                                  <conditionGroups>
+                                    <conditionGroup type="or">
+                                      <conditions>
+                                        <condition field="selections" scope="3b7d-927b-8856-e8b7" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e34-0a27-40d7-4923" type="greaterThan"/>
+                                        <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3f13-48f6-efc1-cf44" type="equalTo"/>
+                                      </conditions>
+                                      <conditionGroups>
+                                        <conditionGroup type="and">
+                                          <conditions>
+                                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                                            <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="32e6-f08c-313b-0be2" type="lessThan"/>
+                                          </conditions>
+                                        </conditionGroup>
+                                      </conditionGroups>
+                                    </conditionGroup>
+                                  </conditionGroups>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="6e34-0a27-40d7-4923" type="greaterThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                                    <condition field="selections" scope="3b7d-927b-8856-e8b7" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8ed7-7588-0f06-9b0d" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                          </conditionGroups>
                         </modifier>
                       </modifiers>
-                    </infoLink>
-                  </infoLinks>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="438b-1aa7-bdc8-f596" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
                   <costs>
                     <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
                     <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
@@ -9853,7 +10049,6 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9d8b-509d-7bcc-6bf1" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="22e3-5925-f1a7-2f4e" name="Stratagem: Imperial Commander&apos;s Armoury" hidden="false" collective="false" import="true" targetId="d7be-7049-0cc9-dcf3" type="selectionEntry"/>
               </entryLinks>
               <costs>
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
@@ -10115,7 +10310,7 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
       <entryLinks>
         <entryLink id="3451-5278-97f0-3b6b" name="Attaché" hidden="false" collective="false" import="true" targetId="698f-df58-b9ae-9ece" type="selectionEntryGroup"/>
         <entryLink id="63ed-f1c0-0f17-758c" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
-        <entryLink id="3cbc-72c4-d38f-3eb2" name="Bodyguard" hidden="false" collective="false" import="true" targetId="3cd9-53fc-5ffb-5f60" type="selectionEntryGroup"/>
+        <entryLink id="6e34-0a27-40d7-4923" name="Stratagem: Imperial Commander&apos;s Armoury" hidden="false" collective="false" import="true" targetId="d7be-7049-0cc9-dcf3" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="4.0"/>
@@ -10198,6 +10393,93 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
               </costs>
             </entryLink>
             <entryLink id="9db4-9465-253b-f021" name="Chainsword" hidden="false" collective="false" import="true" targetId="0dd1-2e2b-7dd1-5495" type="selectionEntry"/>
+            <entryLink id="0d8e-04c0-7e20-0372" name="Relic: Claw of the Desert Tigers" hidden="true" collective="false" import="true" targetId="b317-c165-a7d5-0388" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02d1-fdc2-288b-6781" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8ed7-7588-0f06-9b0d" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02d1-fdc2-288b-6781" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b317-c165-a7d5-0388" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02d1-fdc2-288b-6781" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="6ea3-ca90-2382-3846" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                                <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c470-54ac-0863-8848" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e388-29b0-6904-fc8e" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="f401-e8e9-ce0f-79e3" name="Bolt Pistol" hidden="false" collective="false" import="true" defaultSelectionEntryId="c0f8-adfe-cbbd-2ab3">
@@ -10225,6 +10507,79 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
                 <cost name="pts" typeId="points" value="5.0"/>
               </costs>
             </entryLink>
+            <entryLink id="83aa-3045-a3b3-89f1" name="Relic: The Emperor&apos;s Fury" hidden="true" collective="false" import="true" targetId="0a30-6d27-4709-ca86" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02d1-fdc2-288b-6781" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b317-c165-a7d5-0388" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8ed7-7588-0f06-9b0d" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02d1-fdc2-288b-6781" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b317-c165-a7d5-0388" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="6ea3-ca90-2382-3846" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                                <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c470-54ac-0863-8848" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0316-af7f-ef65-9ee5" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -10235,6 +10590,7 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
         <entryLink id="5396-6bdc-6560-6d2c" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
         <entryLink id="8699-47e8-0c80-2ea4" name="Character Stratagems" hidden="false" collective="false" import="true" targetId="2527-4b0c-1e18-38b3" type="selectionEntryGroup"/>
         <entryLink id="3d01-5e13-ad96-ab2a" name="Bodyguard" hidden="false" collective="false" import="true" targetId="3cd9-53fc-5ffb-5f60" type="selectionEntryGroup"/>
+        <entryLink id="2a23-4ff5-af4d-81bc" name="Stratagem: Imperial Commander&apos;s Armoury" hidden="false" collective="false" import="true" targetId="d7be-7049-0cc9-dcf3" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="40.0"/>
@@ -10461,6 +10817,79 @@ While a unit is suppressed, each time a model in that unit makes an attack, subt
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4d9c-7612-e032-b281" type="max"/>
                   </constraints>
                 </entryLink>
+                <entryLink id="e912-6d36-23e9-34fa" name="Relic: The Emperor&apos;s Fury" hidden="true" collective="false" import="true" targetId="0a30-6d27-4709-ca86" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d101-8840-6f76-ca67" type="greaterThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c54f-c56f-6c91-96c9" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d101-8840-6f76-ca67" type="greaterThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c54f-c56f-6c91-96c9" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                                <condition field="selections" scope="20d1-d4c6-1dea-fe19" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3f13-48f6-efc1-cf44" type="equalTo"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8ed7-7588-0f06-9b0d" type="lessThan"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1afa-b474-2b2f-2c3d" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
             <selectionEntryGroup id="d484-a1bb-991f-c1d4" name="Chainsword" hidden="false" collective="false" import="true" defaultSelectionEntryId="2cf1-2152-417a-6365">
@@ -10506,6 +10935,150 @@ While a unit is suppressed, each time a model in that unit makes an attack, subt
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="984e-3efd-e930-6e6c" type="max"/>
                   </constraints>
                 </entryLink>
+                <entryLink id="6af3-a9d5-d1b4-e01c" name="Relic: Legacy of Kalladius" hidden="true" collective="false" import="true" targetId="eb13-2076-18e2-e4e7" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d101-8840-6f76-ca67" type="greaterThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c54f-c56f-6c91-96c9" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d101-8840-6f76-ca67" type="greaterThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c54f-c56f-6c91-96c9" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                                <condition field="selections" scope="20d1-d4c6-1dea-fe19" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3f13-48f6-efc1-cf44" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8ed7-7588-0f06-9b0d" type="lessThan"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="964a-d700-127f-37f3" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="4dc8-7799-e0a0-d3c9" name="Relic: Claw of the Desert Tigers" hidden="true" collective="false" import="true" targetId="b317-c165-a7d5-0388" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d101-8840-6f76-ca67" type="greaterThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c54f-c56f-6c91-96c9" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c54f-c56f-6c91-96c9" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                              </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d101-8840-6f76-ca67" type="greaterThan"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8ed7-7588-0f06-9b0d" type="lessThan"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5e3f-eaf6-e2de-af9a" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -10530,67 +11103,64 @@ While a unit is suppressed, each time a model in that unit makes an attack, subt
                 </modifier>
               </modifiers>
             </entryLink>
-            <entryLink id="fb61-7f36-cb56-3a99" name="Heirlooms of Conquest" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup">
-              <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f2ee-41e3-618f-08db" type="greaterThan"/>
-                  </conditions>
-                </modifier>
-              </modifiers>
-            </entryLink>
             <entryLink id="0d62-0913-dee3-6601" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
             <entryLink id="3b5a-a749-3233-32dd" name="Character Stratagems" hidden="false" collective="false" import="true" targetId="2527-4b0c-1e18-38b3" type="selectionEntryGroup"/>
-          </entryLinks>
-          <costs>
-            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-            <cost name="pts" typeId="points" value="0.0"/>
-          </costs>
-        </selectionEntry>
-        <selectionEntry id="258f-3c1b-8620-f498" name="Cadian Veteran Guardsman (Medi-pack)" hidden="false" collective="false" import="true" type="model">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dcde-42a3-cc68-af7e" type="min"/>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="94fb-3fe7-826d-5632" type="max"/>
-          </constraints>
-          <profiles>
-            <profile id="582b-6fdd-e9d9-34b7" name="Cadian Veteran Guardsman" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
-              <characteristics>
-                <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
-                <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
-                <characteristic name="BS" typeId="381b-eb28-74c3-df5f">4+</characteristic>
-                <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
-                <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
-                <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
-                <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">2</characteristic>
-                <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
-                <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">5+</characteristic>
-              </characteristics>
-            </profile>
-          </profiles>
-          <categoryLinks>
-            <categoryLink id="e5bd-acae-a41a-58a4" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
-            <categoryLink id="4296-0a85-4091-d778" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
-            <categoryLink id="fd43-5da8-c4e9-20c3" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
-          </categoryLinks>
-          <entryLinks>
-            <entryLink id="8ef7-82c6-8e89-9b59" name="Lasgun" hidden="false" collective="false" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a0fb-127b-88f9-9e04" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6a99-c1b7-bfd1-621a" type="max"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="4fd1-1311-be21-5f81" name="Medi-pack" hidden="false" collective="false" import="true" targetId="1443-a52b-6953-c648" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="871c-0d5c-01f1-bc22" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="265d-60df-3857-94e9" type="min"/>
-              </constraints>
-            </entryLink>
-            <entryLink id="34fe-034c-df8e-c653" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9060-0edc-5c73-d0a8" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ca7c-5686-63e7-5076" type="min"/>
-              </constraints>
+            <entryLink id="8b13-296a-f032-9cf8" name="Bodyguard" hidden="false" collective="false" import="true" targetId="3cd9-53fc-5ffb-5f60" type="selectionEntryGroup"/>
+            <entryLink id="0542-0b37-d2d6-ec34" name="Heirlooms of Conquest" hidden="true" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c54f-c56f-6c91-96c9" type="lessThan"/>
+                            <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="20d1-d4c6-1dea-fe19" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="3f13-48f6-efc1-cf44" type="equalTo"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d101-8840-6f76-ca67" type="greaterThan"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="lessThan"/>
+                            <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
             </entryLink>
           </entryLinks>
           <costs>
@@ -10773,16 +11343,76 @@ While a unit is suppressed, each time a model in that unit makes an attack, subt
               </constraints>
               <infoLinks>
                 <infoLink id="5443-7451-8026-85b0" name="Master Vox" hidden="false" targetId="09e2-faa3-9206-a45e" type="profile"/>
-                <infoLink id="a243-adb9-9d8d-b328" name="Relic: Clarion Proclamatus" hidden="true" targetId="58c4-4b91-7cd9-c8c3" type="profile">
+              </infoLinks>
+              <entryLinks>
+                <entryLink id="3330-305f-a274-2b11" name="Relic: Clarion Proclamatus" hidden="true" collective="false" import="true" targetId="7024-0bc8-1395-0ce7" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="hidden" value="false">
-                      <conditions>
-                        <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8d07-99e2-03ab-062d" type="greaterThan"/>
-                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d101-8840-6f76-ca67" type="greaterThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c54f-c56f-6c91-96c9" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="force" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c54f-c56f-6c91-96c9" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c54f-c56f-6c91-96c9" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
                     </modifier>
                   </modifiers>
-                </infoLink>
-              </infoLinks>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee4a-343e-05ae-4325" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
             </entryLink>
             <entryLink id="e7a4-528e-e054-9184" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
               <constraints>
@@ -10790,7 +11420,6 @@ While a unit is suppressed, each time a model in that unit makes an attack, subt
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a1b7-9a31-32c4-4101" type="min"/>
               </constraints>
             </entryLink>
-            <entryLink id="3516-1123-170c-d1a7" name="Stratagem: Imperial Commander&apos;s Armoury" hidden="false" collective="false" import="true" targetId="d7be-7049-0cc9-dcf3" type="selectionEntry"/>
           </entryLinks>
           <costs>
             <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
@@ -10832,7 +11461,7 @@ While a unit is suppressed, each time a model in that unit makes an attack, subt
               <selectionEntries>
                 <selectionEntry id="abd0-52a2-c2f2-306f" name="Lasgun &amp; Regimental Standard" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a796-e769-16e0-f949" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a796-e769-16e0-f949" type="max"/>
                   </constraints>
                   <infoLinks>
                     <infoLink id="27c9-7fe3-0647-c446" name="Regimental Standard " hidden="false" targetId="0456-0086-5490-3e04" type="profile"/>
@@ -10841,15 +11470,6 @@ While a unit is suppressed, each time a model in that unit makes an attack, subt
                         <modifier type="set" field="hidden" value="true">
                           <conditions>
                             <condition field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="lessThan"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
-                    </infoLink>
-                    <infoLink id="c0d5-135f-73db-2cc1" name="Relic: Finial of the Nemrodesh 1st" hidden="true" targetId="f6fb-0a03-530f-c251" type="profile">
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="false">
-                          <conditions>
-                            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed2f-1b65-e898-073b" type="greaterThan"/>
                           </conditions>
                         </modifier>
                       </modifiers>
@@ -10865,7 +11485,63 @@ While a unit is suppressed, each time a model in that unit makes an attack, subt
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="43fc-4929-55ac-5620" type="min"/>
                       </constraints>
                     </entryLink>
-                    <entryLink id="4f01-ebcc-676f-21fa" name="Stratagem: Imperial Commander&apos;s Armoury" hidden="false" collective="false" import="true" targetId="d7be-7049-0cc9-dcf3" type="selectionEntry"/>
+                    <entryLink id="c54f-c56f-6c91-96c9" name="Relic: Finial of the Nemrodesh 1st" hidden="true" collective="false" import="true" targetId="bed3-70b2-ff0b-8788" type="selectionEntry">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="false">
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c54f-c56f-6c91-96c9" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                  </conditions>
+                                  <conditionGroups>
+                                    <conditionGroup type="or">
+                                      <conditions>
+                                        <condition field="selections" scope="716d-5866-fe42-6511" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c470-54ac-0863-8848" type="greaterThan"/>
+                                        <condition field="selections" scope="716d-5866-fe42-6511" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d101-8840-6f76-ca67" type="greaterThan"/>
+                                      </conditions>
+                                    </conditionGroup>
+                                  </conditionGroups>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e004-31ed-f6a2-3249" type="max"/>
+                      </constraints>
+                    </entryLink>
                   </entryLinks>
                   <costs>
                     <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
@@ -10951,12 +11627,78 @@ While a unit is suppressed, each time a model in that unit makes an attack, subt
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
+        <selectionEntry id="b0b3-3165-ef9b-a53f" name="Cadian Veteran Guardsman w/ Medi-pack" page="0" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cf38-0b5f-aced-4ded" type="max"/>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6066-70c4-390e-f892" type="min"/>
+          </constraints>
+          <profiles>
+            <profile id="e675-37d5-a65f-c35e" name="Cadian Veteran Guardsman" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+              <characteristics>
+                <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
+                <characteristic name="BS" typeId="381b-eb28-74c3-df5f">4+</characteristic>
+                <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
+                <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
+                <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">2</characteristic>
+                <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
+                <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">5+</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <categoryLinks>
+            <categoryLink id="d591-4008-3c4a-32e5" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
+            <categoryLink id="5362-d276-64e6-cfcb" name="Regimental" hidden="false" targetId="54e0-767a-ea48-e51c" primary="false"/>
+            <categoryLink id="2274-0ebe-d0c3-92f4" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
+            <categoryLink id="058f-5d6e-2300-d124" name="Medic" hidden="false" targetId="f89d-fb99-97ed-bc39" primary="false"/>
+          </categoryLinks>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="ea2a-665a-c4b3-4a38" name="Lasgun" hidden="false" collective="false" import="true" defaultSelectionEntryId="4cf9-5f5d-4f83-6c7b">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fe2-087f-f806-c53a" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d2c-0221-4e0e-d777" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="4cf9-5f5d-4f83-6c7b" name="Lasgun" hidden="false" collective="false" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ff9-edf7-8307-8af2" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30f0-fb27-f7b1-a5a8" type="min"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
+          <entryLinks>
+            <entryLink id="90ca-ea02-df2d-ea38" name="Medi-pack" hidden="false" collective="false" import="true" targetId="1443-a52b-6953-c648" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2991-0d5e-3749-cd5f" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f20a-5b54-ba1c-f8c1" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="4c82-967a-96d4-839c" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03fc-a5e8-fdfb-b629" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e56-ba33-eaef-cfd6" type="min"/>
+              </constraints>
+            </entryLink>
+          </entryLinks>
+          <costs>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
       </selectionEntries>
       <entryLinks>
         <entryLink id="41ab-5dd7-0797-8a12" name="Display Regimental Orders" hidden="false" collective="false" import="true" targetId="af30-711d-1707-fcdc" type="selectionEntry"/>
         <entryLink id="7f61-bf6d-a6c0-d7d3" name="Attaché" hidden="false" collective="false" import="true" targetId="698f-df58-b9ae-9ece" type="selectionEntryGroup"/>
-        <entryLink id="7e90-dbdb-23c3-48ad" name="Bodyguard" hidden="false" collective="false" import="true" targetId="3cd9-53fc-5ffb-5f60" type="selectionEntryGroup"/>
         <entryLink id="5c08-9bca-7077-89a5" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
+        <entryLink id="d101-8840-6f76-ca67" name="Stratagem: Imperial Commander&apos;s Armoury" hidden="false" collective="false" import="true" targetId="d7be-7049-0cc9-dcf3" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4351-2734-0da3-94ad" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="75.0"/>
@@ -12355,9 +13097,8 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ae3a-6835-fc7f-280a" name="Hunting Lance" hidden="false" collective="true" import="true" type="upgrade">
+    <selectionEntry id="ae3a-6835-fc7f-280a" name="Hunting Lance" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c644-c9af-a8f6-bb37" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f168-242f-c4e2-b654" type="max"/>
       </constraints>
       <profiles>
@@ -12559,7 +13300,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 </entryLink>
                 <entryLink id="1618-f177-c619-a839" name="Power sword" hidden="false" collective="false" import="true" targetId="bc9e-551d-9afb-78d5" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="0.0"/>
+                    <modifier type="set" field="points" value="5.0"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7749-4e92-8ccb-f508" type="max"/>
@@ -12650,7 +13391,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 </entryLink>
                 <entryLink id="5cdf-6946-6bb5-58f4" name="Plasma pistol" hidden="false" collective="false" import="true" targetId="83be-1ba9-c326-4760" type="selectionEntry">
                   <modifiers>
-                    <modifier type="set" field="points" value="0.0"/>
+                    <modifier type="set" field="points" value="5.0"/>
                   </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6c54-ba10-51b5-9575" type="max"/>
@@ -14347,6 +15088,18 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
           </characteristics>
         </profile>
         <profile id="6a8a-2497-ef32-e21e" name="Psyker" hidden="false" typeId="bc97-dea9-9e88-bb7d" typeName="Psyker">
+          <modifiers>
+            <modifier type="set" field="69d7-b45e-00a2-7e46" value="Smite &amp; 3 Psykana Powers">
+              <conditions>
+                <condition field="selections" scope="6e3f-b42f-0740-448e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ea97-24cc-f581-8f62" type="equalTo"/>
+              </conditions>
+            </modifier>
+            <modifier type="set" field="5afb-9914-904b-d3b3" value="3">
+              <conditions>
+                <condition field="selections" scope="6e3f-b42f-0740-448e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ea97-24cc-f581-8f62" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <characteristics>
             <characteristic name="Cast" typeId="5afb-9914-904b-d3b3">2</characteristic>
             <characteristic name="Deny" typeId="b5ac-9c20-5d5a-6f9b">1</characteristic>
@@ -14405,6 +15158,13 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       </selectionEntries>
       <entryLinks>
         <entryLink id="b579-b3ed-80bf-61a3" name="Psykana Discipline" hidden="false" collective="false" import="true" targetId="13fd-f96b-049d-7216" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="036b-c983-40d1-0cb6" value="3.0">
+              <conditions>
+                <condition field="selections" scope="6e3f-b42f-0740-448e" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ea97-24cc-f581-8f62" type="equalTo"/>
+              </conditions>
+            </modifier>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="036b-c983-40d1-0cb6" type="max"/>
           </constraints>
@@ -14421,8 +15181,13 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
           </modifiers>
         </entryLink>
         <entryLink id="a569-ec4b-5609-281a" name="Field Commander" hidden="false" collective="false" import="true" targetId="c7d5-e7b4-87d5-c29a" type="selectionEntry"/>
-        <entryLink id="3c3e-b0b1-b30c-aaf2" name="Sanctioned Psyker" hidden="false" collective="false" import="true" targetId="de88-2850-74ab-970b" type="selectionEntry"/>
+        <entryLink id="3c3e-b0b1-b30c-aaf2" name="Sanctioned Psyker" hidden="false" collective="false" import="true" targetId="de88-2850-74ab-970b" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true"/>
+          </modifiers>
+        </entryLink>
         <entryLink id="77bf-ac48-a0cf-e946" name="Character Stratagems" hidden="false" collective="false" import="true" targetId="2527-4b0c-1e18-38b3" type="selectionEntryGroup"/>
+        <entryLink id="379d-6051-7119-d019" name="Stratagem: Imperial Commander&apos;s Armoury" hidden="false" collective="false" import="true" targetId="d7be-7049-0cc9-dcf3" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="60.0"/>
@@ -14805,14 +15570,48 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 </entryLink>
               </entryLinks>
             </selectionEntryGroup>
+            <selectionEntryGroup id="4cf2-6708-3bcc-e9f4" name="Hunting Lance" hidden="false" collective="false" import="true" defaultSelectionEntryId="fbdc-3c7c-4d36-0ffd">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ec3a-2d85-a15b-4066" type="min"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="26e4-240a-3df1-9ebf" type="max"/>
+              </constraints>
+              <entryLinks>
+                <entryLink id="fbdc-3c7c-4d36-0ffd" name="Hunting Lance" hidden="false" collective="false" import="true" targetId="ae3a-6835-fc7f-280a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="95a0-7781-27b1-c10d" type="max"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="89bf-9c2b-2e12-b5b8" name="Goad Lance" hidden="false" collective="false" import="true" targetId="8150-24f8-8e4d-3bff" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="16d8-456e-a2d3-2eb4" value="0.0">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="cb55-1684-cb92-8146" value="2.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3ed2-16e4-b5ab-c664" type="atLeast"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                    <modifier type="set" field="16d8-456e-a2d3-2eb4" value="0.0">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="cb55-1684-cb92-8146" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="3ed2-16e4-b5ab-c664" type="atLeast"/>
+                            <condition field="selections" scope="cb55-1684-cb92-8146" value="9.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="model" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="16d8-456e-a2d3-2eb4" type="max"/>
+                    <constraint field="selections" scope="cb55-1684-cb92-8146" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9f36-6971-110a-0542" type="max"/>
+                  </constraints>
+                </entryLink>
+              </entryLinks>
+            </selectionEntryGroup>
           </selectionEntryGroups>
           <entryLinks>
-            <entryLink id="cf52-d80c-97d6-7398" name="Hunting Lance" hidden="false" collective="false" import="true" targetId="ae3a-6835-fc7f-280a" type="selectionEntry">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2070-e04a-8656-bd55" type="max"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9e36-5f5c-d5cb-a580" type="min"/>
-              </constraints>
-            </entryLink>
             <entryLink id="eafa-7f8c-8475-972c" name="Lasgun" hidden="false" collective="false" import="true" targetId="7236-b28a-2b6e-ded7" type="selectionEntry">
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="612d-1572-fba3-06c5" type="min"/>
@@ -14835,14 +15634,14 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       <selectionEntryGroups>
         <selectionEntryGroup id="0c02-7283-6f8d-5b96" name="Rough Riders" hidden="false" collective="false" import="true" defaultSelectionEntryId="d2b6-f688-bb9e-bfe6">
           <constraints>
-            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="241a-aa8c-8ba1-dec4" type="min"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="43ef-5fbc-c07d-c020" type="max"/>
+            <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c2a5-cbb9-1d9e-dc52" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e789-a9a9-8f98-51c7" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="d2b6-f688-bb9e-bfe6" name="Rough Rider" page="0" hidden="false" collective="false" import="true" type="model">
+            <selectionEntry id="d2b6-f688-bb9e-bfe6" name="Rough Rider" page="0" hidden="false" collective="true" import="true" type="model">
               <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e986-1428-6b41-4601" type="min"/>
-                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="f0b8-5078-de74-1a8a" type="max"/>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d12-be05-6a0d-9cf7" type="min"/>
+                <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73c0-c28f-a41e-b722" type="max"/>
               </constraints>
               <profiles>
                 <profile id="73e6-a0a1-9db8-2e67" name="Rough Rider" publicationId="53e9d88f--pubN88319" page="45" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -14859,20 +15658,11 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                   </characteristics>
                 </profile>
               </profiles>
-              <infoLinks>
-                <infoLink id="f7b7-a19c-6802-7ee4" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
-              </infoLinks>
               <entryLinks>
                 <entryLink id="9905-43a3-4779-257b" name="Laspistol" hidden="false" collective="false" import="true" targetId="9c74-d181-d2ec-0ba6" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="395d-f90d-22b2-1b5f" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfd4-15e2-53e9-93b9" type="min"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="2953-5921-1a0a-8794" name="Hunting Lance" hidden="false" collective="false" import="true" targetId="ae3a-6835-fc7f-280a" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="583c-fa0f-2143-1455" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a54f-6b45-86bc-f6be" type="min"/>
                   </constraints>
                 </entryLink>
                 <entryLink id="a50b-6807-9056-e810" name="Chainsword" hidden="false" collective="false" import="true" targetId="de76-80c5-81db-c463" type="selectionEntry">
@@ -14887,6 +15677,18 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0cf-067b-dbff-4471" type="min"/>
                   </constraints>
                 </entryLink>
+                <entryLink id="a9b9-7061-6e7d-62d2" name="Hunting Lance" hidden="false" collective="true" import="true" targetId="ae3a-6835-fc7f-280a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="309c-450e-dfd4-6228" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c05-dfe8-6ece-9694" type="min"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="425e-5952-28aa-3856" name="Frag grenades" hidden="false" collective="false" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf74-be69-e8b1-9cbf" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa55-3798-dab4-818a" type="min"/>
+                  </constraints>
+                </entryLink>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
@@ -14894,19 +15696,19 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="b7fc-08eb-321f-bc90" name="Rough Rider w/ Goad Lance" page="0" hidden="false" collective="false" import="true" type="model">
+            <selectionEntry id="3ed2-16e4-b5ab-c664" name="Rough Rider w/ Goad Lance" page="0" hidden="false" collective="true" import="true" type="model">
               <modifiers>
-                <modifier type="set" field="0d8c-2983-1218-aedf" value="2.0">
+                <modifier type="set" field="4efd-2898-d7dc-d509" value="2.0">
                   <conditions>
                     <condition field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
                   </conditions>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="0d8c-2983-1218-aedf" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4efd-2898-d7dc-d509" type="max"/>
               </constraints>
               <profiles>
-                <profile id="c78d-06b7-019e-7d82" name="Rough Rider" publicationId="53e9d88f--pubN88319" page="45" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+                <profile id="7723-5bac-2c8f-2f63" name="Rough Rider" publicationId="53e9d88f--pubN88319" page="45" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
                     <characteristic name="M" typeId="0bdf-a96e-9e38-7779">12&quot;</characteristic>
                     <characteristic name="WS" typeId="e7f0-1278-0250-df0c">3+</characteristic>
@@ -14920,29 +15722,37 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                   </characteristics>
                 </profile>
               </profiles>
-              <infoLinks>
-                <infoLink id="76d8-a7d2-0db9-6330" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
-              </infoLinks>
               <entryLinks>
-                <entryLink id="f03e-bf61-42a4-ccb8" name="Laspistol" hidden="false" collective="false" import="true" targetId="9c74-d181-d2ec-0ba6" type="selectionEntry">
+                <entryLink id="8c07-2323-f2fd-a783" name="Laspistol" hidden="false" collective="false" import="true" targetId="9c74-d181-d2ec-0ba6" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="42fe-aba6-8901-31b0" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f38d-7067-4984-2e63" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4ba-4812-901c-432f" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e102-2648-4d7e-c175" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="4586-ae6b-bb2a-78b3" name="Chainsword" hidden="false" collective="false" import="true" targetId="de76-80c5-81db-c463" type="selectionEntry">
+                <entryLink id="a342-a29a-2903-156d" name="Chainsword" hidden="false" collective="false" import="true" targetId="de76-80c5-81db-c463" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b8fc-e58e-4873-b130" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb2b-3683-ae47-f438" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1386-8e11-fa1d-b6d9" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36a9-5f35-7f0e-2682" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="ef7b-09bd-87fc-8206" name="Lasgun" hidden="false" collective="false" import="true" targetId="7236-b28a-2b6e-ded7" type="selectionEntry">
+                <entryLink id="1999-6c0f-46d0-a315" name="Lasgun" hidden="false" collective="false" import="true" targetId="7236-b28a-2b6e-ded7" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b360-8296-c26a-dc23" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="85d0-d919-8089-215f" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44b4-ecea-e15d-c94d" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="735d-3e2e-dfad-7ca8" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="312f-22fb-a15e-eacf" name="Goad Lance" hidden="false" collective="false" import="true" targetId="8150-24f8-8e4d-3bff" type="selectionEntry"/>
+                <entryLink id="49ac-af9d-218f-1c2d" name="Goad Lance" hidden="false" collective="true" import="true" targetId="8150-24f8-8e4d-3bff" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="35eb-8c53-9434-8c25" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="769b-0d65-2d0a-1854" type="min"/>
+                  </constraints>
+                </entryLink>
+                <entryLink id="c5d5-4a1b-262a-c8e8" name="Frag grenades" hidden="false" collective="false" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f006-5912-1fed-1712" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa71-bf0b-2afc-5e35" type="min"/>
+                  </constraints>
+                </entryLink>
               </entryLinks>
               <costs>
                 <cost name="pts" typeId="points" value="20.0"/>
@@ -15302,9 +16112,6 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3c7-d408-4f46-7294" type="max"/>
               </constraints>
-              <costs>
-                <cost name="pts" typeId="points" value="5.0"/>
-              </costs>
             </entryLink>
             <entryLink id="6474-fab9-3afe-1866" name="Hunter-killer missile" hidden="false" collective="false" import="true" targetId="32bf-b117-4ecf-5165" type="selectionEntry">
               <constraints>
@@ -16943,6 +17750,101 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0aec-29e1-7327-1dc6" type="max"/>
                   </constraints>
                 </entryLink>
+                <entryLink id="b8c7-4521-632a-2bce" name="Relic: The Emperor&apos;s Fury" hidden="true" collective="false" import="true" targetId="0a30-6d27-4709-ca86" type="selectionEntry">
+                  <modifiers>
+                    <modifier type="set" field="hidden" value="false">
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditionGroups>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd15-47da-b6fc-588e" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                              </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="equalTo"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c470-54ac-0863-8848" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd15-47da-b6fc-588e" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00cb-7dec-59f8-acfc" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                              </conditions>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7b0c-a1c8-4dd0" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00cb-7dec-59f8-acfc" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                              </conditions>
+                              <conditionGroups>
+                                <conditionGroup type="or">
+                                  <conditions>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="equalTo"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c470-54ac-0863-8848" type="equalTo"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                            <conditionGroup type="and">
+                              <conditions>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                                <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8ed7-7588-0f06-9b0d" type="lessThan"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </modifier>
+                  </modifiers>
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4bb1-2fd0-bc8f-4360" type="max"/>
+                  </constraints>
+                  <costs>
+                    <cost name="pts" typeId="points" value="5.0"/>
+                  </costs>
+                </entryLink>
               </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
@@ -16955,18 +17857,59 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
             </entryLink>
             <entryLink id="b967-d8db-a4fd-c33d" name="Display Astra Militarum Orders" hidden="false" collective="false" import="true" targetId="af30-711d-1707-fcdc" type="selectionEntry"/>
             <entryLink id="d1c0-2fc2-ef52-8e4e" name="Warlord" hidden="false" collective="false" import="true" targetId="1f07-a468-bda8-fd3f" type="selectionEntry"/>
-            <entryLink id="d97d-c9fa-12ad-8419" name="Heirlooms of Conquest" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup">
+            <entryLink id="d97d-c9fa-12ad-8419" name="Heirlooms of Conquest" hidden="true" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup">
               <modifiers>
-                <modifier type="set" field="hidden" value="true">
-                  <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f2ee-41e3-618f-08db" type="greaterThan"/>
-                  </conditions>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                            <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                            <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                            <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                            <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c470-54ac-0863-8848" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
                 </modifier>
               </modifiers>
             </entryLink>
             <entryLink id="1342-39cf-ec78-9ef2" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
             <entryLink id="bca2-268b-0a51-cfe6" name="Field Commander" hidden="false" collective="false" import="true" targetId="c7d5-e7b4-87d5-c29a" type="selectionEntry"/>
             <entryLink id="231e-02c5-7d4c-fdd1" name="Character Stratagems" hidden="false" collective="false" import="true" targetId="2527-4b0c-1e18-38b3" type="selectionEntryGroup"/>
+            <entryLink id="7c51-dbd3-8139-29cb" name="Bodyguard" hidden="false" collective="false" import="true" targetId="3cd9-53fc-5ffb-5f60" type="selectionEntryGroup"/>
           </entryLinks>
           <costs>
             <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
@@ -17034,20 +17977,115 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c84c-5fcb-d234-0b94" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a145-fcb4-490f-2c19" type="min"/>
                   </constraints>
-                  <infoLinks>
-                    <infoLink id="dca1-7b8b-ed10-1b6b" name="Relic: Clarion Proclamatus" hidden="true" targetId="58c4-4b91-7cd9-c8c3" type="profile">
-                      <modifiers>
-                        <modifier type="set" field="hidden" value="false">
-                          <conditions>
-                            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="8d07-99e2-03ab-062d" type="greaterThan"/>
-                          </conditions>
-                        </modifier>
-                      </modifiers>
-                    </infoLink>
-                  </infoLinks>
                   <categoryLinks>
                     <categoryLink id="4817-0d4e-a1e7-5d01" name="Vox-Caster" hidden="false" targetId="086d-e3ba-a17b-01bd" primary="false"/>
                   </categoryLinks>
+                  <entryLinks>
+                    <entryLink id="cd8c-18bf-e4c0-2bff" name="Relic: Clarion Proclamatus" hidden="true" collective="false" import="true" targetId="7024-0bc8-1395-0ce7" type="selectionEntry">
+                      <modifiers>
+                        <modifier type="set" field="hidden" value="false">
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd15-47da-b6fc-588e" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00cb-7dec-59f8-acfc" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7b0c-a1c8-4dd0" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00cb-7dec-59f8-acfc" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                  </conditions>
+                                  <conditionGroups>
+                                    <conditionGroup type="and">
+                                      <conditions>
+                                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                                        <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                                      </conditions>
+                                    </conditionGroup>
+                                  </conditionGroups>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7b0c-a1c8-4dd0" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00cb-7dec-59f8-acfc" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                  </conditions>
+                                  <conditionGroups>
+                                    <conditionGroup type="or">
+                                      <conditions>
+                                        <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="equalTo"/>
+                                        <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c470-54ac-0863-8848" type="equalTo"/>
+                                      </conditions>
+                                    </conditionGroup>
+                                  </conditionGroups>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8ed7-7588-0f06-9b0d" type="lessThan"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </modifier>
+                      </modifiers>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bcc7-31a0-3301-b1f1" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="points" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
                 </entryLink>
                 <entryLink id="9bd7-c77f-c054-ea02" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
                   <constraints>
@@ -17064,7 +18102,6 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="88ba-1b61-2c7e-b824" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="d6d6-c191-91b1-bbbb" name="Stratagem: Imperial Commander&apos;s Armoury" hidden="false" collective="false" import="true" targetId="d7be-7049-0cc9-dcf3" type="selectionEntry"/>
               </entryLinks>
               <costs>
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
@@ -17133,16 +18170,103 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                   <infoLinks>
                     <infoLink id="9e7e-e0e8-a82f-6e8b" name="Regimental Standard " hidden="false" targetId="0456-0086-5490-3e04" type="profile"/>
                     <infoLink id="ac4d-b96c-afd8-6ed6" name="Regimental Standard (Aura)" hidden="false" targetId="eb4d-1660-544a-18db" type="profile"/>
-                    <infoLink id="d7ad-296c-1fed-0b32" name="Relic: Finial of the Nemrodesh 1st" hidden="true" targetId="f6fb-0a03-530f-c251" type="profile">
+                  </infoLinks>
+                  <entryLinks>
+                    <entryLink id="7e3c-2a3b-410d-f440" name="Relic: Finial of the Nemrodesh 1st" hidden="true" collective="false" import="true" targetId="bed3-70b2-ff0b-8788" type="selectionEntry">
                       <modifiers>
                         <modifier type="set" field="hidden" value="false">
-                          <conditions>
-                            <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ed2f-1b65-e898-073b" type="greaterThan"/>
-                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditionGroups>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd15-47da-b6fc-588e" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c470-54ac-0863-8848" type="equalTo"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                  </conditions>
+                                  <conditionGroups>
+                                    <conditionGroup type="or">
+                                      <conditions>
+                                        <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="equalTo"/>
+                                        <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c470-54ac-0863-8848" type="equalTo"/>
+                                      </conditions>
+                                    </conditionGroup>
+                                  </conditionGroups>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fd15-47da-b6fc-588e" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00cb-7dec-59f8-acfc" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7d72-7b0c-a1c8-4dd0" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="00cb-7dec-59f8-acfc" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                                    <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                  </conditions>
+                                  <conditionGroups>
+                                    <conditionGroup type="and">
+                                      <conditions>
+                                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                                        <condition field="selections" scope="1f64-1ce0-19ac-6c18" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                                      </conditions>
+                                    </conditionGroup>
+                                  </conditionGroups>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8ed7-7588-0f06-9b0d" type="lessThan"/>
+                                  </conditions>
+                                </conditionGroup>
+                              </conditionGroups>
+                            </conditionGroup>
+                          </conditionGroups>
                         </modifier>
                       </modifiers>
-                    </infoLink>
-                  </infoLinks>
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8375-8dba-9168-f4a3" type="max"/>
+                      </constraints>
+                      <costs>
+                        <cost name="pts" typeId="points" value="5.0"/>
+                      </costs>
+                    </entryLink>
+                  </entryLinks>
                   <costs>
                     <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
                     <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
@@ -17166,7 +18290,6 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03e8-f0ed-de00-8db8" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="c2a2-6417-b01a-feb9" name="Stratagem: Imperial Commander&apos;s Armoury" hidden="false" collective="false" import="true" targetId="d7be-7049-0cc9-dcf3" type="selectionEntry"/>
               </entryLinks>
               <costs>
                 <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
@@ -17381,7 +18504,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       </selectionEntryGroups>
       <entryLinks>
         <entryLink id="fbe6-04e2-fa29-76b1" name="Attaché" hidden="false" collective="false" import="true" targetId="698f-df58-b9ae-9ece" type="selectionEntryGroup"/>
-        <entryLink id="6857-d9f9-cb38-01ac" name="Bodyguard" hidden="false" collective="false" import="true" targetId="3cd9-53fc-5ffb-5f60" type="selectionEntryGroup"/>
+        <entryLink id="1f9e-d180-51bd-9e4c" name="Stratagem: Imperial Commander&apos;s Armoury" hidden="false" collective="false" import="true" targetId="d7be-7049-0cc9-dcf3" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
@@ -19285,6 +20408,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5591-b636-73c3-e3ed" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="0870-6574-d2dc-8691" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="d50a-fbb9-f913-b014" name="Doctrine: Armoured Superiority" hidden="false" targetId="b2fd-4733-bddc-4233" type="profile"/>
@@ -19305,6 +20429,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d988-a398-9a6b-61fb" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="bffc-0644-e60e-ff87" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="5d28-0f50-c9bc-2bc9" name="Doctrine: Blitz Division" hidden="false" targetId="37a7-97cb-9112-c56b" type="profile"/>
@@ -19325,6 +20450,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9257-c5d9-417b-1ca1" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="65d4-29f9-5659-691e" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="d867-b8d5-26ec-4f46" name="Doctrine: Brutal Strength" hidden="false" targetId="5438-3a38-60d0-d189" type="profile"/>
@@ -19345,6 +20471,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e072-e377-b519-e4f0" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="81d9-bfe0-1fb4-88e9" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="dd84-1142-de84-3b80" name="Doctrine: Cult of Sacrifice" hidden="false" targetId="0017-0c4f-66b5-690f" type="profile"/>
@@ -19365,6 +20492,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="243c-579c-5b38-fe7b" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6c7f-ec1e-23f2-931b" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="7c3e-8b17-c989-6c81" name="Doctrine: Elite Sharpshooters" hidden="false" targetId="e2e9-e670-c5f5-0618" type="profile"/>
@@ -19385,6 +20513,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d41f-8a8b-8c88-92e9" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="4a20-0735-b223-a189" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="40e6-4d23-2921-4eb4" name="Doctrine: Expert Bombardiers" hidden="false" targetId="1b1a-e9c8-6fe5-d3e5" type="profile"/>
@@ -19405,6 +20534,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdbf-2115-dad2-35b8" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="b373-9bea-986e-1870" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="89e5-4f83-f2fc-410b" name="Doctrine: Grim Demeanor" hidden="false" targetId="a3d2-2bad-44ee-c917" type="profile"/>
@@ -19425,6 +20555,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d20f-804d-754a-889e" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="a0da-506d-3d2d-8462" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="c876-4874-03c8-f7d6" name="Doctrine: Heirloom Weapons" hidden="false" targetId="32d3-9063-2029-d45b" type="profile"/>
@@ -19445,6 +20576,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c445-376b-30d8-00d3" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="9655-28ca-7ea0-0701" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="c75d-6e3b-b07f-9506" name="Doctrine: Industrial Efficiency" hidden="false" targetId="1b8b-bd08-8f89-0848" type="profile"/>
@@ -19465,6 +20597,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ff1e-bed6-59f9-55d9" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="56d3-468f-1ad6-b09c" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="b673-bb08-07a6-316d" name="Doctrine: Mechanised Infantry" hidden="false" targetId="ea1c-06da-438a-cf51" type="profile"/>
@@ -19485,6 +20618,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="53a4-0bc6-68b8-a09b" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="fe43-a4a9-dba6-1f1e" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="b49c-7665-3081-f18a" name="Doctrine: Parade Drill" hidden="false" targetId="a9f4-2ae1-1447-0d82" type="profile"/>
@@ -19505,6 +20639,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8447-231c-6c99-7f1a" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="5bd5-94a4-b125-4dee" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="e362-e92a-51e3-43ad" name="Doctrine: Recon Operators" hidden="false" targetId="3594-f562-2ecf-c607" type="profile"/>
@@ -19525,6 +20660,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="176f-df3c-2fb1-4280" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="b7d9-4ca2-c825-c9be" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="c447-03e0-cb13-371a" name="Doctrine: Swift as the Wind" hidden="false" targetId="32fd-39a5-3099-65ea" type="profile"/>
@@ -19545,6 +20681,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d15e-26b4-a3f1-ef60" type="max"/>
+                <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="f4f0-50d7-c5f2-0643" type="max"/>
               </constraints>
               <infoLinks>
                 <infoLink id="0718-7487-8889-6da2" name="Doctrine: Veteran Guerrillas" hidden="false" targetId="73e1-d2e0-cbc7-e405" type="profile"/>
@@ -19950,10 +21087,10 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="f19b-ab38-0cc9-d861" name="Lasgun" hidden="false" collective="false" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
+                <entryLink id="631e-7f33-ff11-dee8" name="Lasgun" hidden="false" collective="true" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3a0d-61f6-e1ca-8839" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4c4-31a0-5535-f5f9" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="235f-70b5-184d-1bf1" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="603d-6457-3779-0b4d" type="min"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -19990,10 +21127,10 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="c3c2-4632-9244-57c0" name="Lasgun" hidden="false" collective="false" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
+                <entryLink id="c3c2-4632-9244-57c0" name="Lasgun" hidden="false" collective="true" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b262-1d26-e654-201b" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f462-4d67-b89b-6a72" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b262-1d26-e654-201b" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f462-4d67-b89b-6a72" type="min"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -20030,10 +21167,10 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="0ea7-41b2-7b60-ab67" name="Lasgun" hidden="false" collective="false" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
+                <entryLink id="6d7c-72db-75ee-56ab" name="Lasgun" hidden="false" collective="true" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3429-8d2a-9a5d-29fa" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8d2b-1fb0-a551-fe13" type="min"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3256-1cc7-6659-bfdb" type="max"/>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f247-2f7d-43d2-c29c" type="min"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -20521,7 +21658,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
           <modifiers>
             <modifier type="set" field="hidden" value="true">
               <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="f2ee-41e3-618f-08db" type="greaterThan"/>
+                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4629-5e2b-bf50-a6c8" type="greaterThan"/>
               </conditions>
             </modifier>
           </modifiers>
@@ -20547,6 +21684,11 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8751-58b5-9cc2-c904" type="min"/>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b5f6-0e50-a928-bbbb" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="4629-5e2b-bf50-a6c8" name="Stratagem: Imperial Commander&apos;s Armoury" hidden="false" collective="false" import="true" targetId="d7be-7049-0cc9-dcf3" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="66d6-31aa-7751-86f1" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
@@ -21540,8 +22682,8 @@ Note that this ability only affects the original target of that Order, and not a
       <selectionEntryGroups>
         <selectionEntryGroup id="37cb-def8-ad0c-d824" name="Death Korps Troopers" publicationId="e831-8627-fbc7-5b35" page="92" hidden="false" collective="false" import="true" defaultSelectionEntryId="5f6d-ca0c-2fd1-7815">
           <constraints>
-            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6170-94b8-32a7-5444" type="min"/>
-            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5187-c637-154f-9180" type="max"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6170-94b8-32a7-5444" type="min"/>
+            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5187-c637-154f-9180" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="2a8c-d7b9-324c-0ff7" name="Death Korps Trooper w/ Medi-pack" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -23815,9 +24957,8 @@ You can only use this Stratagem once, unless you are playing a Strike Force batt
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8150-24f8-8e4d-3bff" name="Goad Lance" publicationId="e831-8627-fbc7-5b35" page="99" hidden="false" collective="true" import="true" type="upgrade">
+    <selectionEntry id="8150-24f8-8e4d-3bff" name="Goad Lance" publicationId="e831-8627-fbc7-5b35" page="99" hidden="false" collective="false" import="true" type="upgrade">
       <constraints>
-        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ee3-5964-ebca-21b3" type="min"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdff-6299-3b5e-739f" type="max"/>
       </constraints>
       <profiles>
@@ -23878,6 +25019,35 @@ You can only use this Stratagem once, unless you are playing a Strike Force batt
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="2.0"/>
         <cost name="pts" typeId="points" value="40.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="7d72-7b0c-a1c8-4dd0" name="Relic: Null Coat" publicationId="e831-8627-fbc7-5b35" page="73" hidden="false" collective="false" import="true" type="upgrade">
+      <modifiers>
+        <modifier type="set" field="hidden" value="true">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2aba-e4e7-1d91-1a77" type="notInstanceOf"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+      </modifiers>
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="0b9f-0e33-ddd4-0c76" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="a0d1-7f1b-2a8b-1fea" name="Null Coat" hidden="false" typeId="72c5eafc-75bf-4ed9-b425-78009f1efe82" typeName="Abilities">
+          <characteristics>
+            <characteristic name="Description" typeId="21befb24-fc85-4f52-a745-64b2e48f8228">• In your opponent&apos;s Psychic phase, the bearer can attempt to deny one psychic power as if it were a PSYKER.
+•Add 1 to Deny the Witch tests taken for the bearer.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
@@ -24126,6 +25296,9 @@ You can only use this Stratagem once, unless you are playing a Strike Force batt
               </constraints>
               <selectionEntries>
                 <selectionEntry id="7e8e-83d9-2740-fd56" name="Twin Heavy Bolters" hidden="false" collective="false" import="true" type="upgrade">
+                  <modifiers>
+                    <modifier type="set" field="points" value="0.0"/>
+                  </modifiers>
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="02d1-a87e-9dc1-71dc" type="max"/>
                   </constraints>
@@ -24149,6 +25322,9 @@ You can only use this Stratagem once, unless you are playing a Strike Force batt
                   </constraints>
                   <entryLinks>
                     <entryLink id="3e00-ccf0-ebc9-c207" name="Twin heavy flamer" hidden="false" collective="false" import="true" targetId="8d70-a6af-cbad-f08c" type="selectionEntry">
+                      <modifiers>
+                        <modifier type="set" field="points" value="0.0"/>
+                      </modifiers>
                       <constraints>
                         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b387-aa70-a7d9-8f9f" type="min"/>
                         <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0ba7-ad62-4a58-f256" type="max"/>
@@ -24166,6 +25342,9 @@ You can only use this Stratagem once, unless you are playing a Strike Force batt
           </selectionEntryGroups>
           <entryLinks>
             <entryLink id="ee5f-74b0-fc23-d2b7" name="Lascannon" hidden="false" collective="false" import="true" targetId="a908-4664-11cd-f8b2" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="points" value="0.0"/>
+              </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b7cd-c1cc-4073-0725" type="min"/>
                 <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b594-597f-f4de-db7d" type="max"/>
@@ -24382,7 +25561,7 @@ You can only use this Stratagem once, unless you are playing a Strike Force batt
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="451a-3f92-f7d9-9ba5" type="max"/>
       </constraints>
       <selectionEntries>
-        <selectionEntry id="1cfb-6d96-613e-756d" name="Multi-laser" page="0" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="1cfb-6d96-613e-756d" name="Militarum Multi-laser" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="17f4-9e04-6ed3-fce3" type="max"/>
           </constraints>
@@ -24457,7 +25636,7 @@ You can only use this Stratagem once, unless you are playing a Strike Force batt
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="2e0e-0eb8-4f19-763a" name="Plasma Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
+        <selectionEntry id="2e0e-0eb8-4f19-763a" name="Militarum Plasma Cannon" page="0" hidden="false" collective="false" import="true" type="upgrade">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2ed9-521c-6732-2128" type="max"/>
           </constraints>
@@ -25069,7 +26248,11 @@ You can only use this Stratagem once, unless you are playing a Strike Force batt
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
-        <entryLink id="2171-5f21-6ca6-3424" name="Warlord Traits (BRB)" hidden="false" collective="false" import="true" targetId="d442-1f03-d9da-e77f" type="selectionEntryGroup"/>
+        <entryLink id="2171-5f21-6ca6-3424" name="Warlord Traits (BRB)" hidden="false" collective="false" import="true" targetId="d442-1f03-d9da-e77f" type="selectionEntryGroup">
+          <modifiers>
+            <modifier type="set" field="name" value="Warlord Traits (Core Rules)"/>
+          </modifiers>
+        </entryLink>
       </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="033c-c12e-bdf2-bc9e" name="Turret Cannon" hidden="false" collective="false" import="true" defaultSelectionEntryId="ad5a-de7c-c237-821e">
@@ -25702,7 +26885,7 @@ receive the benefits of cover against that attack.&quot;</characteristic>
             <cost name="pts" typeId="points" value="40.0"/>
           </costs>
         </selectionEntry>
-        <selectionEntry id="8d14-605c-34b9-d67e" name="Vaunted Praetorian" hidden="true" collective="false" import="true" type="upgrade">
+        <selectionEntry id="8d14-605c-34b9-d67e" name="Vaunted Praetorian" hidden="false" collective="false" import="true" type="upgrade">
           <modifiers>
             <modifier type="add" field="category" value="dd6e-7055-ca6b-b711"/>
           </modifiers>
@@ -26097,19 +27280,33 @@ receive the benefits of cover against that attack.&quot;</characteristic>
               <conditions>
                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="1f07-a468-bda8-fd3f" type="lessThan"/>
                 <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7be-7049-0cc9-dcf3" type="lessThan"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
               </conditions>
             </conditionGroup>
           </conditionGroups>
         </modifier>
         <modifier type="increment" field="6a0f-9c75-d490-1802" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c470-54ac-0863-8848" type="greaterThan"/>
-          </conditions>
-        </modifier>
-        <modifier type="decrement" field="6a0f-9c75-d490-1802" value="1.0">
-          <conditions>
-            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
-          </conditions>
+          <conditionGroups>
+            <conditionGroup type="and">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+              </conditions>
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c470-54ac-0863-8848" type="greaterThan"/>
+                    <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7be-7049-0cc9-dcf3" type="atLeast"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </conditionGroup>
+            <conditionGroup type="or">
+              <conditions>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7be-7049-0cc9-dcf3" type="equalTo"/>
+                <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+              </conditions>
+            </conditionGroup>
+          </conditionGroups>
         </modifier>
         <modifier type="set" field="hidden" value="true">
           <conditionGroups>
@@ -26117,7 +27314,6 @@ receive the benefits of cover against that attack.&quot;</characteristic>
               <conditionGroups>
                 <conditionGroup type="and">
                   <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7be-7049-0cc9-dcf3" type="equalTo"/>
                     <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
                     <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c470-54ac-0863-8848" type="equalTo"/>
                   </conditions>
@@ -26126,13 +27322,38 @@ receive the benefits of cover against that attack.&quot;</characteristic>
             </conditionGroup>
           </conditionGroups>
         </modifier>
+        <modifier type="set" field="6a0f-9c75-d490-1802" value="1.0">
+          <conditionGroups>
+            <conditionGroup type="or">
+              <conditionGroups>
+                <conditionGroup type="and">
+                  <conditions>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                    <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7be-7049-0cc9-dcf3" type="equalTo"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </conditionGroup>
+          </conditionGroups>
+        </modifier>
+        <modifier type="decrement" field="6a0f-9c75-d490-1802" value="1.0">
+          <repeats>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0a30-6d27-4709-ca86" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="25d0-9bd6-7b74-98f4" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b317-c165-a7d5-0388" repeats="1" roundUp="false"/>
+            <repeat field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="eb13-2076-18e2-e4e7" repeats="1" roundUp="false"/>
+          </repeats>
+        </modifier>
       </modifiers>
       <constraints>
         <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="6a0f-9c75-d490-1802" type="max"/>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="5d24-89b0-592a-2abb" type="max"/>
       </constraints>
       <entryLinks>
-        <entryLink id="fbb7-d75f-7ef1-6c7f" name="Relic: Claw of the Desert Tigers" hidden="false" collective="false" import="true" targetId="b317-c165-a7d5-0388" type="selectionEntry">
+        <entryLink id="fbb7-d75f-7ef1-6c7f" name="Relic: Claw of the Desert Tigers" hidden="true" collective="false" import="true" targetId="b317-c165-a7d5-0388" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true"/>
+          </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5efc-dc7c-fc40-7135" type="max"/>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="85f5-03b7-5085-2d61" type="max"/>
@@ -26186,7 +27407,7 @@ receive the benefits of cover against that attack.&quot;</characteristic>
             <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="2944-b547-ad2d-046f" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="8f25-ef26-2a3f-afbc" name="Relic (Tallarn): Claw of the Desert Tigers" hidden="false" collective="false" import="true" targetId="0a30-6d27-4709-ca86" type="selectionEntry">
+        <entryLink id="8f25-ef26-2a3f-afbc" name="Relic: The Emperor&apos;s Fury" hidden="true" collective="false" import="true" targetId="0a30-6d27-4709-ca86" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="949c-d2c4-8071-e783" type="max"/>
           </constraints>
@@ -26249,7 +27470,7 @@ receive the benefits of cover against that attack.&quot;</characteristic>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="08f0-9558-b6bd-d985" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="b17a-ce36-12d2-0e8f" name="Relic (32nd Thetoid Eagles): Fire of Judgement" hidden="false" collective="false" import="true" targetId="2698-2602-4337-6408" type="selectionEntry">
+        <entryLink id="b17a-ce36-12d2-0e8f" name="Relic: Order of the Bastium Stellaris" hidden="false" collective="false" import="true" targetId="2698-2602-4337-6408" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3fa7-72d6-5a1c-9db4" type="max"/>
           </constraints>
@@ -26278,9 +27499,10 @@ receive the benefits of cover against that attack.&quot;</characteristic>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5903-4a5d-d4f5-9c52" type="max"/>
           </constraints>
         </entryLink>
-        <entryLink id="0488-54a7-52c4-c7c9" name="Relic: Legacy of Kalladius" hidden="false" collective="false" import="true" targetId="eb13-2076-18e2-e4e7" type="selectionEntry">
+        <entryLink id="0488-54a7-52c4-c7c9" name="Relic: Legacy of Kalladius" hidden="true" collective="false" import="true" targetId="eb13-2076-18e2-e4e7" type="selectionEntry">
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c4b9-90b6-eaec-383a" type="max"/>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="72a8-5303-8058-34d9" type="max"/>
           </constraints>
         </entryLink>
         <entryLink id="d428-6dc8-639e-726f" name="Relic: Gatekeeper" hidden="false" collective="false" import="true" targetId="c723-aa80-a8e0-6a8d" type="selectionEntry">
@@ -26298,6 +27520,22 @@ receive the benefits of cover against that attack.&quot;</characteristic>
           </modifiers>
           <constraints>
             <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e0f5-f3bf-308c-48e8" type="max"/>
+          </constraints>
+        </entryLink>
+        <entryLink id="fd15-47da-b6fc-588e" name="Relic: Null Coat" hidden="false" collective="false" import="true" targetId="7d72-7b0c-a1c8-4dd0" type="selectionEntry">
+          <modifiers>
+            <modifier type="set" field="hidden" value="true">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditions>
+                    <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="2aba-e4e7-1d91-1a77" type="notInstanceOf"/>
+                  </conditions>
+                </conditionGroup>
+              </conditionGroups>
+            </modifier>
+          </modifiers>
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="413b-eb2e-7906-e126" type="max"/>
           </constraints>
         </entryLink>
       </entryLinks>
@@ -26341,6 +27579,9 @@ receive the benefits of cover against that attack.&quot;</characteristic>
               </conditionGroups>
             </modifier>
           </modifiers>
+          <constraints>
+            <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="37e2-a502-2d14-2b57" type="max"/>
+          </constraints>
         </entryLink>
         <entryLink id="d0d7-60a5-28b0-678a" name="Stratagem: Warlord Trait" hidden="false" collective="false" import="true" targetId="6771-6ab3-1672-6a39" type="selectionEntry"/>
         <entryLink id="b260-a1b0-e411-e14d" name="Stratagem: Officer Cadre" publicationId="e831-8627-fbc7-5b35" page="63" hidden="false" collective="false" import="true" targetId="ba4b-6ae1-ffb8-76aa" type="selectionEntry">
@@ -26354,20 +27595,6 @@ receive the benefits of cover against that attack.&quot;</characteristic>
                 </conditionGroup>
               </conditionGroups>
             </modifier>
-          </modifiers>
-        </entryLink>
-        <entryLink id="f2ee-41e3-618f-08db" name="Stratagem: Imperial Commander&apos;s Armoury" publicationId="e831-8627-fbc7-5b35" page="64" hidden="false" collective="false" import="true" targetId="d7be-7049-0cc9-dcf3" type="selectionEntry">
-          <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditionGroups>
-                <conditionGroup type="or">
-                  <conditions>
-                    <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8ed7-7588-0f06-9b0d" type="greaterThan"/>
-                  </conditions>
-                </conditionGroup>
-              </conditionGroups>
-            </modifier>
-            <modifier type="remove" field="category" value="ff36a6f3-19bf-4f48-8956-adacfd28fe74"/>
           </modifiers>
         </entryLink>
       </entryLinks>


### PR DESCRIPTION
Added Goad Lance to Rough Rider Sergeants and set it to be capped at 0 if there are at least 2 goad lance rough riders in the unit, or if the unit has 4 rough riders and one of them has one goad lance


Fixed Infantry Squad plasma pistol and power sword costs

Set up Field ordnance batteries to correctlt have 2 lasguns each

Fixed baneblade sponson costs on first sets

Fixed Armoured and Scout Sentinel Chainsaw costs

Multi-Laser on Sentinels renamed to Militarum multi-lasers

Plasma Cannon on Sentinels renamed to Militarum Plasma Cannon

Moved bodyguards into Cadian Commander options

Vaunted Praetorian now visible on Super Heavy tanks

Changed how Imperial Commander's Armoury works, should work more correctly now, but could use more testing

Fixed Imperial Commander's Armoury on Commissars and Primaris Psykers

Updated max on DKOK to 9

Fixed Kasrkin Warrior Elite limits

Fixed Cadian Command Squad medics on Text Export


Hidden Sanctioned Psyker ability from Primaris Psyker