### PR TITLE
v0.6.4-Counters-Update

### DIFF
--- a/Imperial_Guard_9th_Ed.cat
+++ b/Imperial_Guard_9th_Ed.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="53e9d88f-7463-8c27-fe67-e1a0d1ed0287" name="Imperium - Imperial Guard 9th Ed" revision="333" battleScribeVersion="2.03" authorName="3Komnenos3, TheHalfinStream, Nerdylicious (reference servitor) , based on files originally developed by Jon K, Joe B, Wil" authorContact="" authorUrl="" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="53e9d88f-7463-8c27-fe67-e1a0d1ed0287" name="Imperium - Imperial Guard 9th Ed" revision="334" battleScribeVersion="2.03" authorName="3Komnenos3, TheHalfinStream, Nerdylicious (reference servitor) , based on files originally developed by Jon K, Joe B, Wil" authorContact="" authorUrl="" library="false" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <readme>The BSData team is not responsible for these 9th edition updates and should not be contacted for support. Find us on the Mordian Glory Discord.
 
 This is a heavily modified version of the BSData team&apos;s Astra Militarum 8th Edition battlescribe files, and all credit goes to them for the creation of the 8th edition version which laid the foundation to our project to bring over the 9th edition codex, and an additional thanks for answering some of our questions on the BSData discord, as well as allowing us to go forward with this project.</readme>
@@ -685,12 +685,6 @@ This is a heavily modified version of the BSData team&apos;s Astra Militarum 8th
         <categoryLink id="4f8d-0695-9e4a-6653" name="New CategoryLink" hidden="false" targetId="c845-c72c-6afe-3fc2" primary="true"/>
       </categoryLinks>
     </entryLink>
-    <entryLink id="1ba8-4e15-0911-8927" name="Lord Solar Leontus" hidden="false" collective="false" import="true" targetId="0fcd-d6ee-231e-920e" type="selectionEntry">
-      <categoryLinks>
-        <categoryLink id="be03-0a1d-00ff-5774" name="Supreme Commander" hidden="false" targetId="5750-de0a-589d-eacf" primary="false"/>
-        <categoryLink id="3415-be8a-3f00-d8da" name="Primarch | Daemon Primarch | Supreme Commander" hidden="false" targetId="26b0-4bb9-73aa-d3d7" primary="true"/>
-      </categoryLinks>
-    </entryLink>
     <entryLink id="ba6f-7219-826c-7a15" name="Kasrkin" hidden="false" collective="false" import="true" targetId="0609-08fb-cd8a-8b1e" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="e1fa-6329-3a3a-822a" name="Elites" hidden="false" targetId="638d74c6-bd97-4de5-b65a-6aaa24e9f4b2" primary="true"/>
@@ -826,6 +820,15 @@ This is a heavily modified version of the BSData team&apos;s Astra Militarum 8th
     <entryLink id="e527-aa9d-129a-3541" name="Aegis Defence Line" publicationId="e831-8627-fbc7-5b35" page="114" hidden="false" collective="false" import="true" targetId="6686-a69f-e614-2258" type="selectionEntry">
       <categoryLinks>
         <categoryLink id="8d3b-0998-5a04-32f2" name="Fortification" hidden="false" targetId="d713cda3-5d0f-40d8-b621-69233263ec2a" primary="true"/>
+      </categoryLinks>
+    </entryLink>
+    <entryLink id="84bb-a5f8-77e5-3084" name="Lord Solar Leontus" hidden="false" collective="false" import="true" targetId="0fcd-d6ee-231e-920e" type="selectionEntry">
+      <comment>Supreme Commander Version</comment>
+      <constraints>
+        <constraint field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" id="5f3e-ab6d-fe05-9051" type="max"/>
+      </constraints>
+      <categoryLinks>
+        <categoryLink id="a137-8260-4f87-f37f" name="Primarch | Daemon Primarch | Supreme Commander" hidden="false" targetId="26b0-4bb9-73aa-d3d7" primary="true"/>
       </categoryLinks>
     </entryLink>
   </entryLinks>

--- a/Imperium_-_Imperial_Guard_9th_Ed_Library.cat
+++ b/Imperium_-_Imperial_Guard_9th_Ed_Library.cat
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<catalogue id="a2d9-e3b7-13cc-6f15" name="Imperium - Imperial Guard - 9th Ed - Library" revision="135" battleScribeVersion="2.03" authorName="3Komnenos3, TheHalfinStream, Nerdylicious (reference servitor) , based on files originally developed by Jon K, Joe B, Wil" authorContact="" authorUrl="" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
+<catalogue id="a2d9-e3b7-13cc-6f15" name="Imperium - Imperial Guard - 9th Ed - Library" revision="136" battleScribeVersion="2.03" authorName="3Komnenos3, TheHalfinStream, Nerdylicious (reference servitor) , based on files originally developed by Jon K, Joe B, Wil" authorContact="" authorUrl="" library="true" gameSystemId="28ec-711c-d87f-3aeb" gameSystemRevision="225" xmlns="http://www.battlescribe.net/schema/catalogueSchema">
   <readme>The BSData team is not responsible for these 9th edition updates and should not be contacted for support. Find us on the Mordian Glory Discord.
 
 
@@ -5932,7 +5932,6 @@ If this unit scores 5 or more hits against that enemy unit, then until the end o
               <conditions>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="54fa-3b28-008a-74c1" type="instanceOf"/>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="cf83-4163-2d65-cb4f" type="instanceOf"/>
-                <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="7746-0a7f-e844-2e37" type="instanceOf"/>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8d55-4c9d-ac32-8437" type="instanceOf"/>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="9be9-51c0-3d7c-7e43" type="instanceOf"/>
                 <condition field="selections" scope="ancestor" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="e7df-1257-851a-5cee" type="instanceOf"/>
@@ -10401,7 +10400,6 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
                       <conditionGroups>
                         <conditionGroup type="and">
                           <conditions>
-                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
                             <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
                             <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
                             <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
@@ -10413,6 +10411,14 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
                             <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
                             <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
                           </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="6ea3-ca90-2382-3846" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c470-54ac-0863-8848" type="greaterThan"/>
+                                <condition field="selections" scope="6ea3-ca90-2382-3846" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
                         </conditionGroup>
                         <conditionGroup type="and">
                           <conditions>
@@ -10444,7 +10450,6 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
                             <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
                             <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
                             <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
-                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b317-c165-a7d5-0388" type="lessThan"/>
                           </conditions>
                         </conditionGroup>
                         <conditionGroup type="and">
@@ -10475,6 +10480,93 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
               </modifiers>
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e388-29b0-6904-fc8e" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
+            <entryLink id="b31e-f0f1-f875-ebe5" name="Relic: Legacy of Kalladius" hidden="true" collective="false" import="true" targetId="eb13-2076-18e2-e4e7" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02d1-fdc2-288b-6781" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b317-c165-a7d5-0388" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b317-c165-a7d5-0388" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8ed7-7588-0f06-9b0d" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02d1-fdc2-288b-6781" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b317-c165-a7d5-0388" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02d1-fdc2-288b-6781" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b317-c165-a7d5-0388" type="lessThan"/>
+                            <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="6ea3-ca90-2382-3846" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                                <condition field="selections" scope="6ea3-ca90-2382-3846" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c470-54ac-0863-8848" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0865-ad7a-b973-4e8a" type="max"/>
               </constraints>
               <costs>
                 <cost name="pts" typeId="points" value="5.0"/>
@@ -10590,7 +10682,11 @@ Divination (Psychic Action - Warp Charge 7): In your Psychic phase, one ASTROPAT
         <entryLink id="5396-6bdc-6560-6d2c" name="Warlord Traits" hidden="false" collective="false" import="true" targetId="d6e2-a400-a8db-d4f2" type="selectionEntryGroup"/>
         <entryLink id="8699-47e8-0c80-2ea4" name="Character Stratagems" hidden="false" collective="false" import="true" targetId="2527-4b0c-1e18-38b3" type="selectionEntryGroup"/>
         <entryLink id="3d01-5e13-ad96-ab2a" name="Bodyguard" hidden="false" collective="false" import="true" targetId="3cd9-53fc-5ffb-5f60" type="selectionEntryGroup"/>
-        <entryLink id="2a23-4ff5-af4d-81bc" name="Stratagem: Imperial Commander&apos;s Armoury" hidden="false" collective="false" import="true" targetId="d7be-7049-0cc9-dcf3" type="selectionEntry"/>
+        <entryLink id="2a23-4ff5-af4d-81bc" name="Stratagem: Imperial Commander&apos;s Armoury" hidden="false" collective="false" import="true" targetId="d7be-7049-0cc9-dcf3" type="selectionEntry">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6b94-51fe-5785-4732" type="max"/>
+          </constraints>
+        </entryLink>
       </entryLinks>
       <costs>
         <cost name="pts" typeId="points" value="40.0"/>
@@ -11497,7 +11593,6 @@ While a unit is suppressed, each time a model in that unit makes an attack, subt
                                     <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
                                     <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
                                     <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
-                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="c54f-c56f-6c91-96c9" type="lessThan"/>
                                     <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
                                     <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
                                     <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
@@ -11531,6 +11626,23 @@ While a unit is suppressed, each time a model in that unit makes an attack, subt
                                     <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
                                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
                                     <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                  </conditions>
+                                </conditionGroup>
+                                <conditionGroup type="and">
+                                  <conditions>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0488-54a7-52c4-c7c9" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="fbb7-d75f-7ef1-6c7f" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                                    <condition field="selections" scope="716d-5866-fe42-6511" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d101-8840-6f76-ca67" type="greaterThan"/>
                                   </conditions>
                                 </conditionGroup>
                               </conditionGroups>
@@ -11653,22 +11765,6 @@ While a unit is suppressed, each time a model in that unit makes an attack, subt
             <categoryLink id="2274-0ebe-d0c3-92f4" name="Command Squad" hidden="false" targetId="33c0-8496-22d0-08e9" primary="false"/>
             <categoryLink id="058f-5d6e-2300-d124" name="Medic" hidden="false" targetId="f89d-fb99-97ed-bc39" primary="false"/>
           </categoryLinks>
-          <selectionEntryGroups>
-            <selectionEntryGroup id="ea2a-665a-c4b3-4a38" name="Lasgun" hidden="false" collective="false" import="true" defaultSelectionEntryId="4cf9-5f5d-4f83-6c7b">
-              <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fe2-087f-f806-c53a" type="min"/>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5d2c-0221-4e0e-d777" type="max"/>
-              </constraints>
-              <entryLinks>
-                <entryLink id="4cf9-5f5d-4f83-6c7b" name="Lasgun" hidden="false" collective="false" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="5ff9-edf7-8307-8af2" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30f0-fb27-f7b1-a5a8" type="min"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-            </selectionEntryGroup>
-          </selectionEntryGroups>
           <entryLinks>
             <entryLink id="90ca-ea02-df2d-ea38" name="Medi-pack" hidden="false" collective="false" import="true" targetId="1443-a52b-6953-c648" type="selectionEntry">
               <constraints>
@@ -11680,6 +11776,12 @@ While a unit is suppressed, each time a model in that unit makes an attack, subt
               <constraints>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="03fc-a5e8-fdfb-b629" type="max"/>
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4e56-ba33-eaef-cfd6" type="min"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="6677-0bef-3377-9bba" name="Lasgun" hidden="false" collective="false" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f069-4088-601f-f7bd" type="max"/>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9a2-980f-b9b3-cc1d" type="min"/>
               </constraints>
             </entryLink>
           </entryLinks>
@@ -13097,7 +13199,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="ae3a-6835-fc7f-280a" name="Hunting Lance" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="ae3a-6835-fc7f-280a" name="Hunting Lance" hidden="false" collective="true" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f168-242f-c4e2-b654" type="max"/>
       </constraints>
@@ -15619,6 +15721,23 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1ce0-0ee4-e684-84ef" type="max"/>
               </constraints>
             </entryLink>
+            <entryLink id="6219-03c7-bdae-0867" name="Relic: Claw of the Desert Tigers" hidden="false" collective="false" import="true" targetId="b317-c165-a7d5-0388" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="true">
+                  <conditions>
+                    <condition field="selections" scope="54fa-3b28-008a-74c1" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1ac8-f654-2dc9-4613" type="lessThan"/>
+                  </conditions>
+                </modifier>
+                <modifier type="set" field="d3cf-9817-43a2-4cad" value="1.0">
+                  <conditions>
+                    <condition field="selections" scope="54fa-3b28-008a-74c1" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1ac8-f654-2dc9-4613" type="greaterThan"/>
+                  </conditions>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d3cf-9817-43a2-4cad" type="max"/>
+              </constraints>
+            </entryLink>
           </entryLinks>
           <costs>
             <cost name="pts" typeId="points" value="20.0"/>
@@ -15634,7 +15753,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e789-a9a9-8f98-51c7" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="d2b6-f688-bb9e-bfe6" name="Rough Rider" page="0" hidden="false" collective="true" import="true" type="model">
+            <selectionEntry id="d2b6-f688-bb9e-bfe6" name="Rough Rider" page="0" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0d12-be05-6a0d-9cf7" type="min"/>
                 <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="73c0-c28f-a41e-b722" type="max"/>
@@ -15655,19 +15774,13 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="9905-43a3-4779-257b" name="Laspistol" hidden="false" collective="false" import="true" targetId="9c74-d181-d2ec-0ba6" type="selectionEntry">
+                <entryLink id="9905-43a3-4779-257b" name="Laspistol" hidden="false" collective="true" import="true" targetId="9c74-d181-d2ec-0ba6" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="395d-f90d-22b2-1b5f" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="dfd4-15e2-53e9-93b9" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="a50b-6807-9056-e810" name="Chainsword" hidden="false" collective="false" import="true" targetId="de76-80c5-81db-c463" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4b03-9ac9-9c90-4ba0" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e2ea-1d17-27ef-bc17" type="min"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="b076-55c8-b713-0fb9" name="Lasgun" hidden="false" collective="false" import="true" targetId="7236-b28a-2b6e-ded7" type="selectionEntry">
+                <entryLink id="b076-55c8-b713-0fb9" name="Lasgun" hidden="false" collective="true" import="true" targetId="7236-b28a-2b6e-ded7" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3206-5fd3-677d-f673" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0cf-067b-dbff-4471" type="min"/>
@@ -15679,7 +15792,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c05-dfe8-6ece-9694" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="425e-5952-28aa-3856" name="Frag grenades" hidden="false" collective="false" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
+                <entryLink id="425e-5952-28aa-3856" name="Frag grenades" hidden="false" collective="true" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bf74-be69-e8b1-9cbf" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="aa55-3798-dab4-818a" type="min"/>
@@ -15692,16 +15805,16 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="3ed2-16e4-b5ab-c664" name="Rough Rider w/ Goad Lance" page="0" hidden="false" collective="true" import="true" type="model">
+            <selectionEntry id="3ed2-16e4-b5ab-c664" name="Rough Rider w/ Goad Lance" page="0" hidden="false" collective="false" import="true" type="model">
               <modifiers>
-                <modifier type="set" field="4efd-2898-d7dc-d509" value="2.0">
-                  <conditions>
-                    <condition field="selections" scope="parent" value="10.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" type="atLeast"/>
-                  </conditions>
+                <modifier type="increment" field="4efd-2898-d7dc-d509" value="1.0">
+                  <repeats>
+                    <repeat field="selections" scope="cb55-1684-cb92-8146" value="5.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="model" repeats="1" roundUp="false"/>
+                  </repeats>
                 </modifier>
               </modifiers>
               <constraints>
-                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4efd-2898-d7dc-d509" type="max"/>
+                <constraint field="selections" scope="parent" value="0.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4efd-2898-d7dc-d509" type="max"/>
               </constraints>
               <profiles>
                 <profile id="7723-5bac-2c8f-2f63" name="Rough Rider" publicationId="53e9d88f--pubN88319" page="45" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
@@ -15719,19 +15832,13 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="8c07-2323-f2fd-a783" name="Laspistol" hidden="false" collective="false" import="true" targetId="9c74-d181-d2ec-0ba6" type="selectionEntry">
+                <entryLink id="8c07-2323-f2fd-a783" name="Laspistol" hidden="false" collective="true" import="true" targetId="9c74-d181-d2ec-0ba6" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a4ba-4812-901c-432f" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e102-2648-4d7e-c175" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="a342-a29a-2903-156d" name="Chainsword" hidden="false" collective="false" import="true" targetId="de76-80c5-81db-c463" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1386-8e11-fa1d-b6d9" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="36a9-5f35-7f0e-2682" type="max"/>
-                  </constraints>
-                </entryLink>
-                <entryLink id="1999-6c0f-46d0-a315" name="Lasgun" hidden="false" collective="false" import="true" targetId="7236-b28a-2b6e-ded7" type="selectionEntry">
+                <entryLink id="1999-6c0f-46d0-a315" name="Lasgun" hidden="false" collective="true" import="true" targetId="7236-b28a-2b6e-ded7" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="44b4-ecea-e15d-c94d" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="735d-3e2e-dfad-7ca8" type="max"/>
@@ -15743,7 +15850,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="769b-0d65-2d0a-1854" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="c5d5-4a1b-262a-c8e8" name="Frag grenades" hidden="false" collective="false" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
+                <entryLink id="c5d5-4a1b-262a-c8e8" name="Frag grenades" hidden="false" collective="true" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f006-5912-1fed-1712" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fa71-bf0b-2afc-5e35" type="min"/>
@@ -15762,7 +15869,7 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
       <entryLinks>
         <entryLink id="a950-817d-b849-23d4" name="Has Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="4763-757f-499f-d998" type="selectionEntry"/>
         <entryLink id="d93c-23e0-dc29-12b4" name="Battle Honours (Chapter Approved 2018)" hidden="false" collective="false" import="true" targetId="5518-d0f5-a880-d71c" type="selectionEntryGroup"/>
-        <entryLink id="7448-106a-0470-e9f9" name="Unit Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
+        <entryLink id="7448-106a-0470-e9f9" name="Regimental Doctrines" hidden="false" collective="false" import="true" targetId="71c4-b0c4-a7b5-4f1d" type="selectionEntry"/>
       </entryLinks>
       <costs>
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="5.0"/>
@@ -17933,13 +18040,13 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 <categoryLink id="c994-90ea-1335-f016" name="Infantry" hidden="false" targetId="3d52-fccf-10c0-3fae" primary="false"/>
               </categoryLinks>
               <entryLinks>
-                <entryLink id="f350-fa46-e4e8-7e7e" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                <entryLink id="f350-fa46-e4e8-7e7e" name="Frag &amp; Krak grenades" hidden="false" collective="true" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96a5-0625-511a-5fcf" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0a47-e25b-0354-e2c9" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="cc62-210f-a10e-f78f" name="Hot-Shot Lasgun" hidden="false" collective="false" import="true" targetId="5188-4b26-73ac-1160" type="selectionEntry">
+                <entryLink id="cc62-210f-a10e-f78f" name="Hot-shot lasgun" hidden="false" collective="true" import="true" targetId="ce42-82cb-28b6-dab5" type="selectionEntry">
                   <modifiers>
                     <modifier type="set" field="points" value="0.0"/>
                   </modifiers>
@@ -18788,16 +18895,16 @@ On a 4+ do not remove that marker from the battlefield, but that marker cannot b
                 <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a073-e1dc-c22a-7771" type="max"/>
               </constraints>
               <infoLinks>
-                <infoLink id="b565-5b35-1cfe-b064" hidden="false" targetId="f51905c4-7ffb-3a41-ad86-de14eba93ba3" type="profile"/>
+                <infoLink id="b565-5b35-1cfe-b064" name="Tempestus Scion" hidden="false" targetId="f51905c4-7ffb-3a41-ad86-de14eba93ba3" type="profile"/>
               </infoLinks>
               <entryLinks>
-                <entryLink id="480e-8bfc-298c-987a" name="Hot-shot Lasgun" hidden="false" collective="false" import="true" targetId="ce42-82cb-28b6-dab5" type="selectionEntry">
+                <entryLink id="480e-8bfc-298c-987a" name="Hot-shot lasgun" hidden="false" collective="true" import="true" targetId="ce42-82cb-28b6-dab5" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="989a-7215-ba7d-4a2e" type="max"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d9ac-fbdf-0a62-ce7e" type="min"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="765a-72da-9079-5633" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                <entryLink id="765a-72da-9079-5633" name="Frag &amp; Krak grenades" hidden="false" collective="true" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd88-4c13-a14c-7169" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="db2d-7a19-cdf3-b500" type="max"/>
@@ -20102,106 +20209,6 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
             <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9911-91fb-6a2d-c64c" type="min"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="4b02-603c-5df5-4c0a" name="Kasrkin Trooper with Special Weapon" page="0" hidden="false" collective="false" import="true" type="model">
-              <constraints>
-                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2978-4d8a-6682-7bcc" type="max"/>
-              </constraints>
-              <profiles>
-                <profile id="583e-b286-ea1a-0c18" name="Kasrkin Trooper" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
-                  <characteristics>
-                    <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
-                    <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
-                    <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
-                    <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
-                    <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
-                    <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
-                    <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">2</characteristic>
-                    <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
-                    <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">4+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <selectionEntryGroups>
-                <selectionEntryGroup id="5ba9-c153-ed40-d891" name="Special Weapon" hidden="false" collective="false" import="true" defaultSelectionEntryId="0772-9b43-0b56-40ec">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ee77-752e-0a60-6dfe" type="max"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="347f-439b-e445-7133" type="min"/>
-                  </constraints>
-                  <selectionEntries>
-                    <selectionEntry id="0772-9b43-0b56-40ec" name="Grenade Launcher" hidden="false" collective="false" import="true" type="upgrade">
-                      <constraints>
-                        <constraint field="selections" scope="0609-08fb-cd8a-8b1e" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="01f0-ef53-5b6b-fbb7" type="max"/>
-                      </constraints>
-                      <profiles>
-                        <profile id="1968-e31c-5ea8-ae49" name="Grenade Launcher (Frag)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-                          <characteristics>
-                            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
-                            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault D6</characteristic>
-                            <characteristic name="S" typeId="59b1-319e-ec13-d466">3</characteristic>
-                            <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
-                            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
-                            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast.</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile id="4ac2-767c-dc4c-3489" name="Grenade Launcher (Krak)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-                          <characteristics>
-                            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
-                            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault 1</characteristic>
-                            <characteristic name="S" typeId="59b1-319e-ec13-d466">6</characteristic>
-                            <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
-                            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
-                            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"/>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <costs>
-                        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                        <cost name="pts" typeId="points" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
-                  <entryLinks>
-                    <entryLink id="a602-73f4-0db5-d4c0" name="Plasma gun" hidden="false" collective="false" import="true" targetId="8c14-22cc-93ce-b85a" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="0609-08fb-cd8a-8b1e" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2098-6687-2783-4e19" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="6e9b-0b85-dace-3b96" name="Meltagun" hidden="false" collective="false" import="true" targetId="efc8-c51d-5b02-a3a2" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="0609-08fb-cd8a-8b1e" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d64b-75f2-c494-e661" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="fb37-db28-e398-9b5d" name="Flamer" hidden="false" collective="false" import="true" targetId="fd22-6743-2d4c-dd62" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="0609-08fb-cd8a-8b1e" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b91b-3d18-5922-8d1b" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="7156-41db-cf25-871f" name="Hot-shot Volley Gun" hidden="false" collective="false" import="true" targetId="5d8d-f53d-1a4c-fabb" type="selectionEntry">
-                      <modifiers>
-                        <modifier type="set" field="points" value="0.0"/>
-                      </modifiers>
-                      <constraints>
-                        <constraint field="selections" scope="0609-08fb-cd8a-8b1e" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3068-60c0-ffc7-52e3" type="max"/>
-                      </constraints>
-                    </entryLink>
-                  </entryLinks>
-                </selectionEntryGroup>
-              </selectionEntryGroups>
-              <entryLinks>
-                <entryLink id="8370-9dfc-c46b-7485" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8c03-7a58-cb72-3364" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e7d-1563-26ca-49ab" type="max"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
             <selectionEntry id="2ec2-27de-727f-990f" name="Kasrkin Trooper" page="0" hidden="false" collective="false" import="true" type="model">
               <constraints>
                 <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fa98-d547-aa98-3df1" type="max"/>
@@ -20387,6 +20394,325 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
               </costs>
             </selectionEntry>
           </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="fa09-99e5-7c5a-8b2e" name="Kasrkin Trooper w/ Special Weapon" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="4.0" percentValue="false" shared="false" includeChildSelections="true" includeChildForces="false" id="7d1f-1a4a-70a8-d2d3" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="f479-5d9e-cfde-3532" name="Kasrkin Trooper with Flamer" page="0" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9fff-fe39-d74e-1582" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="d7cc-31e0-86db-3cef" name="Kasrkin Trooper" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+                      <characteristics>
+                        <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                        <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
+                        <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
+                        <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                        <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
+                        <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
+                        <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">2</characteristic>
+                        <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
+                        <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">4+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <selectionEntries>
+                    <selectionEntry id="81cd-efe4-571d-eb4c" name="Flamer" hidden="false" collective="true" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="8904-21fd-7cec-20dc" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2e16-98ef-c7ed-e88e" type="min"/>
+                      </constraints>
+                      <profiles>
+                        <profile id="d35c-2443-c681-7a79" name="Hot-Shot Volley Gun" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                          <characteristics>
+                            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">12&quot;</characteristic>
+                            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault D6</characteristic>
+                            <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
+                            <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
+                            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+                            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Each time an attack is made with this weapon, that attack automatically hits the target.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <costs>
+                        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="0d84-660a-a8df-d487" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="630b-29d1-479e-45c1" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="028a-5ddf-e3ab-b78b" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="78aa-9909-5ef1-c9d2" name="Kasrkin Trooper with Grenade Launcher" page="0" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="dc51-f2c5-41f7-1b8a" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="30f5-1029-5bba-0aec" name="Kasrkin Trooper" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+                      <characteristics>
+                        <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                        <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
+                        <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
+                        <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                        <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
+                        <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
+                        <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">2</characteristic>
+                        <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
+                        <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">4+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <selectionEntries>
+                    <selectionEntry id="b5bc-ac60-e26d-7fbe" name="Grenade Launcher" hidden="false" collective="true" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f0b2-33b9-3f8b-8f8d" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1518-278f-4418-52e2" type="min"/>
+                      </constraints>
+                      <profiles>
+                        <profile id="a006-617e-e64e-e3e5" name="Grenade Launcher (Frag)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                          <characteristics>
+                            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+                            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault D6</characteristic>
+                            <characteristic name="S" typeId="59b1-319e-ec13-d466">3</characteristic>
+                            <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
+                            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+                            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast.</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile id="cea8-dfb2-c8d0-dbce" name="Grenade Launcher (Krak)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                          <characteristics>
+                            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+                            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault 1</characteristic>
+                            <characteristic name="S" typeId="59b1-319e-ec13-d466">6</characteristic>
+                            <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
+                            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
+                            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"/>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <costs>
+                        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="5ca2-6b62-cf38-f59c" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1c48-bd2e-edde-9f79" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b4db-32e3-685d-6ea0" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="d089-6138-064c-ce00" name="Kasrkin Trooper with Hot-Shot Volley Gun" page="0" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9f07-04e1-c369-36fa" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="ab05-b7d3-3d0c-27ad" name="Kasrkin Trooper" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+                      <characteristics>
+                        <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                        <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
+                        <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
+                        <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                        <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
+                        <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
+                        <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">2</characteristic>
+                        <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
+                        <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">4+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <selectionEntries>
+                    <selectionEntry id="9ac3-cecd-06d7-7202" name="Hot-Shot Volley Gun" hidden="false" collective="true" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7680-eb60-35bb-1f2e" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d248-2fb8-0b40-4465" type="min"/>
+                      </constraints>
+                      <profiles>
+                        <profile id="013f-2e1d-9dec-3962" name="Hot-Shot Volley Gun" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                          <characteristics>
+                            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+                            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Rapid Fire 2</characteristic>
+                            <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
+                            <characteristic name="AP" typeId="75aa-a838-b675-6484">-2</characteristic>
+                            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+                            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <costs>
+                        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="6788-aa43-ca18-95fe" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="4a9d-c20e-c05f-fec4" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="bd01-dc2f-a9c1-d92c" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="8184-d715-d42a-84b9" name="Kasrkin Trooper with Meltagun" page="0" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="8c76-49a5-177f-c7cf" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="a72a-7416-3fd4-9dde" name="Kasrkin Trooper" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+                      <characteristics>
+                        <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                        <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
+                        <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
+                        <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                        <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
+                        <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
+                        <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">2</characteristic>
+                        <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
+                        <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">4+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <selectionEntries>
+                    <selectionEntry id="3760-828d-8283-71d6" name="Meltagun" hidden="false" collective="true" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="25ed-2f7a-b2b9-617e" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="afaa-808e-0bae-790b" type="min"/>
+                      </constraints>
+                      <profiles>
+                        <profile id="0f88-5e27-9e4e-6e49" name="Meltagun" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                          <characteristics>
+                            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">12&quot;</characteristic>
+                            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault 1</characteristic>
+                            <characteristic name="S" typeId="59b1-319e-ec13-d466">8</characteristic>
+                            <characteristic name="AP" typeId="75aa-a838-b675-6484">-4</characteristic>
+                            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D6</characteristic>
+                            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Each time an attack is made with this weapon targets a unit within half range, that attack has a Damage characteristic of D6+2</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <costs>
+                        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="ce56-c237-a422-7ac8" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="060d-fd57-16f5-58ad" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9cbe-4a94-3e54-ecc2" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+                <selectionEntry id="150d-4e18-616c-04c3" name="Kasrkin Trooper with Plasma Gun" page="0" hidden="false" collective="false" import="true" type="model">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6184-ad06-b1b4-ea74" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="633c-477b-910d-bda1" name="Kasrkin Trooper" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+                      <characteristics>
+                        <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                        <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
+                        <characteristic name="BS" typeId="381b-eb28-74c3-df5f">3+</characteristic>
+                        <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                        <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
+                        <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
+                        <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">2</characteristic>
+                        <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">7</characteristic>
+                        <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">4+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <selectionEntries>
+                    <selectionEntry id="bde3-ad2b-1126-6061" name="Plasma Gun" hidden="false" collective="true" import="true" type="upgrade">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="30e0-ab8c-79f2-c4b4" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="11c1-a698-9684-1066" type="min"/>
+                      </constraints>
+                      <profiles>
+                        <profile id="1d93-3460-ca4d-ff18" name="Plasma Gun (Standard)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                          <characteristics>
+                            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+                            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Rapid Fire 1</characteristic>
+                            <characteristic name="S" typeId="59b1-319e-ec13-d466">7</characteristic>
+                            <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
+                            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+                            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
+                          </characteristics>
+                        </profile>
+                        <profile id="0721-ed4b-9996-49bf" name="Plasma Gun (Supercharge)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+                          <characteristics>
+                            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+                            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Rapid Fire 1</characteristic>
+                            <characteristic name="S" typeId="59b1-319e-ec13-d466">8</characteristic>
+                            <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
+                            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
+                            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">If any unmodified hit rolls of 1 are made for attacks with this weapon profile, the bearer is destroyed after shooting with this weapon.</characteristic>
+                          </characteristics>
+                        </profile>
+                      </profiles>
+                      <costs>
+                        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                        <cost name="pts" typeId="points" value="0.0"/>
+                      </costs>
+                    </selectionEntry>
+                  </selectionEntries>
+                  <entryLinks>
+                    <entryLink id="be03-dfe3-7689-7a11" name="Frag &amp; Krak grenades" hidden="false" collective="false" import="true" targetId="cddf-945e-1335-e681" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="d7e2-bd27-a52b-366c" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="20cd-da3c-c400-bb09" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                  <costs>
+                    <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+                    <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+                    <cost name="pts" typeId="points" value="0.0"/>
+                  </costs>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
         </selectionEntryGroup>
         <selectionEntryGroup id="6f8b-c1d9-4156-2b54" name="Warrior Elites: Regimental Doctrines" hidden="false" collective="false" import="true" defaultSelectionEntryId="9c07-c27a-1e44-b6bc">
           <constraints>
@@ -21056,7 +21382,10 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
             <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f036-6336-922b-2ede" type="max"/>
           </constraints>
           <selectionEntries>
-            <selectionEntry id="b712-9bc8-16bb-f40b" name="Bombast Field Gun" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="b712-9bc8-16bb-f40b" name="Bombast Field Gun" hidden="false" collective="true" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7cd7-ed33-ae16-1287" type="max"/>
+              </constraints>
               <profiles>
                 <profile id="ce06-0934-d3da-d74f" name="Ordnance Team" publicationId="e831-8627-fbc7-5b35" page="104" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
                   <characteristics>
@@ -21083,7 +21412,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="631e-7f33-ff11-dee8" name="Lasgun" hidden="false" collective="true" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
+                <entryLink id="631e-7f33-ff11-dee8" name="Lasgun" hidden="false" collective="true" import="true" targetId="7236-b28a-2b6e-ded7" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="235f-70b5-184d-1bf1" type="max"/>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="603d-6457-3779-0b4d" type="min"/>
@@ -21096,7 +21425,10 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="6a22-7fb0-ca35-62f0" name="Heavy Lascannon" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="6a22-7fb0-ca35-62f0" name="Heavy Lascannon" hidden="false" collective="true" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="17fa-5b74-4415-3700" type="max"/>
+              </constraints>
               <profiles>
                 <profile id="3b13-47aa-6727-1358" name="Heavy Lascannon" publicationId="e831-8627-fbc7-5b35" page="104" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
                   <characteristics>
@@ -21123,7 +21455,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="c3c2-4632-9244-57c0" name="Lasgun" hidden="false" collective="true" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
+                <entryLink id="c3c2-4632-9244-57c0" name="Lasgun" hidden="false" collective="true" import="true" targetId="7236-b28a-2b6e-ded7" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b262-1d26-e654-201b" type="max"/>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f462-4d67-b89b-6a72" type="min"/>
@@ -21136,7 +21468,10 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
                 <cost name="pts" typeId="points" value="0.0"/>
               </costs>
             </selectionEntry>
-            <selectionEntry id="f23d-651f-1b4c-0872" name="Malleus Rocket Launcher" hidden="false" collective="false" import="true" type="upgrade">
+            <selectionEntry id="f23d-651f-1b4c-0872" name="Malleus Rocket Launcher" hidden="false" collective="true" import="true" type="upgrade">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f204-333d-f315-0629" type="max"/>
+              </constraints>
               <profiles>
                 <profile id="f287-de41-5cbb-1a16" name="Malleus Rocket Launcher" publicationId="e831-8627-fbc7-5b35" page="104" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
                   <characteristics>
@@ -21163,7 +21498,7 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
                 </profile>
               </profiles>
               <entryLinks>
-                <entryLink id="6d7c-72db-75ee-56ab" name="Lasgun" hidden="false" collective="true" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
+                <entryLink id="6d7c-72db-75ee-56ab" name="Lasgun" hidden="false" collective="true" import="true" targetId="7236-b28a-2b6e-ded7" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3256-1cc7-6659-bfdb" type="max"/>
                     <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="f247-2f7d-43d2-c29c" type="min"/>
@@ -21613,6 +21948,192 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1c1-3f7b-d821-7d21" type="max"/>
               </constraints>
             </entryLink>
+            <entryLink id="b0a0-8299-67da-bcf7" name="Relic: Legacy of Kalladius" hidden="true" collective="false" import="true" targetId="eb13-2076-18e2-e4e7" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b317-c165-a7d5-0388" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02d1-fdc2-288b-6781" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c470-54ac-0863-8848" type="greaterThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b317-c165-a7d5-0388" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8ed7-7588-0f06-9b0d" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02d1-fdc2-288b-6781" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b317-c165-a7d5-0388" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02d1-fdc2-288b-6781" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b317-c165-a7d5-0388" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="7746-0a7f-e844-2e37" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                                <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c470-54ac-0863-8848" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7e90-285e-15d2-91db" type="max"/>
+              </constraints>
+            </entryLink>
+            <entryLink id="f852-eeb4-dd82-ccf5" name="Relic: Claw of the Desert Tigers" hidden="true" collective="false" import="true" targetId="b317-c165-a7d5-0388" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02d1-fdc2-288b-6781" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c470-54ac-0863-8848" type="greaterThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8ed7-7588-0f06-9b0d" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02d1-fdc2-288b-6781" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02d1-fdc2-288b-6781" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="7746-0a7f-e844-2e37" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                                <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c470-54ac-0863-8848" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02d1-fdc2-288b-6781" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2c08-7d0b-5700-3965" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
         <selectionEntryGroup id="a2f7-b6bc-20cc-4d42" name="Laspistol" hidden="false" collective="false" import="true" defaultSelectionEntryId="01a7-aaea-8381-bbb7">
@@ -21639,6 +22160,93 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
                 <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="48fd-4203-b73d-30a1" type="max"/>
               </constraints>
             </entryLink>
+            <entryLink id="d676-72b3-179e-81be" name="Relic: The Emperor&apos;s Fury" hidden="true" collective="false" import="true" targetId="0a30-6d27-4709-ca86" type="selectionEntry">
+              <modifiers>
+                <modifier type="set" field="hidden" value="false">
+                  <conditionGroups>
+                    <conditionGroup type="or">
+                      <conditionGroups>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02d1-fdc2-288b-6781" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b317-c165-a7d5-0388" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c470-54ac-0863-8848" type="greaterThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b317-c165-a7d5-0388" type="lessThan"/>
+                            <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8ed7-7588-0f06-9b0d" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02d1-fdc2-288b-6781" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b317-c165-a7d5-0388" type="lessThan"/>
+                          </conditions>
+                        </conditionGroup>
+                        <conditionGroup type="and">
+                          <conditions>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02d1-fdc2-288b-6781" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b317-c165-a7d5-0388" type="lessThan"/>
+                          </conditions>
+                          <conditionGroups>
+                            <conditionGroup type="or">
+                              <conditions>
+                                <condition field="selections" scope="7746-0a7f-e844-2e37" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                                <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c470-54ac-0863-8848" type="equalTo"/>
+                              </conditions>
+                            </conditionGroup>
+                          </conditionGroups>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </modifier>
+              </modifiers>
+              <constraints>
+                <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="7a91-0187-a8e0-66e1" type="max"/>
+              </constraints>
+              <costs>
+                <cost name="pts" typeId="points" value="5.0"/>
+              </costs>
+            </entryLink>
           </entryLinks>
         </selectionEntryGroup>
       </selectionEntryGroups>
@@ -21652,10 +22260,86 @@ If that Detachment contains two or fewer CONSCRIPTS units, this Stratagem costs 
         <entryLink id="3351-85cc-2cbb-08db" name="Display Regimental Orders" hidden="false" collective="false" import="true" targetId="af30-711d-1707-fcdc" type="selectionEntry"/>
         <entryLink id="ddcb-270f-43ad-c225" name="Heirlooms of Conquest" hidden="false" collective="false" import="true" targetId="8ed7-7588-0f06-9b0d" type="selectionEntryGroup">
           <modifiers>
-            <modifier type="set" field="hidden" value="true">
-              <conditions>
-                <condition field="selections" scope="parent" value="0.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="4629-5e2b-bf50-a6c8" type="greaterThan"/>
-              </conditions>
+            <modifier type="set" field="hidden" value="false">
+              <conditionGroups>
+                <conditionGroup type="or">
+                  <conditionGroups>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="c470-54ac-0863-8848" type="greaterThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="bed3-70b2-ff0b-8788" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02d1-fdc2-288b-6781" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b317-c165-a7d5-0388" type="lessThan"/>
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="greaterThan"/>
+                      </conditions>
+                    </conditionGroup>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="d101-8840-6f76-ca67" type="equalTo"/>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="26c1-5b48-3cad-c08b" type="lessThan"/>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="5175-5813-7bb2-a2c2" type="lessThan"/>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0754-3c94-be3c-a866" type="lessThan"/>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="7024-0bc8-1395-0ce7" type="lessThan"/>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="97e4-c6dd-50f8-577c" type="lessThan"/>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="2cf5-48cb-e469-142b" type="lessThan"/>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="ec03-f299-4924-9c73" type="lessThan"/>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="b17a-ce36-12d2-0e8f" type="lessThan"/>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="4f89-a01c-50fc-f27f" type="lessThan"/>
+                        <condition field="selections" scope="roster" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="e77a-cc54-efcf-a09a" type="equalTo"/>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="8ed7-7588-0f06-9b0d" type="lessThan"/>
+                        <condition field="selections" scope="roster" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b317-c165-a7d5-0388" type="lessThan"/>
+                      </conditions>
+                    </conditionGroup>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02d1-fdc2-288b-6781" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b317-c165-a7d5-0388" type="lessThan"/>
+                      </conditions>
+                    </conditionGroup>
+                    <conditionGroup type="and">
+                      <conditions>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="5ae2-c4d2-05bc-a16f" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="ac59-27a4-14ff-220f" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="8802-85b0-d3d3-6158" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="4068-03ef-f2e9-1d58" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="02d1-fdc2-288b-6781" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="1a31-5371-2f9a-9234" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="2698-2602-4337-6408" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="eb13-2076-18e2-e4e7" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="0a30-6d27-4709-ca86" type="lessThan"/>
+                        <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="true" childId="b317-c165-a7d5-0388" type="lessThan"/>
+                      </conditions>
+                      <conditionGroups>
+                        <conditionGroup type="or">
+                          <conditions>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="0.0" percentValue="false" shared="true" includeChildSelections="true" includeChildForces="false" childId="d7be-7049-0cc9-dcf3" type="greaterThan"/>
+                            <condition field="selections" scope="7746-0a7f-e844-2e37" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" childId="c470-54ac-0863-8848" type="equalTo"/>
+                          </conditions>
+                        </conditionGroup>
+                      </conditionGroups>
+                    </conditionGroup>
+                  </conditionGroups>
+                </conditionGroup>
+              </conditionGroups>
             </modifier>
           </modifiers>
         </entryLink>
@@ -22678,8 +23362,8 @@ Note that this ability only affects the original target of that Order, and not a
       <selectionEntryGroups>
         <selectionEntryGroup id="37cb-def8-ad0c-d824" name="Death Korps Troopers" publicationId="e831-8627-fbc7-5b35" page="92" hidden="false" collective="false" import="true" defaultSelectionEntryId="5f6d-ca0c-2fd1-7815">
           <constraints>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6170-94b8-32a7-5444" type="min"/>
-            <constraint field="selections" scope="parent" value="9.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5187-c637-154f-9180" type="max"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6170-94b8-32a7-5444" type="min"/>
+            <constraint field="selections" scope="parent" value="8.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5187-c637-154f-9180" type="max"/>
           </constraints>
           <selectionEntries>
             <selectionEntry id="2a8c-d7b9-324c-0ff7" name="Death Korps Trooper w/ Medi-pack" page="0" hidden="false" collective="false" import="true" type="upgrade">
@@ -22760,6 +23444,9 @@ Note that this ability only affects the original target of that Order, and not a
           </selectionEntries>
           <selectionEntryGroups>
             <selectionEntryGroup id="5645-aa37-bdd3-c282" name="Death Korps Trooper with Special Weapon" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5b40-72c5-b0c8-5da7" type="max"/>
+              </constraints>
               <selectionEntries>
                 <selectionEntry id="62a3-399b-fd91-bae2" name="Death Korps Trooper w/ Sniper Rifle" page="0" hidden="false" collective="false" import="true" type="upgrade">
                   <constraints>
@@ -22769,10 +23456,16 @@ Note that this ability only affects the original target of that Order, and not a
                     <infoLink id="0bcd-28cb-5b80-612d" name="Death Korps Trooper" hidden="false" targetId="df0c-4a32-a356-67e8" type="profile"/>
                   </infoLinks>
                   <entryLinks>
-                    <entryLink id="a2ff-1208-af62-1c04" name="Sniper rifle" hidden="false" collective="false" import="true" targetId="ba62-f2c3-d7bb-4f5d" type="selectionEntry">
+                    <entryLink id="a2ff-1208-af62-1c04" name="Sniper rifle" hidden="false" collective="false" import="true" targetId="db90-b325-244d-3e35" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="90c3-d88c-9c6b-ae06" type="min"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="37b4-8e0b-867a-25dd" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="8590-f76f-5ce8-ff72" name="Frag grenades" hidden="false" collective="false" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="53f4-6651-9343-4cc8" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="195e-2c6a-3f8b-a9fc" type="max"/>
                       </constraints>
                     </entryLink>
                   </entryLinks>
@@ -22790,16 +23483,16 @@ Note that this ability only affects the original target of that Order, and not a
                     <infoLink id="e513-c34a-fc1a-13e0" name="Death Korps Trooper" hidden="false" targetId="df0c-4a32-a356-67e8" type="profile"/>
                   </infoLinks>
                   <entryLinks>
-                    <entryLink id="d0fb-9039-6588-d767" name="Meltagun" hidden="false" collective="false" import="true" targetId="efc8-c51d-5b02-a3a2" type="selectionEntry">
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="e1c3-ac22-1d4d-f9db" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4c97-3188-5552-66f8" type="max"/>
-                      </constraints>
-                    </entryLink>
-                    <entryLink id="2780-c312-a55a-9f92" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
+                    <entryLink id="2780-c312-a55a-9f92" name="Frag grenades" hidden="false" collective="false" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2085-4002-618e-2145" type="max"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="3ae8-e27a-cceb-69e2" type="min"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="0f4f-2b25-9555-7953" name="Meltagun" hidden="false" collective="true" import="true" targetId="5fb2-f02e-743e-6003" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="a9d1-6913-7c52-f5f1" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3382-c060-b4a4-1b72" type="max"/>
                       </constraints>
                     </entryLink>
                   </entryLinks>
@@ -22816,49 +23509,17 @@ Note that this ability only affects the original target of that Order, and not a
                   <infoLinks>
                     <infoLink id="546c-b695-61bb-9b28" name="Death Korps Trooper" hidden="false" targetId="df0c-4a32-a356-67e8" type="profile"/>
                   </infoLinks>
-                  <selectionEntries>
-                    <selectionEntry id="452a-e769-1dbf-f4fd" name="Grenade Launcher" hidden="false" collective="false" import="true" type="upgrade">
-                      <modifiers>
-                        <modifier type="set" field="points" value="0.0"/>
-                      </modifiers>
-                      <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="c295-3e01-73b9-fcc1" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ad5f-bde2-162d-56bc" type="min"/>
-                      </constraints>
-                      <profiles>
-                        <profile id="b5b2-f17a-bf15-d807" name="Grenade Launcher (Frag)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-                          <characteristics>
-                            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
-                            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault D6</characteristic>
-                            <characteristic name="S" typeId="59b1-319e-ec13-d466">3</characteristic>
-                            <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
-                            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
-                            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast.</characteristic>
-                          </characteristics>
-                        </profile>
-                        <profile id="6234-3e81-6bbe-03d5" name="Grenade Launcher (Krak)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
-                          <characteristics>
-                            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
-                            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault 1</characteristic>
-                            <characteristic name="S" typeId="59b1-319e-ec13-d466">6</characteristic>
-                            <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
-                            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
-                            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"/>
-                          </characteristics>
-                        </profile>
-                      </profiles>
-                      <costs>
-                        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                        <cost name="pts" typeId="points" value="5.0"/>
-                        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                      </costs>
-                    </selectionEntry>
-                  </selectionEntries>
                   <entryLinks>
-                    <entryLink id="2e23-8311-e18e-f047" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
+                    <entryLink id="2675-4600-6147-3c6f" name="Frag grenades" hidden="false" collective="false" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="15ba-96ca-cc35-e380" type="min"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d3e1-beea-0d85-9c9a" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7d1a-e4d8-086d-eb03" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="071a-4ae5-b46d-c7d0" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="0095-d082-2acf-57ba" name="Grenade launcher" hidden="false" collective="true" import="true" targetId="6f79-987c-13d7-bd96" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a624-f853-32e4-50e3" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="d8e4-0c7c-48da-319a" type="min"/>
                       </constraints>
                     </entryLink>
                   </entryLinks>
@@ -22876,16 +23537,16 @@ Note that this ability only affects the original target of that Order, and not a
                     <infoLink id="a940-b485-2bec-b04a" name="Death Korps Trooper" hidden="false" targetId="df0c-4a32-a356-67e8" type="profile"/>
                   </infoLinks>
                   <entryLinks>
-                    <entryLink id="3f12-e7e4-3117-cd33" name="Flamer" hidden="false" collective="false" import="true" targetId="fd22-6743-2d4c-dd62" type="selectionEntry">
+                    <entryLink id="3f12-e7e4-3117-cd33" name="Flamer" hidden="false" collective="true" import="true" targetId="85ac-c7ca-ba21-1374" type="selectionEntry">
                       <constraints>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ead0-50ce-96b9-9391" type="min"/>
                         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5574-40ce-f244-fabb" type="max"/>
                       </constraints>
                     </entryLink>
-                    <entryLink id="ecc7-8f6d-37e1-6d64" name="Frag grenades" hidden="false" collective="false" import="true" targetId="f68e-9984-71fe-6bca" type="selectionEntry">
+                    <entryLink id="9eb8-872d-69ad-77ac" name="Frag grenades" hidden="false" collective="false" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
                       <constraints>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="215f-0ae9-3d65-2be6" type="max"/>
-                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b04e-0a27-60c6-d61b" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="811a-bd37-2fd3-31a2" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="1b76-bd23-f69d-8136" type="max"/>
                       </constraints>
                     </entryLink>
                   </entryLinks>
@@ -22896,14 +23557,6 @@ Note that this ability only affects the original target of that Order, and not a
                   </costs>
                 </selectionEntry>
               </selectionEntries>
-              <entryLinks>
-                <entryLink id="7fcb-9a4e-0a23-4282" name="Frag grenades" hidden="false" collective="false" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
-                  <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="aa44-179e-93ac-086e" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="2ba0-3090-5265-9e2f" type="max"/>
-                  </constraints>
-                </entryLink>
-              </entryLinks>
             </selectionEntryGroup>
           </selectionEntryGroups>
         </selectionEntryGroup>
@@ -23154,13 +23807,13 @@ Note that this ability only affects the original target of that Order, and not a
                 <infoLink id="b476-6a0d-5d10-1c84" name="Catachan Jungle Fighter" hidden="false" targetId="8a0e-4f59-67cc-5b60" type="profile"/>
               </infoLinks>
               <entryLinks>
-                <entryLink id="ffbc-97ad-0816-feb8" name="Flamer" hidden="false" collective="false" import="true" targetId="fd22-6743-2d4c-dd62" type="selectionEntry">
+                <entryLink id="ffbc-97ad-0816-feb8" name="Flamer" hidden="false" collective="true" import="true" targetId="85ac-c7ca-ba21-1374" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="1a37-dff4-0362-5c0d" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="161e-7bd4-afae-c1ae" type="max"/>
                   </constraints>
                 </entryLink>
-                <entryLink id="7260-9123-89e1-ee4c" name="Frag grenades" hidden="false" collective="false" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
+                <entryLink id="7260-9123-89e1-ee4c" name="Frag grenades" hidden="false" collective="true" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
                   <constraints>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="54b2-2efb-3510-6e1f" type="min"/>
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="4428-dc01-2e0d-8581" type="max"/>
@@ -24278,9 +24931,6 @@ Note that this ability only affects the original target of that Order, and not a
                   </characteristics>
                 </profile>
               </profiles>
-              <infoLinks>
-                <infoLink id="536b-a3a1-4670-d24d" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
-              </infoLinks>
               <entryLinks>
                 <entryLink id="08b4-3715-52c4-fb77" name="Lasgun" hidden="false" collective="false" import="true" targetId="fd87-854b-d284-184a" type="selectionEntry">
                   <constraints>
@@ -24299,6 +24949,12 @@ Note that this ability only affects the original target of that Order, and not a
                   <categoryLinks>
                     <categoryLink id="d2c2-10e8-d595-42cf" name="Vox-Caster" hidden="false" targetId="086d-e3ba-a17b-01bd" primary="false"/>
                   </categoryLinks>
+                </entryLink>
+                <entryLink id="561d-ff5b-bedb-d916" name="Frag grenades" hidden="false" collective="true" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cfcf-69a7-5dd9-dbec" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6d0b-3ca0-5173-b7a5" type="max"/>
+                  </constraints>
                 </entryLink>
               </entryLinks>
               <costs>
@@ -24326,9 +24982,6 @@ Note that this ability only affects the original target of that Order, and not a
                   </characteristics>
                 </profile>
               </profiles>
-              <infoLinks>
-                <infoLink id="de5f-85d5-dc7d-2de6" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
-              </infoLinks>
               <entryLinks>
                 <entryLink id="914d-f4be-6c31-0d19" name="Lasgun" hidden="false" collective="false" import="true" targetId="7236-b28a-2b6e-ded7" type="selectionEntry">
                   <constraints>
@@ -24336,40 +24989,10 @@ Note that this ability only affects the original target of that Order, and not a
                     <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="6560-f2a1-da76-e4f0" type="min"/>
                   </constraints>
                 </entryLink>
-              </entryLinks>
-              <costs>
-                <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
-                <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
-                <cost name="pts" typeId="points" value="0.0"/>
-              </costs>
-            </selectionEntry>
-            <selectionEntry id="b273-fb2a-b999-32cc" name="Shock Trooper w/ Special Weapon" page="0" hidden="false" collective="false" import="true" type="unit">
-              <constraints>
-                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6966-5ef7-5cbf-ea4d" type="max"/>
-              </constraints>
-              <profiles>
-                <profile id="120e-6b9f-fcd2-d584" name="Shock Trooper" publicationId="e831-8627-fbc7-5b35" page="91" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
-                  <characteristics>
-                    <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
-                    <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
-                    <characteristic name="BS" typeId="381b-eb28-74c3-df5f">4+</characteristic>
-                    <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
-                    <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
-                    <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
-                    <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">1</characteristic>
-                    <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">6</characteristic>
-                    <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">5+</characteristic>
-                  </characteristics>
-                </profile>
-              </profiles>
-              <infoLinks>
-                <infoLink id="992b-8784-b05f-5d05" name="Frag grenades" hidden="false" targetId="fdd8-1a5f-5722-d6ee" type="profile"/>
-              </infoLinks>
-              <entryLinks>
-                <entryLink id="0e94-5a67-138c-936b" name="Cadian Shock Troops Special Weapons" hidden="false" collective="false" import="true" targetId="b03b-b25b-69de-66e4" type="selectionEntryGroup">
+                <entryLink id="e22f-b4ed-f807-d171" name="Frag grenades" hidden="false" collective="true" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
                   <constraints>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fe93-4f43-7a26-56e3" type="min"/>
-                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="fa40-7503-31e4-d6ac" type="max"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="375b-222f-bfcd-0194" type="min"/>
+                    <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="b00c-af3b-f5e1-6884" type="max"/>
                   </constraints>
                 </entryLink>
               </entryLinks>
@@ -24380,6 +25003,151 @@ Note that this ability only affects the original target of that Order, and not a
               </costs>
             </selectionEntry>
           </selectionEntries>
+          <selectionEntryGroups>
+            <selectionEntryGroup id="a668-9dd3-e265-0590" name="Shock Trooper w/ Special Weapon" hidden="false" collective="false" import="true">
+              <constraints>
+                <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="052b-5276-c589-6e4d" type="max"/>
+              </constraints>
+              <selectionEntries>
+                <selectionEntry id="9ee2-e9bf-5754-d242" name="Shock Trooper w/ Flamer" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a2f3-3617-1d35-7a26" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="f9f6-0296-d772-6781" name="Shock Trooper" publicationId="e831-8627-fbc7-5b35" page="91" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+                      <characteristics>
+                        <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                        <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
+                        <characteristic name="BS" typeId="381b-eb28-74c3-df5f">4+</characteristic>
+                        <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                        <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
+                        <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
+                        <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">1</characteristic>
+                        <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">6</characteristic>
+                        <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <entryLinks>
+                    <entryLink id="cb4a-822d-e6fb-1de2" name="Frag grenades" hidden="false" collective="true" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9eed-ab09-b5f2-9011" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="06e0-b73e-5b1b-5ef8" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="85bb-ee23-02d5-c4a3" name="Flamer" hidden="false" collective="false" import="true" targetId="85ac-c7ca-ba21-1374" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="541e-832b-8d5c-05c4" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="43ef-ef19-9c49-8723" type="max"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntry>
+                <selectionEntry id="730c-0c5e-6086-8722" name="Shock Trooper w/ Grenade Launcher" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="3007-cdaf-9b9e-7e34" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="bf3d-809a-d8a5-ba65" name="Shock Trooper" publicationId="e831-8627-fbc7-5b35" page="91" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+                      <characteristics>
+                        <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                        <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
+                        <characteristic name="BS" typeId="381b-eb28-74c3-df5f">4+</characteristic>
+                        <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                        <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
+                        <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
+                        <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">1</characteristic>
+                        <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">6</characteristic>
+                        <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <entryLinks>
+                    <entryLink id="6316-6fa8-1d0a-5a51" name="Frag grenades" hidden="false" collective="true" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9b32-dc0d-9929-c711" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5cee-f98b-a963-f22b" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="0dc9-4b51-e2f4-f2b2" name="Grenade launcher" hidden="false" collective="false" import="true" targetId="6f79-987c-13d7-bd96" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="7075-6cf9-7280-4091" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="dee8-cbce-c94d-2ffa" type="min"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntry>
+                <selectionEntry id="77b9-f787-f6f0-2fdf" name="Shock Trooper w/ Meltagun" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="cef4-5db7-3967-4a49" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="9252-87d5-6b80-f715" name="Shock Trooper" publicationId="e831-8627-fbc7-5b35" page="91" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+                      <characteristics>
+                        <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                        <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
+                        <characteristic name="BS" typeId="381b-eb28-74c3-df5f">4+</characteristic>
+                        <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                        <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
+                        <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
+                        <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">1</characteristic>
+                        <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">6</characteristic>
+                        <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <entryLinks>
+                    <entryLink id="c7d1-9ce5-ee7a-23cb" name="Frag grenades" hidden="false" collective="true" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9c41-f084-e5cc-41d4" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="ac16-1a88-ccc7-db81" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="f46a-3ce1-db56-6f92" name="Meltagun" hidden="false" collective="false" import="true" targetId="5fb2-f02e-743e-6003" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="5c9e-278d-1011-d99e" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9476-505b-3eae-1acd" type="min"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntry>
+                <selectionEntry id="c5c9-0821-6a8f-5d09" name="Shock Trooper w/ Plasma Gun" hidden="false" collective="false" import="true" type="upgrade">
+                  <constraints>
+                    <constraint field="selections" scope="parent" value="2.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="e54a-bda4-7a48-f291" type="max"/>
+                  </constraints>
+                  <profiles>
+                    <profile id="ba90-50ea-f280-77c7" name="Shock Trooper" publicationId="e831-8627-fbc7-5b35" page="91" hidden="false" typeId="800f-21d0-4387-c943" typeName="Unit">
+                      <characteristics>
+                        <characteristic name="M" typeId="0bdf-a96e-9e38-7779">6&quot;</characteristic>
+                        <characteristic name="WS" typeId="e7f0-1278-0250-df0c">4+</characteristic>
+                        <characteristic name="BS" typeId="381b-eb28-74c3-df5f">4+</characteristic>
+                        <characteristic name="S" typeId="2218-aa3c-265f-2939">3</characteristic>
+                        <characteristic name="T" typeId="9c9f-9774-a358-3a39">3</characteristic>
+                        <characteristic name="W" typeId="f330-5e6e-4110-0978">1</characteristic>
+                        <characteristic name="A" typeId="13fc-b29b-31f2-ab9f">1</characteristic>
+                        <characteristic name="Ld" typeId="00ca-f8b8-876d-b705">6</characteristic>
+                        <characteristic name="Save" typeId="c0df-df94-abd7-e8d3">5+</characteristic>
+                      </characteristics>
+                    </profile>
+                  </profiles>
+                  <entryLinks>
+                    <entryLink id="9e31-a5ef-a8ed-2c59" name="Frag grenades" hidden="false" collective="true" import="true" targetId="5de8-906d-ea69-610a" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="6bb8-8c14-0b70-d712" type="min"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="df13-4609-b80b-cba4" type="max"/>
+                      </constraints>
+                    </entryLink>
+                    <entryLink id="0f96-2d97-4880-dee5" name="Plasma Gun" hidden="false" collective="false" import="true" targetId="113c-abef-4bc4-13de" type="selectionEntry">
+                      <constraints>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="a060-1442-b440-9bba" type="max"/>
+                        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="false" includeChildSelections="false" includeChildForces="false" id="9d3a-af3e-dd50-f44d" type="min"/>
+                      </constraints>
+                    </entryLink>
+                  </entryLinks>
+                </selectionEntry>
+              </selectionEntries>
+            </selectionEntryGroup>
+          </selectionEntryGroups>
         </selectionEntryGroup>
       </selectionEntryGroups>
       <entryLinks>
@@ -24953,7 +25721,7 @@ You can only use this Stratagem once, unless you are playing a Strike Force batt
         <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
-    <selectionEntry id="8150-24f8-8e4d-3bff" name="Goad Lance" publicationId="e831-8627-fbc7-5b35" page="99" hidden="false" collective="false" import="true" type="upgrade">
+    <selectionEntry id="8150-24f8-8e4d-3bff" name="Goad Lance" publicationId="e831-8627-fbc7-5b35" page="99" hidden="false" collective="true" import="true" type="upgrade">
       <constraints>
         <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="cdff-6299-3b5e-739f" type="max"/>
       </constraints>
@@ -25045,6 +25813,114 @@ You can only use this Stratagem once, unless you are playing a Strike Force batt
         <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
         <cost name="pts" typeId="points" value="0.0"/>
         <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="85ac-c7ca-ba21-1374" name="Flamer" hidden="false" collective="true" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="b3c9-c9d7-8a05-322a" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="f34b-af9d-3dea-c623" name="Hot-Shot Volley Gun" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">12&quot;</characteristic>
+            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault D6</characteristic>
+            <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
+            <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
+            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Each time an attack is made with this weapon, that attack automatically hits the target.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="6f79-987c-13d7-bd96" name="Grenade launcher" hidden="false" collective="true" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="2970-ac4d-cda2-d581" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="3fec-f834-9ecb-8747" name="Grenade launcher (Frag)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault D6</characteristic>
+            <characteristic name="S" typeId="59b1-319e-ec13-d466">3</characteristic>
+            <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
+            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Blast.</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="31f4-2820-5b24-eb44" name="Grenade launcher (Krak)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault 1</characteristic>
+            <characteristic name="S" typeId="59b1-319e-ec13-d466">6</characteristic>
+            <characteristic name="AP" typeId="75aa-a838-b675-6484">-1</characteristic>
+            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D3</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410"/>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="5fb2-f02e-743e-6003" name="Meltagun" hidden="false" collective="true" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="0fee-e0e9-9fce-9064" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="3324-0e9b-6593-0f2f" name="Meltagun" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">12&quot;</characteristic>
+            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault 1</characteristic>
+            <characteristic name="S" typeId="59b1-319e-ec13-d466">8</characteristic>
+            <characteristic name="AP" typeId="75aa-a838-b675-6484">-4</characteristic>
+            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D6</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Each time an attack is made with this weapon targets a unit within half range, that attack has a Damage characteristic of D6+2</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
+      </costs>
+    </selectionEntry>
+    <selectionEntry id="113c-abef-4bc4-13de" name="Plasma Gun" hidden="false" collective="true" import="true" type="upgrade">
+      <constraints>
+        <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="fb02-d45f-6624-0db4" type="max"/>
+      </constraints>
+      <profiles>
+        <profile id="16a4-f055-f1b5-4f41" name="Plasma Gun (Standard)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Rapid Fire 1</characteristic>
+            <characteristic name="S" typeId="59b1-319e-ec13-d466">7</characteristic>
+            <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
+            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
+          </characteristics>
+        </profile>
+        <profile id="ed05-9cfe-adc6-47dd" name="Plasma Gun (Supercharge)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+          <characteristics>
+            <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+            <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Rapid Fire 1</characteristic>
+            <characteristic name="S" typeId="59b1-319e-ec13-d466">8</characteristic>
+            <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
+            <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
+            <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">If any unmodified hit rolls of 1 are made for attacks with this weapon profile, the bearer is destroyed after shooting with this weapon.</characteristic>
+          </characteristics>
+        </profile>
+      </profiles>
+      <costs>
+        <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+        <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+        <cost name="pts" typeId="points" value="0.0"/>
       </costs>
     </selectionEntry>
   </sharedSelectionEntries>
@@ -28282,24 +29158,83 @@ receive the benefits of cover against that attack.&quot;</characteristic>
             <cost name="pts" typeId="points" value="0.0"/>
           </costs>
         </selectionEntry>
+        <selectionEntry id="9ae0-1be1-a156-4f19" name="Flamer" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="ffa2-e7d2-2664-32cf" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="0043-7969-d419-b6ed" name="Hot-Shot Volley Gun" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">12&quot;</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault D6</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">4</characteristic>
+                <characteristic name="AP" typeId="75aa-a838-b675-6484">0</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Each time an attack is made with this weapon, that attack automatically hits the target.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="ebdc-ddd4-fcd4-76c4" name="Meltagun" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="970a-c5d3-6e2a-9749" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="d313-5e22-589a-c181" name="Meltagun" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">12&quot;</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Assault 1</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">8</characteristic>
+                <characteristic name="AP" typeId="75aa-a838-b675-6484">-4</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">D6</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">Each time an attack is made with this weapon targets a unit within half range, that attack has a Damage characteristic of D6+2</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
+        <selectionEntry id="7d79-7c9b-c0bf-e390" name="Plasma Gun" hidden="false" collective="false" import="true" type="upgrade">
+          <constraints>
+            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="9a37-b26e-6823-6699" type="max"/>
+          </constraints>
+          <profiles>
+            <profile id="a165-e68d-5ac6-c2fa" name="Plasma Gun (Standard)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Rapid Fire 1</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">7</characteristic>
+                <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">1</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">-</characteristic>
+              </characteristics>
+            </profile>
+            <profile id="a37e-8c69-1f8d-b2dd" name="Plasma Gun (Supercharge)" hidden="false" typeId="d5f97c0b-9fc9-478d-aa34-a7c414d3ea48" typeName="Weapon">
+              <characteristics>
+                <characteristic name="Range" typeId="6fa97fa8-ea74-4a27-a0fb-bc4e5f367464">24&quot;</characteristic>
+                <characteristic name="Type" typeId="077c342f-d7b9-45c6-b8af-88e97cafd3a2">Rapid Fire 1</characteristic>
+                <characteristic name="S" typeId="59b1-319e-ec13-d466">8</characteristic>
+                <characteristic name="AP" typeId="75aa-a838-b675-6484">-3</characteristic>
+                <characteristic name="D" typeId="ae8a-3137-d65b-4ca7">2</characteristic>
+                <characteristic name="Abilities" typeId="837d-5e63-aeb7-1410">If any unmodified hit rolls of 1 are made for attacks with this weapon profile, the bearer is destroyed after shooting with this weapon.</characteristic>
+              </characteristics>
+            </profile>
+          </profiles>
+          <costs>
+            <cost name=" PL" typeId="e356-c769-5920-6e14" value="0.0"/>
+            <cost name="CP" typeId="2d3b-b544-ad49-fb75" value="0.0"/>
+            <cost name="pts" typeId="points" value="0.0"/>
+          </costs>
+        </selectionEntry>
       </selectionEntries>
-      <entryLinks>
-        <entryLink id="d795-ceba-6f6c-dcb9" name="Plasma gun" hidden="false" collective="false" import="true" targetId="8c14-22cc-93ce-b85a" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="591d-aa78-a602-146a" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="ce03-ddfd-6d63-76aa" name="Meltagun" hidden="false" collective="false" import="true" targetId="efc8-c51d-5b02-a3a2" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="104b-2b00-8406-24bb" type="max"/>
-          </constraints>
-        </entryLink>
-        <entryLink id="b19f-b7ed-4629-cab8" name="Flamer" hidden="false" collective="false" import="true" targetId="fd22-6743-2d4c-dd62" type="selectionEntry">
-          <constraints>
-            <constraint field="selections" scope="parent" value="1.0" percentValue="false" shared="true" includeChildSelections="false" includeChildForces="false" id="96d4-a6e9-00a6-32e6" type="max"/>
-          </constraints>
-        </entryLink>
-      </entryLinks>
     </selectionEntryGroup>
     <selectionEntryGroup id="8788-8deb-650b-be6a" name="Russ Equipment List" publicationId="e831-8627-fbc7-5b35" page="114929" hidden="false" collective="false" import="true">
       <constraints>


### PR DESCRIPTION
Added Claw of the Desert Tigers on the Rough Riders Sergeant which can be unlockable via the Battlefield Bequest Strat  Added Imperial Commander's Armoury to Cadian Castellan and Commissar

Fixed Cadian Command Squad standard bearer not being able to take the finial of the nemrodesh 1st Reverted Lord Solar to only appear as a Supreme Command Choice Fixed Kasrkin Special Weapon caps and made the choices collectives Attilan Rough Riders can now be selectable with counters Neatened up Shock Troopers w/ Special Weapons options with counters Neatened up Jungle Fighters w/ flamers by using counters Neatened up DKOK Special Weapons troopers by using counters Neatened up Militarum Tempestus Scions Command Squads with Counters Neatened up Field Ordnance Batteries with counters Fixed up DKOK maximum/minimum troopers

Removed Chainswords from Attilan Rough Riders